### PR TITLE
Added support for functional JS testing.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -86,6 +86,34 @@ commands:
       php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional "$@"
       popd >/dev/null || exit 1
 
+  test-functional-javascript:
+    usage: Run FunctionalJavascript tests.
+    cmd: |
+      ahoy selenium-start
+      pushd "build" >/dev/null || exit 1
+      php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
+      popd >/dev/null || exit 1
+
+  selenium-start:
+    usage: Start Selenium container if not already running.
+    cmd: |
+      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
+        echo "Selenium container is already running."
+        exit 0
+      fi
+      docker rm -f selenium 2>/dev/null || true
+      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
+      echo "Waiting for Selenium to be ready..."
+      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
+      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
+        echo "ERROR: Selenium failed to become ready after 30 seconds."
+        exit 1
+      fi
+
+  selenium-stop:
+    usage: Stop Selenium container.
+    cmd: docker rm -f selenium 2>/dev/null || true
+
   reset:
     usage: Reset project to the default state.
     cmd: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ aliases:
     docker:
       - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
 
+  - &selenium_image
+    image: selenium/standalone-chromium:latest
+
 job-test: &job-test
   steps:
     - checkout
@@ -50,6 +53,8 @@ job-test: &job-test
     - run:
         name: Start built-in PHP server
         command: .devtools/start
+        environment:
+          WEBSERVER_HOST: 0.0.0.0
 
     - run:
         name: Provision site
@@ -110,6 +115,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -118,6 +124,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -126,6 +133,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -135,6 +143,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -143,6 +152,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -151,6 +161,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -160,6 +171,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3 # Lowest Drupal version that supports PHP 8.4.
     <<: *job-test
@@ -168,6 +180,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -176,6 +189,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -185,6 +199,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -193,6 +208,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -201,6 +217,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -210,6 +227,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -218,6 +236,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -226,6 +245,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -16,6 +16,12 @@ jobs:
   scaffold-test-devtools:
     runs-on: ubuntu-latest
 
+    services:
+      chrome:
+        image: selenium/standalone-chromium:latest
+        ports:
+          - 4444:4444
+
     strategy:
       fail-fast: false
 
@@ -75,6 +81,7 @@ jobs:
         working-directory: .scaffold/tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBSERVER_HOST: ${{ (matrix.group == 'p3' || matrix.group == 'p4') && '0.0.0.0' || 'localhost' }}
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,12 @@ jobs:
             php-version: 8.4
             drupal-version: 11@beta
 
+    services:
+      chrome:
+        image: selenium/standalone-chromium:latest
+        ports:
+          - 4444:4444
+
     name: ${{ matrix.name }}
 
     env:
@@ -128,6 +134,8 @@ jobs:
 
       - name: Start built-in PHP server
         run: .devtools/start
+        env:
+          WEBSERVER_HOST: 0.0.0.0
 
       - name: Provision site
         run: .devtools/provision

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -86,6 +86,34 @@ commands:
       php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional "$@"
       popd >/dev/null || exit 1
 
+  test-functional-javascript:
+    usage: Run FunctionalJavascript tests.
+    cmd: |
+      ahoy selenium-start
+      pushd "build" >/dev/null || exit 1
+      php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
+      popd >/dev/null || exit 1
+
+  selenium-start:
+    usage: Start Selenium container if not already running.
+    cmd: |
+      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
+        echo "Selenium container is already running."
+        exit 0
+      fi
+      docker rm -f selenium 2>/dev/null || true
+      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
+      echo "Waiting for Selenium to be ready..."
+      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
+      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
+        echo "ERROR: Selenium failed to become ready after 30 seconds."
+        exit 1
+      fi
+
+  selenium-stop:
+    usage: Stop Selenium container.
+    cmd: docker rm -f selenium 2>/dev/null || true
+
   reset:
     usage: Reset project to the default state.
     cmd: |

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -81,6 +81,12 @@ jobs:
             php-version: 8.4
             drupal-version: 11@beta
 
+    services:
+      chrome:
+        image: selenium/standalone-chromium:latest
+        ports:
+          - 4444:4444
+
     name: ${{ matrix.name }}
 
     env:
@@ -128,6 +134,8 @@ jobs:
 
       - name: Start built-in PHP server
         run: .devtools/start
