### PR TITLE
Improved CI performance by splitting tests into 5 parallel groups

### DIFF
--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -40,7 +40,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          extensions: :xdebug, gd, sqlite, pdo_sqlite
+          extensions: gd, sqlite, pdo_sqlite
+          coverage: pcov
+          ini-values: pcov.directory=.
 
       - name: Install Ahoy
         if: matrix.group == 'p3'

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -20,13 +20,14 @@ jobs:
       fail-fast: false
 
       matrix:
-        group: ['p0', 'p1', 'p2']
+        group: ['p0', 'p1', 'p2', 'p3', 'p4']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Upgrade sqlite3
+        if: matrix.group != 'p0'
         run: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
           tar -xzf /tmp/sqlite.tar.gz -C /tmp
@@ -39,9 +40,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          extensions: gd, sqlite, pdo_sqlite
+          extensions: :xdebug, gd, sqlite, pdo_sqlite
 
       - name: Install Ahoy
+        if: matrix.group == 'p3'
         run: |
           os=$(uname -s | tr '[:upper:]' '[:lower:]') && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac)
           sudo wget -q https://github.com/ahoy-cli/ahoy/releases/download/v2.1.1/ahoy-bin-"${os}-${architecture}" -O /usr/local/bin/ahoy
@@ -52,19 +54,22 @@ jobs:
         working-directory: .scaffold/tests
 
       - name: Validate composer.json
+        if: matrix.group == 'p0'
         run: composer validate --strict
         working-directory: .scaffold/tests
 
       - name: Check composer.json is normalized
+        if: matrix.group == 'p0'
         run: composer normalize --dry-run
         working-directory: .scaffold/tests
 
       - name: Lint PHP tests
+        if: matrix.group == 'p0'
         run: composer lint
         working-directory: .scaffold/tests
 
       - name: Run PHP tests with coverage
-        run: composer test-coverage
+        run: composer test-coverage -- --group=${{ matrix.group }}
         working-directory: .scaffold/tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
