### PR TITLE
[#280] Updated rector config to the latest fluent API schema.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/rector.php
+++ b/.scaffold/tests/fixtures/init/_baseline/rector.php
@@ -4,45 +4,64 @@
  * @file
  * Rector configuration.
  *
- * Usage:
- * ./vendor/bin/rector process .
+ * Rector automatically refactors PHP code to:
+ * - Upgrade deprecated Drupal APIs.
+ * - Modernize PHP syntax to leverage new language features.
+ * - Improve code quality and maintainability.
  *
- * @see https://github.com/palantirnet/drupal-rector/blob/main/rector.php
+ * @see https://github.com/palantirnet/drupal-rector
+ * @see https://getrector.com/documentation
+ * @see https://getrector.com/documentation/set-lists
  */
 
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
 use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal8SetList;
 use DrupalRector\Set\Drupal9SetList;
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
+use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
+use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\SetList;
+use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
+use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
+use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
+use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
-return static function (RectorConfig $rectorConfig): void {
-  $rectorConfig->sets([
-    // Provided by Rector.
-    SetList::TYPE_DECLARATION,
-    // Provided by Drupal Rector.
-    Drupal8SetList::DRUPAL_8,
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-  ]);
-
-  $rectorConfig->rule(DeclareStrictTypesRector::class);
-
-  $drupalFinder = new DrupalFinderComposerRuntime();
-  $drupalRoot = $drupalFinder->getDrupalRoot();
-  $rectorConfig->autoloadPaths([
-    $drupalRoot . '/core',
-    $drupalRoot . '/modules',
-    $drupalRoot . '/themes',
-    $drupalRoot . '/profiles',
-  ]);
-
-  $rectorConfig->skip([
-    // Dependencies.
+return RectorConfig::configure()
+  ->withSkip([
+    // Specific rules to skip based on project coding standards.
+    CatchExceptionNameMatchingTypeRector::class,
+    ChangeSwitchToMatchRector::class,
+    CompleteDynamicPropertiesRector::class,
+    CountArrayToEmptyArrayComparisonRector::class,
+    DisallowedEmptyRuleFixerRector::class,
+    InlineArrayReturnAssignRector::class,
+    NewlineAfterStatementRector::class,
+    NewlineBeforeNewAssignSetRector::class,
+    PrivatizeFinalClassMethodRector::class,
+    PrivatizeFinalClassPropertyRector::class,
+    PrivatizeLocalGetterToPropertyRector::class,
+    RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
+    RenameParamToMatchTypeRector::class,
+    RenameVariableToMatchMethodCallReturnTypeRector::class,
+    RenameVariableToMatchNewTypeRector::class,
+    SimplifyEmptyCheckOnEmptyArrayRector::class,
+    StringClassNameToClassConstantRector::class,
+    // Directories to skip.
     '*/vendor/*',
     '*/node_modules/*',
     // Core and contribs.
@@ -55,18 +74,49 @@ return static function (RectorConfig $rectorConfig): void {
     '*/sites/default/files/*',
     // Composer scripts.
     '*/scripts/composer/*',
-  ]);
+  ])
+  // PHP version upgrade sets - modernizes syntax to PHP 8.2.
+  // Includes all rules from PHP 5.3 through 8.2.
+  ->withPhpSets(php82: TRUE)
+  // Code quality improvement sets.
+  ->withPreparedSets(
+    codeQuality: TRUE,
+    codingStyle: TRUE,
+    deadCode: TRUE,
+    naming: TRUE,
+    privatization: TRUE,
+    typeDeclarations: TRUE,
+  )
+  // Drupal-specific deprecation fixes.
+  ->withSets([
+    Drupal9SetList::DRUPAL_9,
+    Drupal10SetList::DRUPAL_10,
+  ])
+  // Additional rules.
+  ->withRules([
+    DeclareStrictTypesRector::class,
+  ])
+  // Configure Drupal autoloading.
+  ->withAutoloadPaths((function (): array {
+    $drupalFinder = new DrupalFinderComposerRuntime();
+    $drupalRoot = $drupalFinder->getDrupalRoot();
 
-  $rectorConfig->fileExtensions([
-    'engine',
-    'inc',
-    'install',
-    'module',
+    return [
+      $drupalRoot . '/core',
+      $drupalRoot . '/modules',
+      $drupalRoot . '/themes',
+      $drupalRoot . '/profiles',
+    ];
+  })())
+  // Drupal file extensions.
+  ->withFileExtensions([
     'php',
+    'module',
+    'install',
     'profile',
     'theme',
-  ]);
-
-  $rectorConfig->importNames(TRUE, FALSE);
-  $rectorConfig->importShortClasses(FALSE);
-};
+    'inc',
+    'engine',
+  ])
+  // Import configuration.
+  ->withImportNames(importNames: TRUE, importDocBlockNames: FALSE, importShortClasses: FALSE);

--- a/rector.php
+++ b/rector.php
@@ -4,45 +4,64 @@
  * @file
  * Rector configuration.
  *
- * Usage:
- * ./vendor/bin/rector process .
+ * Rector automatically refactors PHP code to:
+ * - Upgrade deprecated Drupal APIs.
+ * - Modernize PHP syntax to leverage new language features.
+ * - Improve code quality and maintainability.
  *
- * @see https://github.com/palantirnet/drupal-rector/blob/main/rector.php
+ * @see https://github.com/palantirnet/drupal-rector
+ * @see https://getrector.com/documentation
+ * @see https://getrector.com/documentation/set-lists
  */
 
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
 use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal8SetList;
 use DrupalRector\Set\Drupal9SetList;
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
+use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
+use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\SetList;
+use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
+use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
+use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
+use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
-return static function (RectorConfig $rectorConfig): void {
-  $rectorConfig->sets([
-    // Provided by Rector.
-    SetList::TYPE_DECLARATION,
-    // Provided by Drupal Rector.
-    Drupal8SetList::DRUPAL_8,
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-  ]);
-
-  $rectorConfig->rule(DeclareStrictTypesRector::class);
-
-  $drupalFinder = new DrupalFinderComposerRuntime();
-  $drupalRoot = $drupalFinder->getDrupalRoot();
-  $rectorConfig->autoloadPaths([
-    $drupalRoot . '/core',
-    $drupalRoot . '/modules',
-    $drupalRoot . '/themes',
-    $drupalRoot . '/profiles',
-  ]);
-
-  $rectorConfig->skip([
-    // Dependencies.
+return RectorConfig::configure()
+  ->withSkip([
+    // Specific rules to skip based on project coding standards.
+    CatchExceptionNameMatchingTypeRector::class,
+    ChangeSwitchToMatchRector::class,
+    CompleteDynamicPropertiesRector::class,
+    CountArrayToEmptyArrayComparisonRector::class,
+    DisallowedEmptyRuleFixerRector::class,
+    InlineArrayReturnAssignRector::class,
+    NewlineAfterStatementRector::class,
+    NewlineBeforeNewAssignSetRector::class,
+    PrivatizeFinalClassMethodRector::class,
+    PrivatizeFinalClassPropertyRector::class,
+    PrivatizeLocalGetterToPropertyRector::class,
+    RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
+    RenameParamToMatchTypeRector::class,
+    RenameVariableToMatchMethodCallReturnTypeRector::class,
+    RenameVariableToMatchNewTypeRector::class,
+    SimplifyEmptyCheckOnEmptyArrayRector::class,
+    StringClassNameToClassConstantRector::class,
+    // Directories to skip.
     '*/vendor/*',
     '*/node_modules/*',
     // Core and contribs.
@@ -55,18 +74,49 @@ return static function (RectorConfig $rectorConfig): void {
     '*/sites/default/files/*',
     // Composer scripts.
     '*/scripts/composer/*',
-  ]);
+  ])
+  // PHP version upgrade sets - modernizes syntax to PHP 8.2.
+  // Includes all rules from PHP 5.3 through 8.2.
+  ->withPhpSets(php82: TRUE)
+  // Code quality improvement sets.
+  ->withPreparedSets(
+    codeQuality: TRUE,
+    codingStyle: TRUE,
+    deadCode: TRUE,
+    naming: TRUE,
+    privatization: TRUE,
+    typeDeclarations: TRUE,
+  )
+  // Drupal-specific deprecation fixes.
+  ->withSets([
+    Drupal9SetList::DRUPAL_9,
+    Drupal10SetList::DRUPAL_10,
+  ])
+  // Additional rules.
+  ->withRules([
+    DeclareStrictTypesRector::class,
+  ])
+  // Configure Drupal autoloading.
+  ->withAutoloadPaths((function (): array {
+    $drupalFinder = new DrupalFinderComposerRuntime();
+    $drupalRoot = $drupalFinder->getDrupalRoot();
 
-  $rectorConfig->fileExtensions([
-    'engine',
-    'inc',
-    'install',
-    'module',
+    return [
+      $drupalRoot . '/core',
+      $drupalRoot . '/modules',
+      $drupalRoot . '/themes',
+      $drupalRoot . '/profiles',
+    ];
+  })())
+  // Drupal file extensions.
+  ->withFileExtensions([
     'php',
+    'module',
+    'install',
     'profile',
     'theme',
-  ]);
-
-  $rectorConfig->importNames(TRUE, FALSE);
-  $rectorConfig->importShortClasses(FALSE);
-};
+    'inc',
+    'engine',
+  ])
+  // Import configuration.
+  ->withImportNames(importNames: TRUE, importDocBlockNames: FALSE, importShortClasses: FALSE);


### PR DESCRIPTION
Closes #280

## Checklist before requesting a review

- [ ] Subject includes Drupal issue number and author as `#123456 by JohnDoe: Verb in past tense.`
- [ ] Added context in `Changed` section
- [ ] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for a fix/feature.
- [ ] Relevant tests passed locally.

## Changed

1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the project's Rector configuration to use the latest fluent API schema, addressing #280. This change modernizes the Rector configuration approach from a static closure pattern to the declarative fluent builder API.

## Changes

### Configuration Approach
- Migrated Rector configuration from a static anonymous function returning `void` with a `RectorConfig` parameter to the fluent `RectorConfig::configure()` builder pattern
- Replaced explicit `$rectorConfig` property calls with method chaining: `withSkip()`, `withPhpSets()`, `withPreparedSets()`, `withSets()`, `withRules()`, `withAutoloadPaths()`, `withFileExtensions()`, and `withImportNames()`

### New Rector Rules
Added imports and configuration for 18+ new Rector rules across multiple categories:
- **Code Quality**: CompleteDynamicPropertiesRector, InlineArrayReturnAssignRector, SimplifyEmptyCheckOnEmptyArrayRector, DisallowedEmptyRuleFixerRector
- **Coding Style**: CatchExceptionNameMatchingTypeRector, NewlineBeforeNewAssignSetRector, CountArrayToEmptyArrayComparisonRector, NewlineAfterStatementRector
- **Dead Code**: RemoveAlwaysTrueIfConditionRector
- **Naming**: RenameVariableToMatchMethodCallReturnTypeRector, RenameParamToMatchTypeRector, RenameVariableToMatchNewTypeRector, RenameForeachValueVariableToMatchMethodCallReturnTypeRector
- **PHP 8.0**: ChangeSwitchToMatchRector
- **Privatization**: PrivatizeFinalClassMethodRector, PrivatizeLocalGetterToPropertyRector, PrivatizeFinalClassPropertyRector
- **Type Declaration**: DeclareStrictTypesRector, StringClassNameToClassConstantRector (PHP 5.5)

### Configuration Sets
- Added PHP 8.2 upgrade scope (`php82`)
- Included preconfigured sets for code quality, coding style, dead code, naming, privatization, and type declarations
- Added Drupal-specific sets (DRUPAL_9 and DRUPAL_10)

### Drupal Integration
- Configured dynamic Drupal autoload path computation using `DrupalFinderComposerRuntime`
- Explicitly defined file extensions to include: PHP, module, install, profile, theme, inc, engine

### Skip Rules
- Expanded skip rules to selectively disable certain Rector rules and control scope of analyzed code

## Files Modified
- `rector.php` (root)
- `.scaffold/tests/fixtures/init/_baseline/rector.php`
- `.scaffold/tests/rector.php`

**Effort estimate**: High

<!-- end of auto-generated comment: release notes by coderabbit.ai -->