### PR TITLE
Updated actionlint to v1.7.11

### DIFF
--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -106,5 +106,5 @@ jobs:
         continue-on-error: ${{ vars.DREVOPS_CI_YAMLLINT_IGNORE_FAILURE == '1' }}
 
       - name: Check coding standards with actionlint
-        run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.6.27 -ignore 'SC2002:' -ignore 'SC2155:'
+        run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.7.11 -ignore 'SC2002:' -ignore 'SC2155:'
         continue-on-error: ${{ vars.DREVOPS_CI_ACTIONLINT_IGNORE_FAILURE == '1' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the actionlint Docker image version in the GitHub Actions scaffold test workflow from `rhysd/actionlint:1.6.27` to `rhysd/actionlint:1.7.11`. This is a minor version update for the GitHub Actions linting tool that validates workflow syntax and best practices.

## Changes

- `.github/workflows/scaffold-test.yml`: Updated the actionlint step to use version 1.7.11, while maintaining all existing command arguments and configuration settings.

## Impact

- Minimal: Single line change in a workflow file
- Brings the project up to a more recent version of actionlint for improved linting capabilities
- No changes to the linting rules or validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->