### PR TITLE
Pinned all GHA actions.

### DIFF
--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -15,4 +15,4 @@ jobs:
 
     steps:
       - name: Assign author
-        uses: toshimaru/auto-author-assign@v3.0.1
+        uses: toshimaru/auto-author-assign@4d585cc37690897bd9015942ed6e766aa7cdb97f # v3.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@6b84f2e793b32fa0b03a379cadadec75cc539391 # v2
         with:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           known_hosts: unnecessary

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -20,6 +20,6 @@ jobs:
 
     steps:
       - name: Draft release notes
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Upgrade sqlite3
         if: matrix.group != 'p0'
@@ -37,7 +37,7 @@ jobs:
           sudo ldconfig
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
         with:
           php-version: 8.3
           extensions: gd, sqlite, pdo_sqlite
@@ -77,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload coverage report as an artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.group }}
           path: .scaffold/tests/.logs
@@ -85,7 +85,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           directory: .scaffold/tests/.logs
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check coding standards with yamllint
         run: yamllint --config-file .scaffold/tests/.yamllint-for-gha.yml .github/workflows

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/assign-author.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/assign-author.yml
@@ -15,4 +15,4 @@ jobs:
 
     steps:
       - name: Assign author
-        uses: toshimaru/auto-author-assign@__VERSION__
+        uses: toshimaru/auto-author-assign@__HASH__ # __VERSION__

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@__VERSION__
+        uses: actions/checkout@__HASH__ # __VERSION__
         with:
           fetch-depth: 0
 
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@__VERSION__
+        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
         with:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           known_hosts: unnecessary

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/draft-release-notes.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/draft-release-notes.yml
@@ -20,6 +20,6 @@ jobs:
 
     steps:
       - name: Draft release notes
-        uses: release-drafter/release-drafter@__VERSION__
+        uses: release-drafter/release-drafter@__HASH__ # __VERSION__
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pins GitHub Actions to specific commit hashes

This pull request pins all GitHub Actions used across the repository's workflows to exact commit SHAs instead of version tags, improving reproducibility and security by enabling precise version tracking and preventing unexpected behavior changes from action updates.

### Changes Made

The following workflow files were updated to use commit SHA digests:

- **`.github/workflows/assign-author.yml`**: Updated `toshimaru/auto-author-assign` from `v3.0.1` to commit `4d585cc37690897bd9015942ed6e766aa7cdb97f`
- **`.github/workflows/deploy.yml`**: Updated `actions/checkout` from `v6` and `shimataro/ssh-key-action` from `v2` to their respective commit SHAs
- **`.github/workflows/draft-release-notes.yml`**: Updated `release-drafter/release-drafter` from `v6` to commit `6db134d15f3909ccc9eefd369f02bd1e9cffdf97`
- **`.github/workflows/scaffold-test.yml`**: Updated multiple actions (`actions/checkout`, `shivammathur/setup-php`, `actions/upload-artifact`, `codecov-action`) to their commit SHA equivalents in both scaffold-test-devtools and scaffold-test-actions jobs
- **Test fixture baseline files**: Updated `.scaffold/tests/fixtures/init/_baseline/.github/workflows/` files to use placeholder version and hash markers (`__VERSION__` and `__HASH__`)

### Implementation Details

All changes preserve the original semantic version information in inline comments (e.g., `# v3.0.1`), enabling easy identification of which version each pinned SHA corresponds to. The functional behavior of all workflows remains unchanged.

This aligns with the repository's documented commitment to digest pinning for GitHub Actions, which is mentioned in the README as a measure for reproducibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->