### PR TITLE
Increased coverage for helpers.php.

### DIFF
--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -214,7 +214,9 @@ function extension_info(): array {
   if ($info_files === FALSE || $info_files === []) {
     FAIL('No .info.yml file found.');
 
+    // @codeCoverageIgnoreStart
     return ['name' => '', 'type' => ''];
+    // @codeCoverageIgnoreEnd
   }
   $name = basename($info_files[0], '.info.yml');
   $type = str_contains((string) file_get_contents($info_files[0]), 'type: theme') ? 'theme' : 'module';
@@ -240,14 +242,18 @@ function replace_in_file(string $file, string $pattern, string $replacement): st
   if ($content === FALSE) {
     FAIL('Unable to read file %s.', $file);
 
+    // @codeCoverageIgnoreStart
     return '';
+    // @codeCoverageIgnoreEnd
   }
 
   $replaced = preg_replace($pattern, $replacement, $content);
   if ($replaced === NULL) {
     FAIL('Regex replacement failed in file %s with pattern %s.', $file, $pattern);
 
+    // @codeCoverageIgnoreStart
     return $content;
+    // @codeCoverageIgnoreEnd
   }
 
   file_put_contents($file, $replaced);

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -214,7 +214,9 @@ function extension_info(): array {
   if ($info_files === FALSE || $info_files === []) {
     FAIL('No .info.yml file found.');
 
+    // @codeCoverageIgnoreStart
     return ['name' => '', 'type' => ''];
+    // @codeCoverageIgnoreEnd
   }
   $name = basename($info_files[0], '.info.yml');
   $type = str_contains((string) file_get_contents($info_files[0]), 'type: theme') ? 'theme' : 'module';
@@ -240,14 +242,18 @@ function replace_in_file(string $file, string $pattern, string $replacement): st
   if ($content === FALSE) {
     FAIL('Unable to read file %s.', $file);
 
+    // @codeCoverageIgnoreStart
     return '';
+    // @codeCoverageIgnoreEnd
   }
 
   $replaced = preg_replace($pattern, $replacement, $content);
   if ($replaced === NULL) {
     FAIL('Regex replacement failed in file %s with pattern %s.', $file, $pattern);
 
+    // @codeCoverageIgnoreStart
     return $content;
+    // @codeCoverageIgnoreEnd
   }
 
   file_put_contents($file, $replaced);

--- a/.scaffold/tests/src/Unit/HelpersDrushTest.php
+++ b/.scaffold/tests/src/Unit/HelpersDrushTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\drush;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\drush')]
+#[Group('p0')]
+final class HelpersDrushTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderDrush')]
+  public function testDrush(string $command, string|array|null $args, string $expected_cmd_suffix, string $mock_output, string $expected_output): void {
+    $cwd = getcwd();
+    $expected_cmd = 'build/vendor/bin/drush -r ' . escapeshellarg($cwd . '/build/web') . ' -y ' . $expected_cmd_suffix;
+    $this->mockPassthru(['cmd' => $expected_cmd, 'output' => $mock_output, 'result_code' => 0]);
+    $exit_code = 0;
+    $result = drush($command, $args, $exit_code);
+    $this->assertSame($expected_output, $result);
+    $this->assertSame(0, $exit_code);
+  }
+
+  public static function dataProviderDrush(): \Iterator {
+    yield 'no args' => [
+      'command' => 'status',
+      'args' => NULL,
+      'expected_cmd_suffix' => 'status',
+      'mock_output' => 'Drupal version : 10',
+      'expected_output' => 'Drupal version : 10',
+    ];
+    yield 'string args' => [
+      'command' => 'pm:enable %s',
+      'args' => 'my_module',
+      'expected_cmd_suffix' => 'pm:enable ' . escapeshellarg('my_module'),
+      'mock_output' => '',
+      'expected_output' => '',
+    ];
+    yield 'array args' => [
+      'command' => 'config:set %s %s',
+      'args' => ['system.site', 'name'],
+      'expected_cmd_suffix' => 'config:set ' . escapeshellarg('system.site') . ' ' . escapeshellarg('name'),
+      'mock_output' => 'Set',
+      'expected_output' => 'Set',
+    ];
+    yield 'empty array args' => [
+      'command' => 'status',
+      'args' => [],
+      'expected_cmd_suffix' => 'status',
+      'mock_output' => 'OK',
+      'expected_output' => 'OK',
+    ];
+  }
+
+  public function testDrushFailsWithoutExitCodeRef(): void {
+    $cwd = getcwd();
+    $expected_cmd = 'build/vendor/bin/drush -r ' . escapeshellarg($cwd . '/build/web') . ' -y bad-command';
+    $this->mockPassthru(['cmd' => $expected_cmd, 'output' => '', 'result_code' => 1]);
+    $this->mockQuit(1);
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      drush('bad-command');
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Drush command failed', $output);
+    }
+  }
+
+  public function testDrushFailsWithExitCodeRefDoesNotExit(): void {
+    $cwd = getcwd();
+    $expected_cmd = 'build/vendor/bin/drush -r ' . escapeshellarg($cwd . '/build/web') . ' -y bad-command';
+    $this->mockPassthru(['cmd' => $expected_cmd, 'output' => '', 'result_code' => 2]);
+    $exit_code = 0;
+    $result = drush('bad-command', NULL, $exit_code);
+    $this->assertSame('', $result);
+    $this->assertSame(2, $exit_code);
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersExtensionInfoTest.php
+++ b/.scaffold/tests/src/Unit/HelpersExtensionInfoTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\extension_info;
+use function DrupalExtensionScaffold\DevTools\is_debug;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\extension_info')]
+#[CoversFunction('DrupalExtensionScaffold\DevTools\is_debug')]
+#[Group('p0')]
+final class HelpersExtensionInfoTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderExtensionInfo')]
+  public function testExtensionInfo(string $filename, string $content, string $expected_name, string $expected_type): void {
+    $dir = self::$tmp . '/ext_' . uniqid();
+    mkdir($dir, 0755, TRUE);
+    file_put_contents($dir . '/' . $filename, $content);
+    $original = (string) getcwd();
+    chdir($dir);
+    try {
+      $result = extension_info();
+      $this->assertSame(['name' => $expected_name, 'type' => $expected_type], $result);
+    }
+    finally {
+      chdir($original);
+    }
+  }
+
+  public static function dataProviderExtensionInfo(): \Iterator {
+    yield 'module' => [
+      'filename' => 'my_module.info.yml',
+      'content' => "name: My Module\ntype: module\ncore_version_requirement: ^10\n",
+      'expected_name' => 'my_module',
+      'expected_type' => 'module',
+    ];
+    yield 'theme' => [
+      'filename' => 'my_theme.info.yml',
+      'content' => "name: My Theme\ntype: theme\ncore_version_requirement: ^10\n",
+      'expected_name' => 'my_theme',
+      'expected_type' => 'theme',
+    ];
+  }
+
+  public function testExtensionInfoNoFile(): void {
+    $dir = self::$tmp . '/ext_empty_' . uniqid();
+    mkdir($dir, 0755, TRUE);
+    $original = (string) getcwd();
+    chdir($dir);
+    $this->mockQuit(1);
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      extension_info();
+    }
+    finally {
+      chdir($original);
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('No .info.yml file found', $output);
+    }
+  }
+
+  #[DataProvider('dataProviderIsDebug')]
+  public function testIsDebug(string|false $env_value, bool $expected): void {
+    if ($env_value === FALSE) {
+      $this->envUnset('DEBUG');
+    }
+    else {
+      $this->envSet('DEBUG', $env_value);
+    }
+    $this->assertSame($expected, is_debug());
+  }
+
+  public static function dataProviderIsDebug(): \Iterator {
+    yield 'debug enabled' => ['env_value' => '1', 'expected' => TRUE];
+    yield 'debug disabled' => ['env_value' => '0', 'expected' => FALSE];
+    yield 'debug not set' => ['env_value' => FALSE, 'expected' => FALSE];
+    yield 'debug empty string' => ['env_value' => '', 'expected' => FALSE];
+    yield 'debug other value' => ['env_value' => 'true', 'expected' => FALSE];
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersFilesystemTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFilesystemTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\chmod_recursive;
+use function DrupalExtensionScaffold\DevTools\remove_dir;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\remove_dir')]
+#[CoversFunction('DrupalExtensionScaffold\DevTools\chmod_recursive')]
+#[Group('p0')]
+final class HelpersFilesystemTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testRemoveDirNonExistent(): void {
+    remove_dir(self::$tmp . '/nonexistent_' . uniqid());
+    $this->expectNotToPerformAssertions();
+  }
+
+  #[DataProvider('dataProviderRemoveDir')]
+  public function testRemoveDir(array $structure, bool $has_symlink): void {
+    $dir = self::$tmp . '/remove_' . uniqid();
+    $this->createStructure($dir, $structure);
+    if ($has_symlink) {
+      file_put_contents($dir . '/target.txt', 'target content');
+      symlink($dir . '/target.txt', $dir . '/subdir/link.txt');
+    }
+    $this->assertDirectoryExists($dir);
+    remove_dir($dir);
+    $this->assertDirectoryDoesNotExist($dir);
+  }
+
+  public static function dataProviderRemoveDir(): \Iterator {
+    yield 'empty directory' => [
+      'structure' => [],
+      'has_symlink' => FALSE,
+    ];
+    yield 'with files and nested dirs' => [
+      'structure' => [
+        'file1.txt' => 'content1',
+        'subdir' => [
+          'file2.txt' => 'content2',
+          'nested' => [
+            'file3.txt' => 'content3',
+          ],
+        ],
+      ],
+      'has_symlink' => FALSE,
+    ];
+    yield 'with symlinks' => [
+      'structure' => [
+        'subdir' => [],
+      ],
+      'has_symlink' => TRUE,
+    ];
+  }
+
+  public function testChmodRecursiveNonExistent(): void {
+    chmod_recursive(self::$tmp . '/nonexistent_' . uniqid(), 0755);
+    $this->expectNotToPerformAssertions();
+  }
+
+  #[DataProvider('dataProviderChmodRecursive')]
+  public function testChmodRecursive(array $structure, int $mode, array $expected_perms): void {
+    $dir = self::$tmp . '/chmod_' . uniqid();
+    $this->createStructure($dir, $structure);
+    chmod_recursive($dir, $mode);
+    foreach ($expected_perms as $relative_path => $expected_mode) {
+      $path = $relative_path === '.' ? $dir : $dir . '/' . $relative_path;
+      $this->assertSame($expected_mode, fileperms($path) & 0777, sprintf('Permissions mismatch for %s', $relative_path));
+    }
+  }
+
+  public static function dataProviderChmodRecursive(): \Iterator {
+    yield 'flat files' => [
+      'structure' => [
+        'file1.txt' => 'content1',
+        'file2.txt' => 'content2',
+      ],
+      'mode' => 0755,
+      'expected_perms' => [
+        '.' => 0755,
+        'file1.txt' => 0755,
+        'file2.txt' => 0755,
+      ],
+    ];
+    yield 'nested directories' => [
+      'structure' => [
+        'subdir' => [
+          'file.txt' => 'content',
+        ],
+      ],
+      'mode' => 0700,
+      'expected_perms' => [
+        '.' => 0700,
+        'subdir' => 0700,
+        'subdir/file.txt' => 0700,
+      ],
+    ];
+  }
+
+  public function testChmodRecursiveSkipsSymlinks(): void {
+    $dir = self::$tmp . '/chmod_symlink_' . uniqid();
+    $target_dir = self::$tmp . '/chmod_target_' . uniqid();
+    mkdir($dir, 0755, TRUE);
+    mkdir($target_dir, 0755, TRUE);
+    file_put_contents($target_dir . '/target.txt', 'content');
+    chmod($target_dir . '/target.txt', 0644);
+    symlink($target_dir . '/target.txt', $dir . '/link.txt');
+    chmod_recursive($dir, 0755);
+    $this->assertTrue(is_link($dir . '/link.txt'));
+    $this->assertSame(0644, fileperms($target_dir . '/target.txt') & 0777);
+  }
+
+  protected function createStructure(string $base_path, array $structure): void {
+    if (!is_dir($base_path)) {
+      mkdir($base_path, 0755, TRUE);
+    }
+    foreach ($structure as $name => $content) {
+      $path = $base_path . '/' . $name;
+      if (is_array($content)) {
+        mkdir($path, 0755, TRUE);
+        $this->createStructure($path, $content);
+      }
+      else {
+        file_put_contents($path, $content);
+      }
+    }
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersReplaceInFileTest.php
+++ b/.scaffold/tests/src/Unit/HelpersReplaceInFileTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\replace_in_file;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\replace_in_file')]
+#[Group('p0')]
+final class HelpersReplaceInFileTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderReplaceInFile')]
+  public function testReplaceInFile(string $initial_content, string $pattern, string $replacement, string $expected_content): void {
+    $file = self::$tmp . '/replace_' . uniqid() . '.txt';
+    file_put_contents($file, $initial_content);
+    $result = replace_in_file($file, $pattern, $replacement);
+    $this->assertSame($expected_content, $result);
+    $this->assertSame($expected_content, file_get_contents($file));
+  }
+
+  public static function dataProviderReplaceInFile(): \Iterator {
+    yield 'simple replacement' => [
+      'initial_content' => 'Hello World',
+      'pattern' => '/World/',
+      'replacement' => 'PHP',
+      'expected_content' => 'Hello PHP',
+    ];
+    yield 'regex replacement' => [
+      'initial_content' => 'version: 1.0.0',
+      'pattern' => '/version: \d+\.\d+\.\d+/',
+      'replacement' => 'version: 2.0.0',
+      'expected_content' => 'version: 2.0.0',
+    ];
+    yield 'no match leaves content unchanged' => [
+      'initial_content' => 'Hello World',
+      'pattern' => '/Goodbye/',
+      'replacement' => 'Hi',
+      'expected_content' => 'Hello World',
+    ];
+    yield 'multiple matches' => [
+      'initial_content' => 'foo bar foo baz foo',
+      'pattern' => '/foo/',
+      'replacement' => 'qux',
+      'expected_content' => 'qux bar qux baz qux',
+    ];
+  }
+
+  public function testReplaceInFileNonExistentFile(): void {
+    $file = self::$tmp . '/nonexistent_' . uniqid() . '.txt';
+    $this->mockQuit(1);
+    $this->expectException(QuitErrorException::class);
+    set_error_handler(static fn(): bool => TRUE);
+    ob_start();
+    try {
+      replace_in_file($file, '/foo/', 'bar');
+    }
+    finally {
+      restore_error_handler();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Unable to read file', $output);
+    }
+  }
+
+  public function testReplaceInFileInvalidRegex(): void {
+    $file = self::$tmp . '/invalid_regex_' . uniqid() . '.txt';
+    file_put_contents($file, 'test content');
+    $this->mockQuit(1);
+    $this->expectException(QuitErrorException::class);
+    set_error_handler(static fn(): bool => TRUE);
+    ob_start();
+    try {
+      replace_in_file($file, '/(?invalid/', 'bar');
+    }
+    finally {
+      restore_error_handler();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Regex replacement failed', $output);
+    }
+  }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Increases code coverage for helper functions in `.devtools/helpers.php` by adding code coverage ignore markers and introducing comprehensive unit tests.

## Changes

### `.devtools/helpers.php`
- Added `@codeCoverageIgnore` markers around early return paths and error handling code that is difficult to test in normal operation:
  - Early return in `extension_info()` when no .info.yml file is found
  - Error handling returns in `replace_in_file()` for file read failures and regex replacement failures

### New Unit Tests
Introduced four new unit test files under `.scaffold/tests/src/Unit/`:

- HelpersDrushTest.php
  - Data-driven tests for the `drush()` helper covering various argument formats (no args, string args, array args) and failure scenarios including non-zero exit codes with and without exit code reference parameters. Validates constructed command, mocked output, and returned results.

- HelpersExtensionInfoTest.php
  - Tests for `extension_info()` covering module and theme .info.yml files and handling of missing .info.yml files (error output and QuitErrorException). Also tests `is_debug()` across multiple environment variable scenarios.

- HelpersFilesystemTest.php
  - Tests for `remove_dir()` (including nested structures and symlink handling) and `chmod_recursive()` (flat and nested structures, preserving symlink targets). Includes helper to build test directory structures.

- HelpersReplaceInFileTest.php
  - Tests for `replace_in_file()` covering literal and regex patterns, multiple matches, no-match scenarios, and version-extraction replacements. Error handling tests for non-existent files and invalid regex patterns (expecting QuitErrorException and specific error messages).

## Public API / Declarations

- No changes to exported/public function signatures in production code.
- New PHPUnit test classes and methods added under the test namespace; no production API surface changes.

## Review Effort

Medium — Adds focused coverage markers and substantial unit tests that exercise normal and error flows across helper utilities.

Possibly related to:
- Repository issue tracker: https://github.com/AlexSkrypnyk/drupal_extension_scaffold/issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->