+        env:
+          WEBSERVER_HOST: __VERSION__.0
 
       - name: Provision site
         run: .devtools/provision

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -35,6 +35,9 @@ This is a Force Crystal template for creating contributed modules or themes. The
 - `make test-unit` / `ahoy test-unit` - Run unit tests only
 - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
 - `make test-functional` / `ahoy test-functional` - Run functional tests only
+- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
+- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
 
 ### Drupal Commands
 

--- a/.scaffold/tests/fixtures/init/_baseline/README.md
+++ b/.scaffold/tests/fixtures/init/_baseline/README.md
@@ -146,13 +146,27 @@ the tests.
 
 The `test` command is a wrapper for multiple test commands:
 ```bash
-make test-unit        # Run Unit tests
-make test-kernel      # Run Kernel tests
-make test-functional  # Run Functional tests
+make test-unit                    # Run Unit tests
+make test-kernel                  # Run Kernel tests
+make test-functional              # Run Functional tests
+make test-functional-javascript   # Run FunctionalJavascript tests
 
-ahoy test-unit        # Run Unit tests
-ahoy test-kernel      # Run Kernel tests
-ahoy test-functional  # Run Functional tests
+ahoy test-unit                    # Run Unit tests
+ahoy test-kernel                  # Run Kernel tests
+ahoy test-functional              # Run Functional tests
+ahoy test-functional-javascript   # Run FunctionalJavascript tests
+```
+
+### Running FunctionalJavascript tests
+
+FunctionalJavascript tests require a browser controlled via WebDriver.
+
+```bash
+ahoy selenium-start
+WEBSERVER_HOST=__VERSION__.0 ahoy start
+ahoy provision
+ahoy test-functional-javascript
+ahoy selenium-stop
 ```
 
 ### Running specific tests

--- a/.scaffold/tests/fixtures/init/_baseline/phpunit.d10.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpunit.d10.xml
@@ -64,7 +64,7 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=''/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
     </php>
     <testsuites>
         <testsuite name="unit">
@@ -80,13 +80,10 @@
             <directory>web/themes/custom/*/tests/src/Functional</directory>
         </testsuite>
 
-        <!-- Not implemented. -->
-        <!-- See https://github.com/drevops/scaffold/issues/820 -->
-        <!--
         <testsuite name="functional-javascript">
-          <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+            <directory>web/modules/custom/*/tests/src/FunctionalJavascript</directory>
+            <directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <logging>

--- a/.scaffold/tests/fixtures/init/_baseline/phpunit.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpunit.xml
@@ -54,7 +54,7 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=""/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "goog:chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
     </php>
     <extensions>
         <!-- Functional tests HTML output logging. -->
