### PR TITLE
Fixed Renovate updating PHP library constraints.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/renovate.json
+++ b/.scaffold/tests/fixtures/init/_baseline/renovate.json
@@ -4,29 +4,17 @@
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
-    "major": {
-        "enabled": false
-    },
-    "groupName": "all dependencies",
-    "groupSlug": "all",
     "branchPrefix": "deps/",
-    "composer": {
-        "managerFilePatterns": ["/composer\\.dev\\.json$/"]
-    },
+    "enabledManagers": ["github-actions", "npm"],
     "packageRules": [
-        {
-            "matchDepNames": ["php"],
-            "matchManagers": ["composer"],
-            "enabled": false
-        },
         {
             "matchDepNames": ["node", "yarn"],
             "matchManagers": ["npm"],
             "enabled": false
         },
         {
-            "matchManagers": ["composer"],
-            "matchFileNames": ["composer.json"],
+            "matchManagers": ["npm"],
+            "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {

--- a/renovate.json
+++ b/renovate.json
@@ -4,29 +4,17 @@
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
-    "major": {
-        "enabled": false
-    },
-    "groupName": "all dependencies",
-    "groupSlug": "all",
     "branchPrefix": "deps/",
-    "composer": {
-        "managerFilePatterns": ["/composer\\.dev\\.json$/"]
-    },
+    "enabledManagers": ["github-actions", "npm"],
     "packageRules": [
-        {
-            "matchDepNames": ["php"],
-            "matchManagers": ["composer"],
-            "enabled": false
-        },
         {
             "matchDepNames": ["node", "yarn"],
             "matchManagers": ["npm"],
             "enabled": false
         },
         {
-            "matchManagers": ["composer"],
-            "matchFileNames": ["composer.json"],
+            "matchManagers": ["npm"],
+            "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {


### PR DESCRIPTION
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes Renovate configuration to prevent it from updating PHP library constraints. The changes simplify the Renovate setup by removing PHP/Composer-specific rules and focusing on npm and GitHub Actions management.

## Changes

- **renovate.json** and **.scaffold/tests/fixtures/init/_baseline/renovate.json**: 
  - Replaced composer-based configuration rules with a simplified `enabledManagers` list containing `github-actions` and `npm`
  - Removed global `groupName`/`groupSlug` settings and the PHP-specific rule (previously preventing PHP dependency updates)
  - Updated the npm rule to include `matchUpdateTypes: ["major"]` constraint
  - Maintained the existing npm/yarn rule in disabled state
  - Added broader grouping rule for all dependencies

## Possibly related

- #93: Fixed Renovatebot not ignoring CI configs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->