### PR TITLE
Better removal of asset packagist.

### DIFF
--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -132,7 +132,13 @@ PASS("Configuration from extension's composer.json merged.");
 // Asset Packagist sometimes fails, so we remove it by default. If it's needed,
 // the lines below can be commented out.
 TASK('Removing asset-packagist.');
-passthru('composer --working-dir=build config --unset repositories.1 2>/dev/null');
+$build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
+if (!empty($build_json['repositories'])) {
+  /** @var array<int, array<string, string>> $repositories */
+  $repositories = (array) $build_json['repositories'];
+  $build_json['repositories'] = array_values(array_filter($repositories, fn(array $r): bool => !isset($r['url']) || !str_contains($r['url'], 'asset-packagist.org')));
+  file_put_contents($build_composer_json, json_encode($build_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+}
 PASS('Asset Packagist removed.');
 
 if (is_dir('patches')) {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -132,7 +132,13 @@ PASS("Configuration from extension's composer.json merged.");
 // Asset Packagist sometimes fails, so we remove it by default. If it's needed,
 // the lines below can be commented out.
 TASK('Removing asset-packagist.');
-passthru('composer --working-dir=build config --unset repositories.1 2>/dev/null');
+$build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
+if (!empty($build_json['repositories'])) {
+  /** @var array<int, array<string, string>> $repositories */
+  $repositories = (array) $build_json['repositories'];
+  $build_json['repositories'] = array_values(array_filter($repositories, fn(array $r): bool => !isset($r['url']) || !str_contains($r['url'], 'asset-packagist.org')));
+  file_put_contents($build_composer_json, json_encode($build_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+}
 PASS('Asset Packagist removed.');
 
 if (is_dir('patches')) {

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -19,6 +19,11 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 #[Group('p0')]
 final class AssembleTest extends UnitTestCase {
 
+  /**
+   * @var array<int, string>
+   */
+  protected array $capturedBuildComposerJson = [];
+
   protected function setUp(): void {
     parent::setUp();
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
@@ -68,6 +73,10 @@ final class AssembleTest extends UnitTestCase {
 
     // Build/composer.json content (scaffold).
     $build_composer_json = json_encode([
+      'repositories' => [
+        ['type' => 'composer', 'url' => 'https://packages.drupal.org/8'],
+        ['type' => 'composer', 'url' => 'https://asset-packagist.org'],
+      ],
       'require' => ['drupal/core-recommended' => '^11', 'drupal/core-composer-scaffold' => '^11'],
       'minimum-stability' => 'stable',
       'prefer-stable' => TRUE,
@@ -189,8 +198,14 @@ final class AssembleTest extends UnitTestCase {
       return '';
     });
 
-    // Mock file_put_contents.
-    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', fn(): int => 100);
+    // Mock file_put_contents - capture writes to build/composer.json.
+    $this->capturedBuildComposerJson = [];
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function (string $file, string $content): int {
+      if ($file === 'build/composer.json') {
+        $this->capturedBuildComposerJson[] = $content;
+      }
+      return 100;
+    });
 
     // Mock copy.
     $this->registerMock('copy', 'DrupalExtensionScaffold\\DevTools', fn(): true => TRUE);
@@ -213,29 +228,26 @@ final class AssembleTest extends UnitTestCase {
     // 3. git checkout.
     $passthru_responses[] = ['cmd' => sprintf('git --git-dir=build/.git --work-tree=build checkout %s', escapeshellarg((string) $effective_sha))];
 
-    // 4. remove asset-packagist.
-    $passthru_responses[] = ['cmd' => 'composer --working-dir=build config --unset repositories.1 2>/dev/null'];
-
-    // 5. Patches copy (if applicable).
+    // 4. Patches copy (if applicable).
     if ($config['has_patches']) {
       // copy_dir is called but it's a real function that uses PHP iterators,
       // so we don't need to mock it separately - tested in HelpersCopyDirTest.
     }
 
-    // 6. GitHub token (if applicable).
+    // 5. GitHub token (if applicable).
     if ($config['github_token'] !== '') {
       $passthru_responses[] = ['cmd' => sprintf('composer config --global github-oauth.github.com %s', escapeshellarg((string) $config['github_token']))];
     }
 
-    // 7. composer install.
+    // 6. composer install.
     $passthru_responses[] = ['cmd' => 'composer --working-dir=build install'];
 
-    // 8. Suggested dependencies.
+    // 7. Suggested dependencies.
     foreach (array_keys($config['suggestions']) as $suggest) {
       $passthru_responses[] = ['cmd' => sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest))];
     }
 
-    // 9. NPM install and build (if applicable).
+    // 8. NPM install and build (if applicable).
     if ($config['has_package_lock'] && !$config['has_skip_npm_build']) {
       $cmd = $config['has_nvmrc'] ? 'nvm use && ' : '';
       $cmd .= $config['has_node_modules'] ? '' : 'npm --prefix build ci && ';
@@ -298,6 +310,12 @@ final class AssembleTest extends UnitTestCase {
     $this->assertStringContainsString('Dependencies installed', $output);
     $this->assertStringContainsString("Extension's code symlinked", $output);
     $this->assertStringContainsString('ASSEMBLE COMPLETE', $output);
+
+    // Verify asset-packagist was removed from the final build/composer.json.
+    $this->assertStringContainsString('Asset Packagist removed', $output);
+    $this->assertNotEmpty($this->capturedBuildComposerJson, 'Expected at least one write to build/composer.json');
+    $last_written = end($this->capturedBuildComposerJson);
+    $this->assertStringNotContainsString('asset-packagist.org', (string) $last_written);
 
     $drupal_version = $env['DRUPAL_VERSION'] ?? '11';
     $this->assertStringContainsString('Initialising Drupal ' . $drupal_version . ' site', $output);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR improves the removal of the asset-packagist Composer repository by replacing the Composer CLI-based approach with direct JSON file manipulation.

## Changes

**`.devtools/assemble`**
- Replaces the Composer CLI `config --unset` approach with direct manipulation of `build/composer.json`.
- New implementation:
  - Loads and decodes `build/composer.json`.
  - Filters the `repositories` array to remove any repository whose `url` contains `asset-packagist.org` (keeps entries without a `url`).
  - Re-indexes and re-encodes the JSON with pretty printing and writes it back only when repositories exist.
  - Maintains the existing TASK/PASS flow and messaging.

**`.scaffold/tests/src/Unit/AssembleTest.php`**
- Added `protected array $capturedBuildComposerJson = [];` to capture writes to `build/composer.json` during tests.
- Reworked the `file_put_contents` mock to capture written content rather than returning a fixed value.
- Expanded the test scaffold `build/composer.json` to include two repositories (Drupal.org and asset-packagist.org).
- Added assertions to verify that:
  - `asset-packagist.org` is removed from the final `build/composer.json`.
  - At least one write to `build/composer.json` occurred during assembly.

**`.scaffold/tests/fixtures/init/_baseline/.devtools/assemble`**
- Updated fixture to reflect the new JSON-based removal step (same logic as in `.devtools/assemble`).

## Impact

- More reliable removal of asset-packagist by operating directly on composer.json instead of relying on Composer CLI repository indexing.
- Improves testability by verifying the final JSON content and capturing file writes.
- Handles cases where repository indexes vary or expected CLI indices are absent.

## Possibly related

I searched the repository for references to asset-packagist and removal-related issues/mentions and found no existing repository issues or explicit issue references related to this change. If there is an existing GitHub issue tracking asset-packagist removal or related composer repository handling, please add a reference (for example, #<issue-number>) so this PR can be linked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->