@@ -90,13 +90,10 @@
             <directory>web/themes/custom/*/tests/src/Functional</directory>
         </testsuite>
 
-        <!-- Not implemented. -->
-        <!-- See https://github.com/drevops/vortex/issues/820 -->
-        <!--
         <testsuite name="functional-javascript">
-          <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+            <directory>web/modules/custom/*/tests/src/FunctionalJavascript</directory>
+            <directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <logging>

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/FunctionalJavascript/ForceCrystalJsTestBase.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/FunctionalJavascript/ForceCrystalJsTestBase.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\force_crystal\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Base class for ForceCrystal JavaScript functional tests.
+ *
+ * @group force_crystal
+ */
+abstract class ForceCrystalJsTestBase extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['force_crystal'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // Override SIMPLETEST_BASE_URL so that Chrome inside the Selenium
+    // container can reach the PHP webserver on the host machine.
+    // In CircleCI, all containers share the network namespace, so
+    // 'localhost' works without override.
+    if (!getenv('CIRCLECI')) {
+      $port = getenv('WEBSERVER_PORT') ?: '8000';
+      $host = PHP_OS_FAMILY === 'Darwin' ? 'host.docker.internal' : '__VERSION__.1';
+      putenv('SIMPLETEST_BASE_URL=http://' . $host . ':' . $port);
+    }
+    parent::setUp();
+  }
+
+  /**
+   * Create a screenshot with an auto-generated filename.
+   *
+   * Filename format: {ms_timestamp}-{Class}-{method}-L{line}.png.
+   *
+   * @param bool $set_background_color
+   *   (optional) Whether to set the background color. Defaults to TRUE.
+   */
+  protected function createAutoScreenshot(bool $set_background_color = TRUE): void {
+    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+    $line = $trace[0]['line'] ?? 0;
+    $class = str_replace('\\', '_', $trace[1]['class'] ?? 'Unknown');
+    $method = $trace[1]['function'];
+    $timestamp = (int) (microtime(TRUE) * 1000);
+
+    $filename = sprintf('%d-%s-%s-L%d.png', $timestamp, $class, $method, $line);
+    $path = \Drupal::root() . '/sites/simpletest/browser_output/' . $filename;
+
+    $this->createScreenshot($path, $set_background_color);
+    $this->assertFileExists($path);
+  }
+
+}

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/FunctionalJavascript/ForceCrystalSmokeJsTest.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/FunctionalJavascript/ForceCrystalSmokeJsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\force_crystal\FunctionalJavascript;
+
+/**
+ * Smoke test validating the WebDriver and screenshot pipeline.
+ *
+ * @group force_crystal
+ */
+class ForceCrystalSmokeJsTest extends ForceCrystalJsTestBase {
+
+  /**
+   * Tests WebDriver connectivity and screenshot generation.
+   */
+  public function testSmokeWebDriver(): void {
+    // Verify unauthenticated page renders.
+    $this->drupalGet('/user/login');
+    $this->createAutoScreenshot();
+
+    // Create user and log in.
+    $account = $this->drupalCreateUser(['administer site configuration']);
+    $this->assertNotEmpty($account);
+    $this->drupalLogin($account);
+
+    // Verify authenticated page renders.
+    $this->drupalGet('<front>');
+    $this->createAutoScreenshot();
+
+    // Verify Drupal JavaScript API is available.
+    $this->assertJsCondition('typeof Drupal !== "undefined" && typeof Drupal.behaviors !== "undefined"');
+  }
+
+}

--- a/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
@@ -15,6 +15,9 @@ aliases:
     docker:
       - image: cimg/php:__VERSION__
 
+  - &selenium_image
+    image: selenium/standalone-chromium:latest
+
 job-test: &job-test
   steps:
     - checkout
@@ -50,6 +53,8 @@ job-test: &job-test
     - run:
         name: Start built-in PHP server
         command: .devtools/start
+        environment:
+          WEBSERVER_HOST: __VERSION__.0
 
     - run:
         name: Provision site
@@ -110,6 +115,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -118,6 +124,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -126,6 +133,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -135,6 +143,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -143,6 +152,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -151,6 +161,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -160,6 +171,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3 # Lowest Drupal version that supports PHP 8.4.
     <<: *job-test
@@ -168,6 +180,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -176,6 +189,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -185,6 +199,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -193,6 +208,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -201,6 +217,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -210,6 +227,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -218,6 +236,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -226,6 +245,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
@@ -15,6 +15,9 @@ aliases:
     docker:
       - image: cimg/php:__VERSION__
 
+  - &selenium_image
+    image: selenium/standalone-chromium:latest
+
 job-test: &job-test
   steps:
     - checkout
@@ -50,6 +53,8 @@ job-test: &job-test
     - run:
         name: Start built-in PHP server
         command: .devtools/start
+        environment:
+          WEBSERVER_HOST: __VERSION__.0
 
     - run:
         name: Provision site
@@ -110,6 +115,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -118,6 +124,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -126,6 +133,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -135,6 +143,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -143,6 +152,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -151,6 +161,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -160,6 +171,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3 # Lowest Drupal version that supports PHP 8.4.
     <<: *job-test
@@ -168,6 +180,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -176,6 +189,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -185,6 +199,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -193,6 +208,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -201,6 +217,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -210,6 +227,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -218,6 +236,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -226,6 +245,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, start, status, stop, test, test-functional, test-kernel, test-unit
+.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-kernel, test-unit
 
 help:
 	@echo "COMMANDS"
@@ -17,10 +17,13 @@ help:
 	@echo "reset           - Reset project to the default state."
 	@echo "start           - Start development environment."
 	@echo "stop            - Stop development environment."
