### PR TITLE
Improved test performance.

### DIFF
--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -16,24 +16,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('p3')]
 final class AhoyTest extends DevtoolsTestCase {
 
-  public function testBuild(): void {
-    $this->processRun('ahoy', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
-  }
-
-  public function testAssemble(): void {
-    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
-    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
-    $this->assertDirectoryExists(self::$sut . '/build/vendor');
-    $this->assertFileExists(self::$sut . '/build/composer.json');
-    $this->assertFileExists(self::$sut . '/build/composer.lock');
-    $this->assertDirectoryExists(self::$sut . '/build/node_modules');
-    $this->assertProcessAnyOutputContains('Would run build');
-  }
-
   public function testAssembleSkipNpmBuild(): void {
     touch(self::$sut . '/.skip_npm_build');
 
@@ -48,38 +30,33 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessAnyOutputNotContains('Would run build');
   }
 
-  public function testStart(): void {
+  public function testWorkflow(): void {
+    // Start without build fails.
     $this->processRun('ahoy', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
     $this->assertProcessAnyOutputNotContains('ENVIRONMENT READY');
 
+    // Stop without build succeeds.
+    $this->processRun('ahoy', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
+
     $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+    $this->assertDirectoryExists(self::$sut . '/build/vendor');
+    $this->assertFileExists(self::$sut . '/build/composer.json');
+    $this->assertFileExists(self::$sut . '/build/composer.lock');
+    $this->assertDirectoryExists(self::$sut . '/build/node_modules');
+    $this->assertProcessAnyOutputContains('Would run build');
 
     $this->processRun('ahoy', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT READY');
-  }
-
-  public function testStop(): void {
-    $this->processRun('ahoy', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
-
-    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
-    $this->processRun('ahoy', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
 
     $this->processRun('ahoy', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
-  }
-
-  public function testProvision(): void {
-    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
 
     $this->processRun('ahoy', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
@@ -89,16 +66,11 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
 
+    // Provision is idempotent.
     $this->processRun('ahoy', ['provision'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
-  }
-
-  public function testBuildBasicWorkflow(): void {
-    $this->processRun('ahoy', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
 
     $this->processRun('ahoy', ['drush', 'status'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
@@ -109,18 +81,24 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('user/reset/1/');
 
-    $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
+    $this->runLint();
 
     $this->processRun('ahoy', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
+
+    $this->runJsTests();
+
+    $this->runUnitTests();
+
+    $this->runKernelTests();
+
+    $this->runFunctionalTests();
+
+    $this->runFunctionalJavascriptTests();
   }
 
-  public function testLintAndLintFix(): void {
-    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
+  protected function runLint(): void {
     $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
@@ -158,10 +136,7 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessSuccessful();
   }
 
-  public function testJsTestFailure(): void {
-    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
+  protected function runJsTests(): void {
     $this->processRun('ahoy', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
@@ -171,10 +146,7 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessFailed();
   }
 
-  public function testUnitTestFailure(): void {
-    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
+  protected function runUnitTests(): void {
     $this->processRun('ahoy', ['test-unit'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
@@ -186,10 +158,17 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessFailed();
   }
 
-  public function testFunctionalTestFailure(): void {
-    $this->processRun('ahoy', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+  protected function runKernelTests(): void {
+    $this->processRun('ahoy', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
+    File::replaceContentInFile(self::$sut . '/tests/src/Kernel/YourExtensionServiceKernelTest.php', 'assertEquals', 'assertNotEquals');
+
+    $this->processRun('ahoy', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessFailed();
+  }
+
+  protected function runFunctionalTests(): void {
     $this->processRun('ahoy', ['test-functional'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
@@ -200,16 +179,13 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessFailed();
   }
 
-  public function testKernelTestFailure(): void {
-    $this->processRun('ahoy', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+  protected function runFunctionalJavascriptTests(): void {
+    $this->processRun('ahoy', ['test-functional-javascript'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
-    $this->processRun('ahoy', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
+    File::replaceContentInFile(self::$sut . '/tests/src/FunctionalJavascript/YourExtensionSmokeJsTest.php', 'assertNotEmpty', 'assertEmpty');
 
-    File::replaceContentInFile(self::$sut . '/tests/src/Kernel/YourExtensionServiceKernelTest.php', 'assertEquals', 'assertNotEquals');
-
-    $this->processRun('ahoy', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->processRun('ahoy', ['test-functional-javascript'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
   }
 

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -16,30 +16,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('p4')]
 final class MakeTest extends DevtoolsTestCase {
 
-  public function testDefault(): void {
-    $this->processRun('make', [], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
-    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
-    $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
-
-    $this->assertDirectoryExists(self::$sut . '/build/vendor');
-    $this->assertFileExists(self::$sut . '/build/composer.json');
-    $this->assertFileExists(self::$sut . '/build/composer.lock');
-  }
-
-  public function testAssemble(): void {
-    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
-    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
-    $this->assertDirectoryExists(self::$sut . '/build/vendor');
-    $this->assertFileExists(self::$sut . '/build/composer.json');
-    $this->assertFileExists(self::$sut . '/build/composer.lock');
-    $this->assertDirectoryExists(self::$sut . '/build/node_modules');
-    $this->assertProcessAnyOutputContains('Would run build');
-  }
-
   public function testAssembleSkipNpmBuild(): void {
     touch(self::$sut . '/.skip_npm_build');
 
@@ -54,39 +30,32 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessAnyOutputNotContains('Would run build');
   }
 
-  public function testStart(): void {
+  public function testWorkflow(): void {
+    // Start without build fails.
     $this->processRun('make', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
 
+    // Stop without build succeeds.
+    $this->processRun('make', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
+
     $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+    $this->assertDirectoryExists(self::$sut . '/build/vendor');
+    $this->assertFileExists(self::$sut . '/build/composer.json');
+    $this->assertFileExists(self::$sut . '/build/composer.lock');
+    $this->assertDirectoryExists(self::$sut . '/build/node_modules');
+    $this->assertProcessAnyOutputContains('Would run build');
 
     $this->processRun('make', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT READY');
-  }
-
-  public function testStop(): void {
-    $this->processRun('make', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
-
-    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
-    $this->processRun('make', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
 
     $this->processRun('make', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
-  }
-
-  public function testProvision(): void {
-    $this->processRun('make', ['stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-
-    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
 
     $this->processRun('make', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
@@ -96,16 +65,11 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
 
+    // Provision is idempotent.
     $this->processRun('make', ['provision'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
-  }
-
-  public function testBuildBasicWorkflow(): void {
-    $this->processRun('make', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
 
     $this->processRun('make', ['drush', 'status'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
@@ -116,18 +80,24 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('user/reset/1/');
 
-    $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
+    $this->runLint();
 
     $this->processRun('make', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
+
+    $this->runJsTests();
+
+    $this->runUnitTests();
+
+    $this->runKernelTests();
+
+    $this->runFunctionalTests();
+
+    $this->runFunctionalJavascriptTests();
   }
 
-  public function testLintAndLintFix(): void {
-    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
+  protected function runLint(): void {
     $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
@@ -165,10 +135,7 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessSuccessful();
   }
 
-  public function testJsTestFailure(): void {
-    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
+  protected function runJsTests(): void {
     $this->processRun('make', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
@@ -178,10 +145,7 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessFailed();
   }
 
-  public function testUnitTestFailure(): void {
-    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-
+  protected function runUnitTests(): void {
     $this->processRun('make', ['test-unit'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
@@ -193,10 +157,17 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessFailed();
   }
 
-  public function testFunctionalTestFailure(): void {
-    $this->processRun('make', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+  protected function runKernelTests(): void {
+    $this->processRun('make', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
+    File::replaceContentInFile(self::$sut . '/tests/src/Kernel/YourExtensionServiceKernelTest.php', 'assertEquals', 'assertNotEquals');
+
+    $this->processRun('make', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessFailed();
+  }
+
+  protected function runFunctionalTests(): void {
     $this->processRun('make', ['test-functional'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
@@ -207,16 +178,13 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessFailed();
   }
 
-  public function testKernelTestFailure(): void {
-    $this->processRun('make', ['build'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+  protected function runFunctionalJavascriptTests(): void {
+    $this->processRun('make', ['test-functional-javascript'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
-    $this->processRun('make', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
+    File::replaceContentInFile(self::$sut . '/tests/src/FunctionalJavascript/YourExtensionSmokeJsTest.php', 'assertNotEmpty', 'assertEmpty');
 
-    File::replaceContentInFile(self::$sut . '/tests/src/Kernel/YourExtensionServiceKernelTest.php', 'assertEquals', 'assertNotEquals');
-
-    $this->processRun('make', ['test-kernel'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->processRun('make', ['test-functional-javascript'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Consolidated Functional Test Suite for Improved Performance

This PR refactors the functional test suites for both Ahoy and Make workflows by consolidating many standalone tests into unified workflow tests with reusable helper methods to improve performance and reduce duplication.

### Key Changes
- Consolidated multiple public tests into a single workflow-based test in both AhoyTest and MakeTest:
  - Removed many standalone tests (build/assemble/stop/provision, individual failure tests, and several legacy tests).
  - Renamed testStart() → testWorkflow() in both classes.
  - Replaced discrete tests with a workflow that exercises assemble/start/provision (with idempotence), then runs all test suites in sequence.
- Added protected helper methods to encapsulate test groups and reduce duplication:
  - runLint(), runJsTests(), runUnitTests(), runKernelTests(), runFunctionalTests(), runFunctionalJavascriptTests().
- Adjusted assertions and test flows to validate progressive workflow states and outputs instead of multiple independent end-state assertions.
- Goal: reduce redundant environment setup/teardown and improve overall test performance while preserving coverage.

### Files Modified
- .scaffold/tests/src/Functional/AhoyTest.php (+38/−62)
- .scaffold/tests/src/Functional/MakeTest.php (+38/−70)

### Possibly related
I did not find any explicit issue references in the repository for this change. Possibly related to issues about test performance, test-suite consolidation, or workflow-driven testing (please link any tracking issue, e.g. #123, if this PR addresses one).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->