### PR TITLE
Added `--no-interaction` flag to init.php

### DIFF
--- a/.scaffold/tests/src/Functional/InitTest.php
+++ b/.scaffold/tests/src/Functional/InitTest.php
@@ -42,6 +42,7 @@ final class InitTest extends FunctionalTestCase {
     array $expected = [],
     ?SerializableClosure $before = NULL,
     ?SerializableClosure $after = NULL,
+    bool $no_interaction = FALSE,
   ): void {
     self::$fixtures = static::locationsFixtureDir();
 
@@ -50,9 +51,14 @@ final class InitTest extends FunctionalTestCase {
       $before($this);
     }
 
-    $answers = self::tuiEntries(array_replace(self::defaultAnswers(), $answers));
-
-    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.php', [], $answers);
+    if ($no_interaction) {
+      $args = ['Force Crystal', 'force_crystal', 'module', 'gha', 'ahoy', '--no-interaction'];
+      $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.php', $args);
+    }
+    else {
+      $answers = self::tuiEntries(array_replace(self::defaultAnswers(), $answers));
+      $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.php', [], $answers);
+    }
 
     $this->assertProcessSuccessful();
 
@@ -124,6 +130,14 @@ final class InitTest extends FunctionalTestCase {
       [
         'remove_self' => 'n',
       ],
+    ];
+
+    yield 'no_interaction' => [
+      [],
+      [],
+      NULL,
+      NULL,
+      TRUE,
     ];
   }
 

--- a/.scaffold/tests/src/Unit/InitHelpersTest.php
+++ b/.scaffold/tests/src/Unit/InitHelpersTest.php
@@ -399,6 +399,44 @@ final class InitHelpersTest extends UnitTestCase {
     ];
   }
 