-	@echo "test            - Run all tests."
-	@echo "test-functional - Run functional tests."
-	@echo "test-kernel     - Run kernel tests."
-	@echo "test-unit       - Run unit tests."
+	@echo "test                       - Run all tests."
+	@echo "test-functional            - Run functional tests."
+	@echo "test-functional-javascript - Run FunctionalJavascript tests."
+	@echo "test-kernel                - Run kernel tests."
+	@echo "test-unit                  - Run unit tests."
+	@echo "selenium-start             - Start Selenium container."
+	@echo "selenium-stop              - Stop Selenium container."
 
 build: stop assemble start provision
 
@@ -84,6 +87,28 @@ test-functional:
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
+
+test-functional-javascript: selenium-start
+	pushd "build" >/dev/null || exit 1 && \
+	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	popd >/dev/null || exit 1
+
+selenium-start:
+	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
+		echo "Selenium container is already running."; \
+	else \
+		docker rm -f selenium 2>/dev/null || true; \
+		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
+		echo "Waiting for Selenium to be ready..."; \
+		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
+		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
+			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
+			exit 1; \
+		fi; \
+	fi
+
+selenium-stop:
+	docker rm -f selenium 2>/dev/null || true
 
 reset:
 	killall -9 php >/dev/null 2>&1 || true && \

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
@@ -15,6 +15,9 @@ aliases:
     docker:
       - image: cimg/php:__VERSION__
 
+  - &selenium_image
+    image: selenium/standalone-chromium:latest
+
 job-test: &job-test
   steps:
     - checkout
@@ -50,6 +53,8 @@ job-test: &job-test
     - run:
         name: Start built-in PHP server
         command: .devtools/start
+        environment:
+          WEBSERVER_HOST: __VERSION__.0
 
     - run:
         name: Provision site
@@ -110,6 +115,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -118,6 +124,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -126,6 +133,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -135,6 +143,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
     <<: *job-test
@@ -143,6 +152,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -151,6 +161,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -160,6 +171,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3 # Lowest Drupal version that supports PHP 8.4.
     <<: *job-test
@@ -168,6 +180,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
     <<: *job-test
@@ -176,6 +189,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -185,6 +199,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -193,6 +208,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -201,6 +217,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
@@ -210,6 +227,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
     <<: *job-test
@@ -218,6 +236,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
     <<: *job-test
@@ -226,6 +245,7 @@ jobs:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
+      - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, start, status, stop, test, test-functional, test-kernel, test-unit
+.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-kernel, test-unit
 
 help:
 	@echo "COMMANDS"
@@ -17,10 +17,13 @@ help:
 	@echo "reset           - Reset project to the default state."
 	@echo "start           - Start development environment."
 	@echo "stop            - Stop development environment."
-	@echo "test            - Run all tests."
-	@echo "test-functional - Run functional tests."
-	@echo "test-kernel     - Run kernel tests."
-	@echo "test-unit       - Run unit tests."
+	@echo "test                       - Run all tests."
+	@echo "test-functional            - Run functional tests."
+	@echo "test-functional-javascript - Run FunctionalJavascript tests."
+	@echo "test-kernel                - Run kernel tests."
+	@echo "test-unit                  - Run unit tests."
+	@echo "selenium-start             - Start Selenium container."
+	@echo "selenium-stop              - Stop Selenium container."
 
 build: stop assemble start provision
 
@@ -84,6 +87,28 @@ test-functional:
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
+
+test-functional-javascript: selenium-start
+	pushd "build" >/dev/null || exit 1 && \
+	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	popd >/dev/null || exit 1
+
+selenium-start:
+	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
+		echo "Selenium container is already running."; \
+	else \
+		docker rm -f selenium 2>/dev/null || true; \
+		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
+		echo "Waiting for Selenium to be ready..."; \
+		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
+		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
+			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
+			exit 1; \
+		fi; \
+	fi
+
+selenium-stop:
+	docker rm -f selenium 2>/dev/null || true
 
 reset:
 	killall -9 php >/dev/null 2>&1 || true && \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ This is a Drupal extension scaffold template for creating contributed modules or
 - `make test-unit` / `ahoy test-unit` - Run unit tests only
 - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
 - `make test-functional` / `ahoy test-functional` - Run functional tests only
+- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
+- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
 
 ### Drupal Commands
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, start, status, stop, test, test-functional, test-kernel, test-unit
+.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-kernel, test-unit
 
 help:
 	@echo "COMMANDS"
@@ -17,10 +17,13 @@ help:
 	@echo "reset           - Reset project to the default state."
 	@echo "start           - Start development environment."
 	@echo "stop            - Stop development environment."
-	@echo "test            - Run all tests."
-	@echo "test-functional - Run functional tests."
-	@echo "test-kernel     - Run kernel tests."
-	@echo "test-unit       - Run unit tests."
+	@echo "test                       - Run all tests."
+	@echo "test-functional            - Run functional tests."
+	@echo "test-functional-javascript - Run FunctionalJavascript tests."
+	@echo "test-kernel                - Run kernel tests."
+	@echo "test-unit                  - Run unit tests."
+	@echo "selenium-start             - Start Selenium container."
+	@echo "selenium-stop              - Stop Selenium container."
 
 build: stop assemble start provision
 
@@ -84,6 +87,28 @@ test-functional:
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
+
+test-functional-javascript: selenium-start
+	pushd "build" >/dev/null || exit 1 && \
+	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	popd >/dev/null || exit 1
+
+selenium-start:
+	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
+		echo "Selenium container is already running."; \
+	else \
+		docker rm -f selenium 2>/dev/null || true; \
+		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
+		echo "Waiting for Selenium to be ready..."; \
+		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
+		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
+			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
+			exit 1; \
+		fi; \
+	fi
+
+selenium-stop:
+	docker rm -f selenium 2>/dev/null || true
 
 reset:
 	killall -9 php >/dev/null 2>&1 || true && \

--- a/README.dist.md
+++ b/README.dist.md
@@ -146,13 +146,27 @@ the tests.
 
 The `test` command is a wrapper for multiple test commands:
 ```bash
-make test-unit        # Run Unit tests
-make test-kernel      # Run Kernel tests
-make test-functional  # Run Functional tests
+make test-unit                    # Run Unit tests
+make test-kernel                  # Run Kernel tests
+make test-functional              # Run Functional tests
+make test-functional-javascript   # Run FunctionalJavascript tests
 
-ahoy test-unit        # Run Unit tests
-ahoy test-kernel      # Run Kernel tests
-ahoy test-functional  # Run Functional tests
+ahoy test-unit                    # Run Unit tests
+ahoy test-kernel                  # Run Kernel tests
+ahoy test-functional              # Run Functional tests
+ahoy test-functional-javascript   # Run FunctionalJavascript tests
+```
+
+### Running FunctionalJavascript tests
+
+FunctionalJavascript tests require a browser controlled via WebDriver.
+
+```bash
+ahoy selenium-start
+WEBSERVER_HOST=0.0.0.0 ahoy start
+ahoy provision
+ahoy test-functional-javascript
+ahoy selenium-stop
 ```
 
 ### Running specific tests

--- a/README.md
+++ b/README.md
@@ -268,13 +268,27 @@ the tests.
 
 The `test` command is a wrapper for multiple test commands:
 ```bash
-make test-unit        # Run Unit tests
-make test-kernel      # Run Kernel tests
-make test-functional  # Run Functional tests
+make test-unit                    # Run Unit tests
+make test-kernel                  # Run Kernel tests
+make test-functional              # Run Functional tests
+make test-functional-javascript   # Run FunctionalJavascript tests
 
-ahoy test-unit        # Run Unit tests
-ahoy test-kernel      # Run Kernel tests
-ahoy test-functional  # Run Functional tests
+ahoy test-unit                    # Run Unit tests
+ahoy test-kernel                  # Run Kernel tests
+ahoy test-functional              # Run Functional tests
+ahoy test-functional-javascript   # Run FunctionalJavascript tests
+```
+
+### Running FunctionalJavascript tests
+
+FunctionalJavascript tests require a browser controlled via WebDriver.
+
+```bash
+ahoy selenium-start
+WEBSERVER_HOST=0.0.0.0 ahoy start
+ahoy provision
+ahoy test-functional-javascript
+ahoy selenium-stop
 ```
 
 <details>

