### PR TITLE
Fixed `make provision` test failing.

### DIFF
--- a/.scaffold/tests/bats/functional.make.bats
+++ b/.scaffold/tests/bats/functional.make.bats
@@ -70,6 +70,7 @@ export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
 }
 
 @test "make provision" {
+  run make stop
   run make assemble
   run make start
   run make provision


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the provisioning workflow test to invoke a stop step before setup and provisioning, ensuring a clean baseline. Improves reliability and consistency across CI and local runs, reducing flakiness. No changes to application behavior or user flows; assertions unchanged—only test sequencing refined. Helps catch environment-related issues earlier. Faster root-cause analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->