### PR TITLE
[#235] Fixed token replacement for `your-extension` during init.

### DIFF
--- a/.scaffold/tests/bats/_assert_init.bash
+++ b/.scaffold/tests/bats/_assert_init.bash
@@ -80,6 +80,7 @@ assert_files_present_common() {
 
   # Assert other things.
   assert_dir_not_contains_string "${dir}" "your_extension"
+  assert_dir_not_contains_string "${dir}" "your-extension"
 
   popd >/dev/null || exit 1
 }

--- a/init.sh
+++ b/init.sh
@@ -165,6 +165,7 @@ process_internal() {
   replace_string_content "your extension" "${extension_name}"
   replace_string_content "Your+Extension" "${extension_machine_name}"
   replace_string_content "your_extension" "${extension_machine_name}"
+  replace_string_content "your-extension" "${extension_machine_name}"
   replace_string_content "YourExtension" "${extension_machine_name_class}"
   replace_string_content "Provides your_extension functionality." "Provides ${extension_machine_name} functionality."
   replace_string_content "drupal-module" "drupal-${extension_type}"


### PR DESCRIPTION
Closes #235



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Project initialization now replaces both underscore and hyphen versions of the placeholder, ensuring cleaner scaffolding.
- Bug Fixes
  - Prevents leftover hyphenated placeholder strings in generated projects for more consistent output.
- Tests
  - Added checks to confirm no hyphenated placeholder remains after initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->