### PR TITLE
Fixed PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Closes #
 
 - [ ] Subject includes Drupal issue number and author as `#123456 by JohnDoe: Verb in past tense.`
 - [ ] Added context in `Changed` section
-- [ ] Self-reviewed code and commented in commented complex areas.
+- [ ] Self-reviewed code and commented in complex areas.
 - [ ] Added tests for a fix/feature.
 - [ ] Relevant tests passed locally.
 

--- a/.scaffold/tests/fixtures/init/_baseline/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Closes #
 
 - [ ] Subject includes Drupal issue number and author as `#123456 by JohnDoe: Verb in past tense.`
 - [ ] Added context in `Changed` section
-- [ ] Self-reviewed code and commented in commented complex areas.
+- [ ] Self-reviewed code and commented in complex areas.
 - [ ] Added tests for a fix/feature.
 - [ ] Relevant tests passed locally.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixed a typo in the pull request template by removing the duplicate word "commented" from a checklist item. Changed the text from "Self-reviewed code and commented in commented complex areas." to "Self-reviewed code and commented in complex areas."

## Changes

- Updated `.github/PULL_REQUEST_TEMPLATE.md` to correct the duplicated "commented" word in the code review checklist item
- Updated the baseline test fixture at `.scaffold/tests/fixtures/init/_baseline/.github/PULL_REQUEST_TEMPLATE.md` with the same correction

## Impact

- Low effort review
- No functional changes; purely textual correction to improve clarity
- No impact on logic, workflow, or control flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->