### PR TITLE
Simplified PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,1 @@
 Closes #
-
-## Checklist before requesting a review
-
-- [ ] Subject includes Drupal issue number and author as `#123456 by JohnDoe: Verb in past tense.`
-- [ ] Added context in `Changed` section
-- [ ] Self-reviewed code and commented in complex areas.
-- [ ] Added tests for a fix/feature.
-- [ ] Relevant tests passed locally.
-
-## Changed
-
-1.

--- a/.scaffold/tests/fixtures/init/_baseline/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,1 @@
 Closes #
-
-## Checklist before requesting a review
-
-- [ ] Subject includes Drupal issue number and author as `#123456 by JohnDoe: Verb in past tense.`
-- [ ] Added context in `Changed` section
-- [ ] Self-reviewed code and commented in complex areas.
-- [ ] Added tests for a fix/feature.
-- [ ] Relevant tests passed locally.
-
-## Changed
-
-1.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Simplifies the pull request template by removing unnecessary sections and guidance items.

## Changes

- **PR Template Simplification**: Removed the "Checklist before requesting a review" section and the "Changed" section from the PR template
- **Baseline Fixture Update**: Applied the same template simplification to the scaffold test baseline fixture at `.scaffold/tests/fixtures/init/_baseline/.github/PULL_REQUEST_TEMPLATE.md`

## Impact

- Reduces initial reviewer guidance from the template
- Streamlines the PR creation process by eliminating required checklist steps
- No impact on runtime logic or code functionality; this is a textual/template adjustment only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->