### PR TITLE
[#242] Split lint and test jobs for GHA.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,56 @@ on:
       - 1.x
 
 jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        with:
+          php-version: 8.4
+          extensions: gd, sqlite, pdo_sqlite
+
+      - name: Assemble the codebase
+        run: .devtools/assemble
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint code with PHPCS
+        working-directory: build
+        run: vendor/bin/phpcs
+        continue-on-error: ${{ vars.CI_PHPCS_IGNORE_FAILURE == '1' }}
+
+      - name: Lint code with PHPStan
+        working-directory: build
+        run: vendor/bin/phpstan
+        continue-on-error: ${{ vars.CI_PHPSTAN_IGNORE_FAILURE == '1' }}
+
+      - name: Lint code with Rector
+        working-directory: build
+        run: vendor/bin/rector --clear-cache --dry-run
+        continue-on-error: ${{ vars.CI_RECTOR_IGNORE_FAILURE == '1' }}
+
+      - name: Lint code with Twig CS Fixer
+        working-directory: build
+        run: vendor/bin/twig-cs-fixer
+        continue-on-error: ${{ vars.CI_TWIGCSFIXER_IGNORE_FAILURE == '1' }}
+
+      - name: Lint module code with NodeJS linters
+        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
+        working-directory: build
+        run: npm run lint
+        continue-on-error: ${{ vars.CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
+
   test:
     runs-on: ubuntu-24.04
 
@@ -139,32 +189,6 @@ jobs:
 
       - name: Provision site
         run: .devtools/provision
-
-      - name: Lint code with PHPCS
-        working-directory: build
-        run: vendor/bin/phpcs
-        continue-on-error: ${{ vars.CI_PHPCS_IGNORE_FAILURE == '1' }}
-
-      - name: Lint code with PHPStan
-        working-directory: build
-        run: vendor/bin/phpstan
-        continue-on-error: ${{ vars.CI_PHPSTAN_IGNORE_FAILURE == '1' || endsWith(matrix.name, 'canary') }}
-
-      - name: Lint code with Rector
-        working-directory: build
-        run: vendor/bin/rector --clear-cache --dry-run
-        continue-on-error: ${{ vars.CI_RECTOR_IGNORE_FAILURE == '1' }}
-
-      - name: Lint code with Twig CS Fixer
-        working-directory: build
-        run: vendor/bin/twig-cs-fixer
-        continue-on-error: ${{ vars.CI_TWIGCSFIXER_IGNORE_FAILURE == '1' }}
-
-      - name: Lint module code with NodeJS linters
-        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
-        working-directory: build
-        run: npm run lint
-        continue-on-error: ${{ vars.CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 
       - name: Run JS tests
         if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -11,6 +11,56 @@ on:
       - 1.x
 
 jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@__HASH__ # __VERSION__
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@__HASH__ # __VERSION__
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@__HASH__ # __VERSION__
+        with:
+          php-version: 8.4
+          extensions: gd, sqlite, pdo_sqlite
+
+      - name: Assemble the codebase
+        run: .devtools/assemble
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint code with PHPCS
+        working-directory: build
+        run: vendor/bin/phpcs
+        continue-on-error: ${{ vars.CI_PHPCS_IGNORE_FAILURE == '1' }}
+
+      - name: Lint code with PHPStan
+        working-directory: build
+        run: vendor/bin/phpstan
+        continue-on-error: ${{ vars.CI_PHPSTAN_IGNORE_FAILURE == '1' }}
+
+      - name: Lint code with Rector
+        working-directory: build
+        run: vendor/bin/rector --clear-cache --dry-run
+        continue-on-error: ${{ vars.CI_RECTOR_IGNORE_FAILURE == '1' }}
+
+      - name: Lint code with Twig CS Fixer
+        working-directory: build
+        run: vendor/bin/twig-cs-fixer
+        continue-on-error: ${{ vars.CI_TWIGCSFIXER_IGNORE_FAILURE == '1' }}
+
+      - name: Lint module code with NodeJS linters
+        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
+        working-directory: build
+        run: npm run lint
+        continue-on-error: ${{ vars.CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
+
   test:
     runs-on: ubuntu-24.04
 
@@ -139,32 +189,6 @@ jobs:
 
       - name: Provision site
         run: .devtools/provision
-
-      - name: Lint code with PHPCS
-        working-directory: build
-        run: vendor/bin/phpcs
-        continue-on-error: ${{ vars.CI_PHPCS_IGNORE_FAILURE == '1' }}
-
-      - name: Lint code with PHPStan
-        working-directory: build
-        run: vendor/bin/phpstan
-        continue-on-error: ${{ vars.CI_PHPSTAN_IGNORE_FAILURE == '1' || endsWith(matrix.name, 'canary') }}
-
-      - name: Lint code with Rector
-        working-directory: build
-        run: vendor/bin/rector --clear-cache --dry-run
-        continue-on-error: ${{ vars.CI_RECTOR_IGNORE_FAILURE == '1' }}
-
-      - name: Lint code with Twig CS Fixer
-        working-directory: build
-        run: vendor/bin/twig-cs-fixer
-        continue-on-error: ${{ vars.CI_TWIGCSFIXER_IGNORE_FAILURE == '1' }}
-
-      - name: Lint module code with NodeJS linters
-        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
-        working-directory: build
-        run: npm run lint
-        continue-on-error: ${{ vars.CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 
       - name: Run JS tests
         if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}


### PR DESCRIPTION
Closes #242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR splits the GitHub Actions CI workflow into separate `lint` and `test` jobs, addressing issue #242. This change allows linting and testing to run independently in parallel, improving CI organization and performance.

## Changes

### Workflow Reorganization
- **New `lint` job**: Created a dedicated job that runs on Ubuntu 24.04 with the following steps:
  - Code checkout and Composer dependency caching
  - PHP 8.4 setup with required extensions (gd, sqlite, pdo_sqlite)
  - Codebase assembly
  - Multiple linting tools: PHPCS, PHPStan, Rector, Twig CS Fixer, and NodeJS linters (conditional)
  - Each linting step respects per-tool CI environment variables for failure handling

- **Refactored `test` job**: Removed all linting steps, now focuses solely on testing workflow:
  - Eliminated PHPCS, PHPStan, Rector, Twig CS Fixer, and NodeJS lint steps
  - Retains all test execution, web server provisioning, and artifact upload functionality

### Files Modified
- `.github/workflows/test.yml` (+50/-26 lines)
- `.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml` (+50/-26 lines)

## Benefits
- Parallel execution: Lint and test jobs can run concurrently
- Clearer responsibility separation between linting and testing
- Simpler test job workflow focused on testing concerns
- Maintains conditional NodeJS linting based on lock file presence
- Per-tool failure handling preserved through environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->