-#[Group('p1')]
+#[Group('p3')]
 final class AhoyTest extends DevtoolsTestCase {
 
   public function testBuild(): void {

--- a/.scaffold/tests/src/Functional/AssembleTest.php
+++ b/.scaffold/tests/src/Functional/AssembleTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
-#[Group('p0')]
+#[Group('p2')]
 final class AssembleTest extends DevtoolsTestCase {
 
   #[DataProvider('dataProviderAssemble')]

--- a/.scaffold/tests/src/Functional/InitTest.php
+++ b/.scaffold/tests/src/Functional/InitTest.php
@@ -8,12 +8,14 @@ use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
 use Laravel\SerializableClosure\SerializableClosure;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class InitTest.
  *
  * Functional tests for init.php script.
  */
+#[Group('p1')]
 final class InitTest extends FunctionalTestCase {
 
   use SnapshotTrait;

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
-#[Group('p2')]
+#[Group('p4')]
 final class MakeTest extends DevtoolsTestCase {
 
   public function testDefault(): void {

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
 #[RunTestsInSeparateProcesses]
-#[Group('scripts')]
+#[Group('p0')]
 final class AssembleTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/DeployTest.php
+++ b/.scaffold/tests/src/Unit/DeployTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
 #[RunTestsInSeparateProcesses]
-#[Group('scripts')]
+#[Group('p0')]
 final class DeployTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/HelpersCommandExistsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersCommandExistsTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 
 #[CoversFunction('DrupalExtensionScaffold\DevTools\command_path')]
 #[CoversFunction('DrupalExtensionScaffold\DevTools\command_must_exist')]
-#[Group('helpers')]
+#[Group('p0')]
 final class HelpersCommandExistsTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/HelpersCopyDirTest.php
+++ b/.scaffold/tests/src/Unit/HelpersCopyDirTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  */
 #[CoversFunction('DrupalExtensionScaffold\DevTools\copy_dir')]
-#[Group('helpers')]
+#[Group('p0')]
 final class HelpersCopyDirTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/HelpersFormatterTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFormatterTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 #[CoversFunction('DrupalExtensionScaffold\DevTools\FAIL_NO_EXIT')]
 #[CoversFunction('DrupalExtensionScaffold\DevTools\FAIL')]
 #[CoversFunction('DrupalExtensionScaffold\DevTools\term_supports_color')]
-#[Group('helpers')]
+#[Group('p0')]
 final class HelpersFormatterTest extends UnitTestCase {
 
   #[DataProvider('dataProviderOutputFormatters')]

--- a/.scaffold/tests/src/Unit/HelpersGetenvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersGetenvTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 #[RunTestsInSeparateProcesses]
-#[Group('helpers')]
+#[Group('p0')]
 final class HelpersGetenvTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Group;
 
 #[CoversFunction('DrupalExtensionScaffold\DevTools\passthru_or_fail')]
-#[Group('helpers')]
+#[Group('p0')]
 final class HelpersPassthruOrFailTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/InitHelpersTest.php
+++ b/.scaffold/tests/src/Unit/InitHelpersTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class InitHelpersTest.
  *
  * Unit tests for helper functions in init.php.
  */
+#[Group('p0')]
 final class InitHelpersTest extends UnitTestCase {
 
   protected string $originalCwd;

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
 #[RunTestsInSeparateProcesses]
-#[Group('scripts')]
+#[Group('p0')]
 final class ProvisionTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/StartTest.php
+++ b/.scaffold/tests/src/Unit/StartTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
 #[RunTestsInSeparateProcesses]
-#[Group('scripts')]
+#[Group('p0')]
 final class StartTest extends UnitTestCase {
 
   protected function setUp(): void {

--- a/.scaffold/tests/src/Unit/StopTest.php
+++ b/.scaffold/tests/src/Unit/StopTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
 #[RunTestsInSeparateProcesses]
-#[Group('scripts')]
+#[Group('p0')]
 final class StopTest extends UnitTestCase {
 
   protected function setUp(): void {


### PR DESCRIPTION
# Improved CI performance by splitting tests into 5 parallel groups

## Summary

Reorganized the `scaffold-test.yml` CI workflow from 3 runners (that each ran all tests redundantly) into 5 runners that each run only their assigned test group. This should significantly reduce total CI time by parallelizing functional tests and avoiding unnecessary setup steps per runner. Also disabled xdebug for faster PHP setup.

## Changes

### Test group reassignment
- Renamed `#[Group('helpers')]` and `#[Group('scripts')]` to `#[Group('p0')]` on all unit test classes.
- Added `#[Group('p0')]` to `InitHelpersTest` (previously ungrouped).
- Added `#[Group('p1')]` to `Functional\InitTest` (previously ungrouped).
- Renamed `Functional\AssembleTest` from `p0` to `p2`.
- Renamed `Functional\AhoyTest` from `p1` to `p3`.
- Renamed `Functional\MakeTest` from `p2` to `p4`.

### Workflow optimization
- Expanded matrix from `['p0', 'p1', 'p2']` to `['p0', 'p1', 'p2', 'p3', 'p4']`.
- Added `--group` flag to `composer test-coverage` so each runner only executes its assigned tests.
- Gated lint steps (composer validate, normalize, phpcs/phpstan/rector) to `p0` only.
- Gated Ahoy install to `p3` only.
- Gated SQLite upgrade to `p1`-`p4` only (not needed for unit tests).
- Disabled xdebug via `:xdebug` prefix in `setup-php` extensions.

## Before / After

```
Before (3 runners, each running ALL tests)
──────────────────────────────────────────
┌──────┐  ┌──────┐  ┌──────┐
│  p0  │  │  p1  │  │  p2  │
├──────┤  ├──────┤  ├──────┤
│sqlite│  │sqlite│  │sqlite│
│ ahoy │  │ ahoy │  │ ahoy │
│ lint │  │ lint │  │ lint │
│ ALL  │  │ ALL  │  │ ALL  │
│tests │  │tests │  │tests │
└──────┘  └──────┘  └──────┘

After (5 runners, each running ONLY its group)
───────────────────────────────────────────────
┌──────┐  ┌──────┐  ┌──────┐  ┌──────┐  ┌──────┐
│  p0  │  │  p1  │  │  p2  │  │  p3  │  │  p4  │
├──────┤  ├──────┤  ├──────┤  ├──────┤  ├──────┤
│      │  │sqlite│  │sqlite│  │sqlite│  │sqlite│
│ lint │  │      │  │      │  │ ahoy │  │      │
│ unit │  │ Init │  │Assem.│  │ Ahoy │  │ Make │
│tests │  │ Test │  │ Test │  │ Test │  │ Test │
└──────┘  └──────┘  └──────┘  └──────┘  └──────┘
```