+  public function testAskNoInteractionWithDefault(): void {
+    no_interaction(TRUE);
+    try {
+      $this->assertSame('default_val', ask('Name', 'default_val'));
+    }
+    finally {
+      no_interaction(FALSE);
+    }
+  }
+
+  public function testAskNoInteractionWithoutDefault(): void {
+    no_interaction(TRUE);
+    try {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("No default value for prompt 'Name' in non-interactive mode.");
+      ask('Name');
+    }
+    finally {
+      no_interaction(FALSE);
+    }
+  }
+
+  #[DataProvider('dataProviderAskYesnoNoInteraction')]
+  public function testAskYesnoNoInteraction(string $default, string $expected): void {
+    no_interaction(TRUE);
+    try {
+      $this->assertSame($expected, ask_yesno('Proceed', $default));
+    }
+    finally {
+      no_interaction(FALSE);
+    }
+  }
+
+  public static function dataProviderAskYesnoNoInteraction(): \Iterator {
+    yield 'default Y returns y' => ['Y', 'y'];
+    yield 'default N returns n' => ['N', 'n'];
+  }
+
   public function testVerboseReturnsBuffer(): void {
     $buffer = verbose('Test message' . PHP_EOL);
     $this->assertContains('Test message' . PHP_EOL, $buffer);

--- a/init.php
+++ b/init.php
@@ -34,6 +34,11 @@ function main(array $argv, int $argc): void {
     return;
   }
 
+  if (in_array('--no-interaction', $argv, TRUE)) {
+    no_interaction(TRUE);
+    $argv = array_values(array_filter($argv, static fn(string $v): bool => $v !== '--no-interaction'));
+  }
+
   $extension_name = $argv[1] ?? '';
   $extension_machine_name = $argv[2] ?? '';
   $extension_type = $argv[3] ?? '';
@@ -177,6 +182,7 @@ Arguments:
 
 Options:
   --help                This help.
+  --no-interaction      Skip interactive prompts; use default values.
 
 Examples:
   Interactive:
@@ -184,6 +190,9 @@ Examples:
 
   Silent:
     php {$script_name} "Extension Name" extension_machine_name module gha ahoy
+
+  Non-interactive:
+    php {$script_name} "Extension Name" extension_machine_name module gha ahoy --no-interaction
 
 EOF;
   verbose($out);
@@ -509,6 +518,13 @@ function is_binary_file(string $path): bool {
  *   The user's input or the default value.
  */
 function ask(string $prompt, string $default = '', array|callable|null $validator = NULL): string {
+  if (no_interaction()) {
+    if ($default !== '') {
+      return $default;
+    }
+    throw new \Exception("No default value for prompt '" . $prompt . "' in non-interactive mode.");
+  }
+
   $display = $default !== '' ? color($prompt, 'green') . ' [' . color($default, 'dim') . ']: ' : color($prompt, 'green') . ': ';
   $result = '';
   while ($result === '') {
@@ -545,6 +561,10 @@ function ask(string $prompt, string $default = '', array|callable|null $validato
  *   The lowercased answer ('y' or 'n').
  */
 function ask_yesno(string $prompt, string $default = 'Y'): string {
+  if (no_interaction()) {
+    return strtolower($default);
+  }
+
   $options = $default === 'Y' ? 'Y/n' : 'y/N';
   $result = readline(color($prompt, 'green') . ' [' . color($options, 'dim') . ']: ');
   if ($result === FALSE || trim($result) === '') {
@@ -590,6 +610,24 @@ function color(string $text, string $color): string {
   $codes = ['red' => '31', 'green' => '32', 'yellow' => '33', 'cyan' => '36', 'dim' => '2'];
 
   return "\033[" . ($codes[$color] ?? '0') . 'm' . $text . "\033[0m";
+}
+
+/**
+ * Get or set the non-interactive mode flag.
+ *
+ * @param bool|null $value
+ *   Pass TRUE or FALSE to set the flag, or NULL to read it.
+ *
+ * @return bool
+ *   The current non-interactive mode state.
+ */
+function no_interaction(?bool $value = NULL): bool {
+  static $active = FALSE;
+  if ($value !== NULL) {
+    $active = $value;
+  }
+
+  return $active;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request adds a `--no-interaction` flag to the `init.php` script, enabling non-interactive mode for automated initialization workflows. When the flag is provided, the script skips all interactive prompts and uses default values or fails if no default is available.

## Changes

### init.php
- Added detection and processing of the `--no-interaction` flag in `main()` (removes the flag from argv and enables non-interactive mode).
- Added global helper `function no_interaction(?bool $value = NULL): bool` to get/set non-interactive state.
- Updated `ask()` to return the default in non-interactive mode or throw an exception if no default is provided.
- Updated `ask_yesno()` to return the lowercased default in non-interactive mode.
- Updated `print_help()` to document the new `--no-interaction` option with usage examples.
- Ensures non-interactive flow uses defaults or fails fast when required values are missing.

### Tests
- Functional (.scaffold/tests/src/Functional/InitTest.php):
  - Extended `testInit()` signature with `bool $no_interaction = FALSE`.
  - Added a "no_interaction" dataset to `dataProviderInit()` exercising the non-interactive path.
- Unit (.scaffold/tests/src/Unit/InitHelpersTest.php):
  - Added `testAskNoInteractionWithDefault()` to verify `ask()` returns default in non-interactive mode.
  - Added `testAskNoInteractionWithoutDefault()` to verify `ask()` throws when no default is provided.
  - Added `testAskYesnoNoInteraction()` and `dataProviderAskYesnoNoInteraction()` to verify `ask_yesno()` behavior in non-interactive mode.

## Impact
Enables CI/CD pipelines and automated tools to run the initialization script without user interaction by specifying all required arguments and the `--no-interaction` flag. Scripts/automation can now fail early if required inputs are not provided.

## Possibly related
Possibly related to issue #160 — "Add support for `composer create-project`" (https://github.com/AlexSkrypnyk/drupal_extension_scaffold/issues/160), which would benefit from a fully non-interactive initialization flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->