--- a/init.php
+++ b/init.php
@@ -289,6 +289,8 @@ function process_internal(string $extension_name, string $extension_machine_name
   @rename('tests/src/Unit/YourExtensionServiceUnitTest.php', 'tests/src/Unit/' . $extension_machine_name_class . 'ServiceUnitTest.php');
   @rename('tests/src/Kernel/YourExtensionServiceKernelTest.php', 'tests/src/Kernel/' . $extension_machine_name_class . 'ServiceKernelTest.php');
   @rename('tests/src/Functional/YourExtensionFunctionalTest.php', 'tests/src/Functional/' . $extension_machine_name_class . 'FunctionalTest.php');
+  @rename('tests/src/FunctionalJavascript/YourExtensionJsTestBase.php', 'tests/src/FunctionalJavascript/' . $extension_machine_name_class . 'JsTestBase.php');
+  @rename('tests/src/FunctionalJavascript/YourExtensionSmokeJsTest.php', 'tests/src/FunctionalJavascript/' . $extension_machine_name_class . 'SmokeJsTest.php');
 
   // Remove scaffold files.
   @unlink('LICENSE');

--- a/phpunit.d10.xml
+++ b/phpunit.d10.xml
@@ -64,7 +64,7 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=''/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
     </php>
     <testsuites>
         <testsuite name="unit">
@@ -80,13 +80,10 @@
             <directory>web/themes/custom/*/tests/src/Functional</directory>
         </testsuite>
 
-        <!-- Not implemented. -->
-        <!-- See https://github.com/drevops/scaffold/issues/820 -->
-        <!--
         <testsuite name="functional-javascript">
-          <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+            <directory>web/modules/custom/*/tests/src/FunctionalJavascript</directory>
+            <directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <logging>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -54,7 +54,7 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=""/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "goog:chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
     </php>
     <extensions>
         <!-- Functional tests HTML output logging. -->
@@ -90,13 +90,10 @@
             <directory>web/themes/custom/*/tests/src/Functional</directory>
         </testsuite>
 
-        <!-- Not implemented. -->
-        <!-- See https://github.com/drevops/vortex/issues/820 -->
-        <!--
         <testsuite name="functional-javascript">
-          <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+            <directory>web/modules/custom/*/tests/src/FunctionalJavascript</directory>
+            <directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <logging>

--- a/tests/src/FunctionalJavascript/YourExtensionJsTestBase.php
+++ b/tests/src/FunctionalJavascript/YourExtensionJsTestBase.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\your_extension\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Base class for YourExtension JavaScript functional tests.
+ *
+ * @group your_extension
+ */
+abstract class YourExtensionJsTestBase extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['your_extension'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // Override SIMPLETEST_BASE_URL so that Chrome inside the Selenium
+    // container can reach the PHP webserver on the host machine.
+    // In CircleCI, all containers share the network namespace, so
+    // 'localhost' works without override.
+    if (!getenv('CIRCLECI')) {
+      $port = getenv('WEBSERVER_PORT') ?: '8000';
+      $host = PHP_OS_FAMILY === 'Darwin' ? 'host.docker.internal' : '172.17.0.1';
+      putenv('SIMPLETEST_BASE_URL=http://' . $host . ':' . $port);
+    }
+    parent::setUp();
+  }
+
+  /**
+   * Create a screenshot with an auto-generated filename.
+   *
+   * Filename format: {ms_timestamp}-{Class}-{method}-L{line}.png.
+   *
+   * @param bool $set_background_color
+   *   (optional) Whether to set the background color. Defaults to TRUE.
+   */
+  protected function createAutoScreenshot(bool $set_background_color = TRUE): void {
+    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+    $line = $trace[0]['line'] ?? 0;
+    $class = str_replace('\\', '_', $trace[1]['class'] ?? 'Unknown');
+    $method = $trace[1]['function'];
+    $timestamp = (int) (microtime(TRUE) * 1000);
+
+    $filename = sprintf('%d-%s-%s-L%d.png', $timestamp, $class, $method, $line);
+    $path = \Drupal::root() . '/sites/simpletest/browser_output/' . $filename;
+
+    $this->createScreenshot($path, $set_background_color);
+    $this->assertFileExists($path);
+  }
+
+}

--- a/tests/src/FunctionalJavascript/YourExtensionSmokeJsTest.php
+++ b/tests/src/FunctionalJavascript/YourExtensionSmokeJsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\your_extension\FunctionalJavascript;
+
+/**
+ * Smoke test validating the WebDriver and screenshot pipeline.
+ *
+ * @group your_extension
+ */
+class YourExtensionSmokeJsTest extends YourExtensionJsTestBase {
+
+  /**
+   * Tests WebDriver connectivity and screenshot generation.
+   */
+  public function testSmokeWebDriver(): void {
+    // Verify unauthenticated page renders.
+    $this->drupalGet('/user/login');
+    $this->createAutoScreenshot();
+
+    // Create user and log in.
+    $account = $this->drupalCreateUser(['administer site configuration']);
+    $this->assertNotEmpty($account);
+    $this->drupalLogin($account);
+
+    // Verify authenticated page renders.
+    $this->drupalGet('<front>');
+    $this->createAutoScreenshot();
+
+    // Verify Drupal JavaScript API is available.
+    $this->assertJsCondition('typeof Drupal !== "undefined" && typeof Drupal.behaviors !== "undefined"');
+  }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Added support for functional JavaScript testing

## Overview
This pull request adds comprehensive support for functional JavaScript testing using Selenium WebDriver in the Drupal extension scaffold. It includes new test infrastructure, configuration updates, CI integration, test examples, and documentation for running browser-driven tests.

## Changes Made

### Infrastructure & Configuration
- .ahoy.yml: Added Ahoy commands
  - test-functional-javascript — runs functional JavaScript tests (invokes selenium-start)
  - selenium-start — starts a Selenium container (with readiness check, 30s timeout)
  - selenium-stop — stops/removes the Selenium container
- Makefile: new PHONY targets and help text for selenium-start, selenium-stop, and test-functional-javascript; selenium lifecycle and readiness logic added
- init.php: updated rename operations to template FunctionalJavascript test filenames

### CI/CD updates
- .circleci/config.yml: adds selenium/standalone-chromium:latest to container config (yaml anchor) and sets WEBSERVER_HOST for the PHP server
- .github/workflows/test.yml and scaffold GH workflows: add a chrome service using selenium/standalone-chromium:latest (exposes port 4444) and set WEBSERVER_HOST for the PHP server
- CircleCI configs in scaffold fixtures updated similarly

### PHPUnit / Test Framework
- phpunit.xml & phpunit.d10.xml: populate MINK_DRIVER_ARGS_WEBDRIVER with Chrome WebDriver options (w3c true, args --no-sandbox, --disable-gpu, --window-size=1280,1024) and enable the functional-javascript testsuite directories:
  - web/modules/custom/*/tests/src/FunctionalJavascript
  - web/themes/custom/*/tests/src/FunctionalJavascript

- New test base and example tests:
  - tests/src/FunctionalJavascript/YourExtensionJsTestBase.php — abstract base extending WebDriverTestBase; Docker/Selenium-aware SIMPLETEST_BASE_URL handling; createAutoScreenshot() helper with deterministic naming and file existence assertion
  - tests/src/FunctionalJavascript/YourExtensionSmokeJsTest.php — smoke test exercising unauthenticated/authenticated renders, screenshots, and asserting Drupal JS API presence

### Documentation & Templates
- README.md / README.dist.md: document test-functional-javascript and add a "Running FunctionalJavascript tests" section with a browser-driven run sequence (selenium-start → start server with WEBSERVER_HOST=0.0.0.0 → provision → run tests → selenium-stop)
- AGENTS.md: documents the new test and selenium Ahoy/Make targets
- Scaffold fixtures (.scaffold/...) updated to include the same changes for new project templates

## Key Features
- Containerized Selenium lifecycle with readiness validation and cleanup targets
- Docker-aware SIMPLETEST_BASE_URL configuration for WebDriver tests
- Automated, trace-informed screenshot capture for browser tests
- CI integration for CircleCI and GitHub Actions to provide a Selenium service in test runs
- Example base class and smoke test to bootstrap extension JavaScript testing

## Possibly related
I searched the repository for existing mentions of Selenium, WebDriver, functional-javascript, and related configuration. No open GitHub issue numbers or explicit repository issue references were found to link from this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->