### PR TITLE
[#362] Added support for automated free port lookup via '.env' file.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -3,6 +3,9 @@
 ---
 ahoyapi: v2
 
+env:
+  - .env
+
 commands:
 
   build:

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -77,7 +77,10 @@ function dotenv_read(string $file = '.env'): array {
   $vars = [];
   foreach (preg_split('/\r\n|\r|\n/', $contents) ?: [] as $line) {
     $trimmed = trim($line);
-    if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+    if ($trimmed === '') {
+      continue;
+    }
+    if (str_starts_with($trimmed, '#')) {
       continue;
     }
 
@@ -148,7 +151,13 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
   $replaced = FALSE;
   foreach ($lines as $i => $line) {
     $trimmed = trim($line);
-    if ($trimmed === '' || str_starts_with($trimmed, '#') || !str_contains($trimmed, '=')) {
+    if ($trimmed === '') {
+      continue;
+    }
+    if (str_starts_with($trimmed, '#')) {
+      continue;
+    }
+    if (!str_contains($trimmed, '=')) {
       continue;
     }
 

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -129,7 +129,10 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
   $assignment = sprintf('%s=%s', $key, $value);
 
   if (!file_exists($file)) {
-    file_put_contents($file, $assignment . PHP_EOL);
+    if (file_put_contents($file, $assignment . PHP_EOL) === FALSE) {
+      FAIL('Unable to write %s', $file);
+    }
+
     return;
   }
 
@@ -148,7 +151,9 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
     array_pop($lines);
   }
 
-  $replaced = FALSE;
+  // Replace the LAST matching assignment so dotenv_read()'s
+  // last-assignment-wins semantics agree with what is written.
+  $replace_index = NULL;
   foreach ($lines as $i => $line) {
     $trimmed = trim($line);
     if ($trimmed === '') {
@@ -163,25 +168,48 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
 
     [$existing_key] = explode('=', $trimmed, 2);
     if (trim($existing_key) === $key) {
-      $lines[$i] = $assignment;
-      $replaced = TRUE;
-      break;
+      $replace_index = $i;
     }
   }
 
-  if (!$replaced) {
+  if ($replace_index === NULL) {
     $lines[] = $assignment;
   }
+  else {
+    $lines[$replace_index] = $assignment;
+  }
 
-  file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL);
+  if (file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
+    FAIL('Unable to write %s', $file);
+  }
+}
+
+/**
+ * Validate that a value is a TCP port in the range 1-65535.
+ *
+ * Calls FAIL() with a descriptive message if validation fails.
+ *
+ * @param string $value
+ *   The value to validate.
+ * @param string $source
+ *   Source name used in the error message (e.g. 'WEBSERVER_PORT').
+ */
+function validate_port_or_fail(string $value, string $source): void {
+  if (!ctype_digit($value) || (int) $value < 1 || (int) $value > 65535) {
+    FAIL('Invalid %s "%s". Expected integer in range 1-65535.', $source, $value);
+  }
 }
 
 /**
  * Find a free TCP port by scanning a range of ports.
  *
- * Attempts to open a server socket on each port in turn, starting from
- * $start, and returns the first port that is free. Calls FAIL() if no
- * free port is found within $max_attempts.
+ * Probes each port on both IPv4 (127.0.0.1) and IPv6 ([::1]) loopback
+ * interfaces and returns the first port that is free on both. This is
+ * needed because PHP's built-in webserver (php -S localhost:N) binds to
+ * IPv6 only on systems where 'localhost' resolves that way, while
+ * stream_socket_server() falls back between stacks - so a single-stack
+ * probe can incorrectly report a port as free. Calls FAIL() if no free
+ * port is found within $max_attempts.
  *
  * @param int $start
  *   Port number to start scanning from.
@@ -199,10 +227,20 @@ function find_free_port(int $start = 8000, int $max_attempts = 100): int {
     FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
   }
 
+  $probe_addresses = ['127.0.0.1', '[::1]'];
+
   for ($port = $start; $port < $start + $max_attempts; $port++) {
-    $sock = @stream_socket_server(sprintf('tcp://127.0.0.1:%d', $port), $errno, $errstr);
-    if ($sock !== FALSE) {
+    $all_free = TRUE;
+    foreach ($probe_addresses as $address) {
+      $sock = @stream_socket_server(sprintf('tcp://%s:%d', $address, $port), $errno, $errstr);
+      if ($sock === FALSE) {
+        $all_free = FALSE;
+        break;
+      }
       fclose($sock);
+    }
+
+    if ($all_free) {
       return $port;
     }
   }

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -132,8 +132,11 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
 
   $contents = file_get_contents($file);
   if ($contents === FALSE) {
-    file_put_contents($file, $assignment . PHP_EOL);
+    FAIL('Unable to read %s', $file);
+
+    // @codeCoverageIgnoreStart
     return;
+    // @codeCoverageIgnoreEnd
   }
 
   $lines = preg_split('/\r\n|\r|\n/', $contents) ?: [];

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -203,13 +203,13 @@ function validate_port_or_fail(string $value, string $source): void {
 /**
  * Find a free TCP port by scanning a range of ports.
  *
- * Probes each port on both IPv4 (127.0.0.1) and IPv6 ([::1]) loopback
- * interfaces and returns the first port that is free on both. This is
- * needed because PHP's built-in webserver (php -S localhost:N) binds to
- * IPv6 only on systems where 'localhost' resolves that way, while
- * stream_socket_server() falls back between stacks - so a single-stack
- * probe can incorrectly report a port as free. Calls FAIL() if no free
- * port is found within $max_attempts.
+ * Each port is probed by attempting a client connect to localhost. A
+ * connection that succeeds means some server is already listening on
+ * that port (on either IPv4 or IPv6, whichever the resolver picks).
+ * A connection that is refused means the port is free. This works on
+ * environments without IPv6 (e.g. Docker-based CI) where a server-side
+ * bind probe to [::1] would always fail. Calls FAIL() if no free port
+ * is found within $max_attempts.
  *
  * @param int $start
  *   Port number to start scanning from.
@@ -227,22 +227,12 @@ function find_free_port(int $start = 8000, int $max_attempts = 100): int {
     FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
   }
 
-  $probe_addresses = ['127.0.0.1', '[::1]'];
-
   for ($port = $start; $port < $start + $max_attempts; $port++) {
-    $all_free = TRUE;
-    foreach ($probe_addresses as $address) {
-      $sock = @stream_socket_server(sprintf('tcp://%s:%d', $address, $port), $errno, $errstr);
-      if ($sock === FALSE) {
-        $all_free = FALSE;
-        break;
-      }
-      fclose($sock);
-    }
-
-    if ($all_free) {
+    $conn = @stream_socket_client(sprintf('tcp://localhost:%d', $port), $errno, $errstr, 0.2);
+    if ($conn === FALSE) {
       return $port;
     }
+    fclose($conn);
   }
 
   FAIL('Unable to find a free port in range %d-%d', $start, $start + $max_attempts - 1);

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -183,6 +183,13 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
  *   The first free port found.
  */
 function find_free_port(int $start = 8000, int $max_attempts = 100): int {
+  if ($start < 1 || $start > 65535) {
+    FAIL('Start port must be between 1 and 65535, got %d', $start);
+  }
+  if ($max_attempts < 1) {
+    FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
+  }
+
   for ($port = $start; $port < $start + $max_attempts; $port++) {
     $sock = @stream_socket_server(sprintf('tcp://127.0.0.1:%d', $port), $errno, $errstr);
     if ($sock !== FALSE) {

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -51,6 +51,151 @@ function getenv_default(mixed ...$vars): string {
 }
 
 /**
+ * Read variables from a dotenv-style file into an associative array.
+ *
+ * Parses lines of the form KEY=VALUE. Lines that are blank or start with
+ * '#' (after optional whitespace) are ignored. Surrounding single or double
+ * quotes around the value are stripped. Keys and values are trimmed.
+ *
+ * @param string $file
+ *   Path to the dotenv file.
+ *
+ * @return array<string, string>
+ *   Associative array of key-value pairs. Empty if the file does not exist
+ *   or contains no parseable lines.
+ */
+function dotenv_read(string $file = '.env'): array {
+  if (!file_exists($file)) {
+    return [];
+  }
+
+  $contents = file_get_contents($file);
+  if ($contents === FALSE) {
+    return [];
+  }
+
+  $vars = [];
+  foreach (preg_split('/\r\n|\r|\n/', $contents) ?: [] as $line) {
+    $trimmed = trim($line);
+    if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+      continue;
+    }
+
+    if (!str_contains($trimmed, '=')) {
+      continue;
+    }
+
+    [$key, $value] = explode('=', $trimmed, 2);
+    $key = trim($key);
+    $value = trim($value);
+
+    if ($key === '') {
+      continue;
+    }
+
+    if (strlen($value) >= 2) {
+      $first = $value[0];
+      $last = $value[strlen($value) - 1];
+      if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+        $value = substr($value, 1, -1);
+      }
+    }
+
+    $vars[$key] = $value;
+  }
+
+  return $vars;
+}
+
+/**
+ * Set or update a variable in a dotenv-style file.
+ *
+ * If the key already exists in the file, its line is rewritten in place,
+ * preserving the order of other lines and any comments or blank lines.
+ * If the key does not exist, the assignment is appended to the end of the
+ * file. The file is created with the single assignment if it does not exist.
+ *
+ * @param string $key
+ *   Variable name to write.
+ * @param string $value
+ *   Variable value to write. Not quoted.
+ * @param string $file
+ *   Path to the dotenv file.
+ */
+function dotenv_write_var(string $key, string $value, string $file = '.env'): void {
+  $assignment = sprintf('%s=%s', $key, $value);
+
+  if (!file_exists($file)) {
+    file_put_contents($file, $assignment . PHP_EOL);
+    return;
+  }
+
+  $contents = file_get_contents($file);
+  if ($contents === FALSE) {
+    file_put_contents($file, $assignment . PHP_EOL);
+    return;
+  }
+
+  $lines = preg_split('/\r\n|\r|\n/', $contents) ?: [];
+  $trailing_newline = $contents !== '' && (str_ends_with($contents, "\n") || str_ends_with($contents, "\r"));
+  if ($trailing_newline && end($lines) === '') {
+    array_pop($lines);
+  }
+
+  $replaced = FALSE;
+  foreach ($lines as $i => $line) {
+    $trimmed = trim($line);
+    if ($trimmed === '' || str_starts_with($trimmed, '#') || !str_contains($trimmed, '=')) {
+      continue;
+    }
+
+    [$existing_key] = explode('=', $trimmed, 2);
+    if (trim($existing_key) === $key) {
+      $lines[$i] = $assignment;
+      $replaced = TRUE;
+      break;
+    }
+  }
+
+  if (!$replaced) {
+    $lines[] = $assignment;
+  }
+
+  file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL);
+}
+
+/**
+ * Find a free TCP port by scanning a range of ports.
+ *
+ * Attempts to open a server socket on each port in turn, starting from
+ * $start, and returns the first port that is free. Calls FAIL() if no
+ * free port is found within $max_attempts.
+ *
+ * @param int $start
+ *   Port number to start scanning from.
+ * @param int $max_attempts
+ *   Maximum number of ports to try.
+ *
+ * @return int
+ *   The first free port found.
+ */
+function find_free_port(int $start = 8000, int $max_attempts = 100): int {
+  for ($port = $start; $port < $start + $max_attempts; $port++) {
+    $sock = @stream_socket_server(sprintf('tcp://127.0.0.1:%d', $port), $errno, $errstr);
+    if ($sock !== FALSE) {
+      fclose($sock);
+      return $port;
+    }
+  }
+
+  FAIL('Unable to find a free port in range %d-%d', $start, $start + $max_attempts - 1);
+
+  // @codeCoverageIgnoreStart
+  return $start;
+  // @codeCoverageIgnoreEnd
+}
+
+/**
  * Get required environment variable with fallback support.
  */
 function getenv_required(mixed ...$vars): string {

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -32,6 +32,7 @@ if ($webserver_port === '') {
   $dotenv = dotenv_read('.env');
   $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
 }
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -23,8 +23,15 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Default '8000'.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
+}
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');

--- a/.devtools/start
+++ b/.devtools/start
@@ -34,6 +34,7 @@ if ($webserver_port === '') {
     dotenv_write_var('WEBSERVER_PORT', $webserver_port);
   }
 }
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
@@ -49,8 +50,8 @@ TASK('Stopping previously started services, if any.');
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 
 TASK('Starting the PHP webserver.');
-$cwd = getcwd();
-passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $webserver_host, $webserver_port, $cwd, $cwd));
+$cwd = (string) getcwd();
+passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
 
 NOTE('Waiting %s seconds for the server to be ready.', (string) $webserver_wait_timeout);
 sleep($webserver_wait_timeout);

--- a/.devtools/start
+++ b/.devtools/start
@@ -19,8 +19,21 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Auto-discovery via find_free_port(), persisted to .env.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
+    $webserver_port = $dotenv['WEBSERVER_PORT'];
+  }
+  else {
+    $webserver_port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
+  }
+}
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -34,10 +34,10 @@ echo '      💻 STOP ENVIRONMENT      ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
-TASK('Stopping previously started services, if any.');
+TASK('Stopping previously started services on port %s, if any.', $webserver_port);
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 sleep(1);
-PASS('Services stopped.');
+PASS('Services stopped on port %s.', $webserver_port);
 
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -25,6 +25,7 @@ if ($webserver_port === '') {
   $dotenv = dotenv_read('.env');
   $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
 }
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // -----------------------------------------------------------------------------
 

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -16,8 +16,15 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Default '8000'.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
+}
 
 // -----------------------------------------------------------------------------
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.env
 /.logs
 /build
 /composer.lock

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -3,6 +3,9 @@
 ---
 ahoyapi: v2
 
+env:
+  - .env
+
 commands:
 
   build:

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -77,7 +77,10 @@ function dotenv_read(string $file = '.env'): array {
   $vars = [];
   foreach (preg_split('/\r\n|\r|\n/', $contents) ?: [] as $line) {
     $trimmed = trim($line);
-    if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+    if ($trimmed === '') {
+      continue;
+    }
+    if (str_starts_with($trimmed, '#')) {
       continue;
     }
 
@@ -148,7 +151,13 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
   $replaced = FALSE;
   foreach ($lines as $i => $line) {
     $trimmed = trim($line);
-    if ($trimmed === '' || str_starts_with($trimmed, '#') || !str_contains($trimmed, '=')) {
+    if ($trimmed === '') {
+      continue;
+    }
+    if (str_starts_with($trimmed, '#')) {
+      continue;
+    }
+    if (!str_contains($trimmed, '=')) {
       continue;
     }
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -129,7 +129,10 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
   $assignment = sprintf('%s=%s', $key, $value);
 
   if (!file_exists($file)) {
-    file_put_contents($file, $assignment . PHP_EOL);
+    if (file_put_contents($file, $assignment . PHP_EOL) === FALSE) {
+      FAIL('Unable to write %s', $file);
+    }
+
     return;
   }
 
@@ -148,7 +151,9 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
     array_pop($lines);
   }
 
-  $replaced = FALSE;
+  // Replace the LAST matching assignment so dotenv_read()'s
+  // last-assignment-wins semantics agree with what is written.
+  $replace_index = NULL;
   foreach ($lines as $i => $line) {
     $trimmed = trim($line);
     if ($trimmed === '') {
@@ -163,25 +168,48 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
 
     [$existing_key] = explode('=', $trimmed, 2);
     if (trim($existing_key) === $key) {
-      $lines[$i] = $assignment;
-      $replaced = TRUE;
-      break;
+      $replace_index = $i;
     }
   }
 
-  if (!$replaced) {
+  if ($replace_index === NULL) {
     $lines[] = $assignment;
   }
+  else {
+    $lines[$replace_index] = $assignment;
+  }
 
-  file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL);
+  if (file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
+    FAIL('Unable to write %s', $file);
+  }
+}
+
+/**
+ * Validate that a value is a TCP port in the range 1-65535.
+ *
+ * Calls FAIL() with a descriptive message if validation fails.
+ *
+ * @param string $value
+ *   The value to validate.
+ * @param string $source
+ *   Source name used in the error message (e.g. 'WEBSERVER_PORT').
+ */
+function validate_port_or_fail(string $value, string $source): void {
+  if (!ctype_digit($value) || (int) $value < 1 || (int) $value > 65535) {
+    FAIL('Invalid %s "%s". Expected integer in range 1-65535.', $source, $value);
+  }
 }
 
 /**
  * Find a free TCP port by scanning a range of ports.
  *
- * Attempts to open a server socket on each port in turn, starting from
- * $start, and returns the first port that is free. Calls FAIL() if no
- * free port is found within $max_attempts.
+ * Probes each port on both IPv4 (127.0.0.1) and IPv6 ([::1]) loopback
+ * interfaces and returns the first port that is free on both. This is
+ * needed because PHP's built-in webserver (php -S localhost:N) binds to
+ * IPv6 only on systems where 'localhost' resolves that way, while
+ * stream_socket_server() falls back between stacks - so a single-stack
+ * probe can incorrectly report a port as free. Calls FAIL() if no free
+ * port is found within $max_attempts.
  *
  * @param int $start
  *   Port number to start scanning from.
@@ -199,10 +227,20 @@ function find_free_port(int $start = 8000, int $max_attempts = 100): int {
     FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
   }
 
+  $probe_addresses = ['127.0.0.1', '[::1]'];
+
   for ($port = $start; $port < $start + $max_attempts; $port++) {
-    $sock = @stream_socket_server(sprintf('tcp://127.0.0.1:%d', $port), $errno, $errstr);
-    if ($sock !== FALSE) {
+    $all_free = TRUE;
+    foreach ($probe_addresses as $address) {
+      $sock = @stream_socket_server(sprintf('tcp://%s:%d', $address, $port), $errno, $errstr);
+      if ($sock === FALSE) {
+        $all_free = FALSE;
+        break;
+      }
       fclose($sock);
+    }
+
+    if ($all_free) {
       return $port;
     }
   }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -203,13 +203,13 @@ function validate_port_or_fail(string $value, string $source): void {
 /**
  * Find a free TCP port by scanning a range of ports.
  *
- * Probes each port on both IPv4 (127.0.0.1) and IPv6 ([::1]) loopback
- * interfaces and returns the first port that is free on both. This is
- * needed because PHP's built-in webserver (php -S localhost:N) binds to
- * IPv6 only on systems where 'localhost' resolves that way, while
- * stream_socket_server() falls back between stacks - so a single-stack
- * probe can incorrectly report a port as free. Calls FAIL() if no free
- * port is found within $max_attempts.
+ * Each port is probed by attempting a client connect to localhost. A
+ * connection that succeeds means some server is already listening on
+ * that port (on either IPv4 or IPv6, whichever the resolver picks).
+ * A connection that is refused means the port is free. This works on
+ * environments without IPv6 (e.g. Docker-based CI) where a server-side
+ * bind probe to [::1] would always fail. Calls FAIL() if no free port
+ * is found within $max_attempts.
  *
  * @param int $start
  *   Port number to start scanning from.
@@ -227,22 +227,12 @@ function find_free_port(int $start = 8000, int $max_attempts = 100): int {
     FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
   }
 
-  $probe_addresses = ['127.0.0.1', '[::1]'];
-
   for ($port = $start; $port < $start + $max_attempts; $port++) {
-    $all_free = TRUE;
-    foreach ($probe_addresses as $address) {
-      $sock = @stream_socket_server(sprintf('tcp://%s:%d', $address, $port), $errno, $errstr);
-      if ($sock === FALSE) {
-        $all_free = FALSE;
-        break;
-      }
-      fclose($sock);
-    }
-
-    if ($all_free) {
+    $conn = @stream_socket_client(sprintf('tcp://localhost:%d', $port), $errno, $errstr, 0.2);
+    if ($conn === FALSE) {
       return $port;
     }
+    fclose($conn);
   }
 
   FAIL('Unable to find a free port in range %d-%d', $start, $start + $max_attempts - 1);

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -51,6 +51,161 @@ function getenv_default(mixed ...$vars): string {
 }
 
 /**
+ * Read variables from a dotenv-style file into an associative array.
+ *
+ * Parses lines of the form KEY=VALUE. Lines that are blank or start with
+ * '#' (after optional whitespace) are ignored. Surrounding single or double
+ * quotes around the value are stripped. Keys and values are trimmed.
+ *
+ * @param string $file
+ *   Path to the dotenv file.
+ *
+ * @return array<string, string>
+ *   Associative array of key-value pairs. Empty if the file does not exist
+ *   or contains no parseable lines.
+ */
+function dotenv_read(string $file = '.env'): array {
+  if (!file_exists($file)) {
+    return [];
+  }
+
+  $contents = file_get_contents($file);
+  if ($contents === FALSE) {
+    return [];
+  }
+
+  $vars = [];
+  foreach (preg_split('/\r\n|\r|\n/', $contents) ?: [] as $line) {
+    $trimmed = trim($line);
+    if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+      continue;
+    }
+
+    if (!str_contains($trimmed, '=')) {
+      continue;
+    }
+
+    [$key, $value] = explode('=', $trimmed, 2);
+    $key = trim($key);
+    $value = trim($value);
+
+    if ($key === '') {
+      continue;
+    }
+
+    if (strlen($value) >= 2) {
+      $first = $value[0];
+      $last = $value[strlen($value) - 1];
+      if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+        $value = substr($value, 1, -1);
+      }
+    }
+
+    $vars[$key] = $value;
+  }
+
+  return $vars;
+}
+
+/**
+ * Set or update a variable in a dotenv-style file.
+ *
+ * If the key already exists in the file, its line is rewritten in place,
+ * preserving the order of other lines and any comments or blank lines.
+ * If the key does not exist, the assignment is appended to the end of the
+ * file. The file is created with the single assignment if it does not exist.
+ *
+ * @param string $key
+ *   Variable name to write.
+ * @param string $value
+ *   Variable value to write. Not quoted.
+ * @param string $file
+ *   Path to the dotenv file.
+ */
+function dotenv_write_var(string $key, string $value, string $file = '.env'): void {
+  $assignment = sprintf('%s=%s', $key, $value);
+
+  if (!file_exists($file)) {
+    file_put_contents($file, $assignment . PHP_EOL);
+    return;
+  }
+
+  $contents = file_get_contents($file);
+  if ($contents === FALSE) {
+    FAIL('Unable to read %s', $file);
+
+    // @codeCoverageIgnoreStart
+    return;
+    // @codeCoverageIgnoreEnd
+  }
+
+  $lines = preg_split('/\r\n|\r|\n/', $contents) ?: [];
+  $trailing_newline = $contents !== '' && (str_ends_with($contents, "\n") || str_ends_with($contents, "\r"));
+  if ($trailing_newline && end($lines) === '') {
+    array_pop($lines);
+  }
+
+  $replaced = FALSE;
+  foreach ($lines as $i => $line) {
+    $trimmed = trim($line);
+    if ($trimmed === '' || str_starts_with($trimmed, '#') || !str_contains($trimmed, '=')) {
+      continue;
+    }
+
+    [$existing_key] = explode('=', $trimmed, 2);
+    if (trim($existing_key) === $key) {
+      $lines[$i] = $assignment;
+      $replaced = TRUE;
+      break;
+    }
+  }
+
+  if (!$replaced) {
+    $lines[] = $assignment;
+  }
+
+  file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL);
+}
+
+/**
+ * Find a free TCP port by scanning a range of ports.
+ *
+ * Attempts to open a server socket on each port in turn, starting from
+ * $start, and returns the first port that is free. Calls FAIL() if no
+ * free port is found within $max_attempts.
+ *
+ * @param int $start
+ *   Port number to start scanning from.
+ * @param int $max_attempts
+ *   Maximum number of ports to try.
+ *
+ * @return int
+ *   The first free port found.
+ */
+function find_free_port(int $start = 8000, int $max_attempts = 100): int {
+  if ($start < 1 || $start > 65535) {
+    FAIL('Start port must be between 1 and 65535, got %d', $start);
+  }
+  if ($max_attempts < 1) {
+    FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
+  }
+
+  for ($port = $start; $port < $start + $max_attempts; $port++) {
+    $sock = @stream_socket_server(sprintf('tcp://127.0.0.1:%d', $port), $errno, $errstr);
+    if ($sock !== FALSE) {
+      fclose($sock);
+      return $port;
+    }
+  }
+
+  FAIL('Unable to find a free port in range %d-%d', $start, $start + $max_attempts - 1);
+
+  // @codeCoverageIgnoreStart
+  return $start;
+  // @codeCoverageIgnoreEnd
+}
+
+/**
  * Get required environment variable with fallback support.
  */
 function getenv_required(mixed ...$vars): string {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -32,6 +32,7 @@ if ($webserver_port === '') {
   $dotenv = dotenv_read('.env');
   $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
 }
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -23,8 +23,15 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Default '8000'.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
+}
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -19,25 +19,11 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Auto-discovery via find_free_port(), persisted to .env.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
-    $webserver_port = $dotenv['WEBSERVER_PORT'];
-  }
-  else {
-    $webserver_port = (string) find_free_port();
-    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-  }
-}
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
-
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
+
+// Lock file recording the PID of the PHP server we started.
+$lock_file = '.logs/webserver.pid';
 
 // -----------------------------------------------------------------------------
 
@@ -47,7 +33,62 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 TASK('Stopping previously started services, if any.');
-@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+
+// Cleanup any server we started in a previous run, using the PID lock file.
+// This is project-local, so it never touches servers belonging to other
+// projects running in different directories.
+$prev_pid = 0;
+if (file_exists($lock_file)) {
+  $lock_contents = trim((string) @file_get_contents($lock_file));
+  if ($lock_contents !== '' && ctype_digit($lock_contents)) {
+    $prev_pid = (int) $lock_contents;
+    @exec(sprintf('kill -9 %d 2>/dev/null', $prev_pid));
+  }
+  @unlink($lock_file);
+  sleep(1);
+}
+
+// Resolve the port the server should listen on. Precedence:
+// 1. WEBSERVER_PORT env var.
+// 2. WEBSERVER_PORT entry in .env.
+// 3. Default 8000.
+//
+// Auto-discovery only kicks in when neither of the above is set AND the
+// default port turns out to be held by another process (e.g. another project
+// running in a different directory). In that case, a free port is discovered
+// and persisted to .env so the same port is reused on subsequent runs in
+// this project.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+$from_persistent_source = $webserver_port !== '';
+
+if (!$from_persistent_source) {
+  $dotenv = dotenv_read('.env');
+  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
+    $webserver_port = $dotenv['WEBSERVER_PORT'];
+    $from_persistent_source = TRUE;
+  }
+  else {
+    $webserver_port = '8000';
+  }
+}
+
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+
+if (!$from_persistent_source) {
+  // Default port is in play. Probe via a client connect (not a bind probe)
+  // so we correctly detect a listener regardless of whether it bound to
+  // IPv4 127.0.0.1 or IPv6 [::1]. If something is listening, this project
+  // cannot reuse the default - discover a different port and persist that
+  // choice to .env.
+  $probe = @stream_socket_client(sprintf('tcp://%s:%d', $webserver_host, (int) $webserver_port), $errno, $errstr, 0.2);
+  if ($probe !== FALSE) {
+    fclose($probe);
+    NOTE('Port %s is in use; discovering a free port.', $webserver_port);
+    $webserver_port = (string) find_free_port((int) $webserver_port + 1);
+    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
+    NOTE('Using port %s (persisted to .env).', $webserver_port);
+  }
+}
 
 TASK('Starting the PHP webserver.');
 $cwd = (string) getcwd();
@@ -75,6 +116,22 @@ if ($headers === FALSE || !isset($headers[0]) || !str_contains($headers[0], '200
 }
 PASS('Server can serve content.');
 
+// Capture the PID of the running server and record it for the next run's
+// cleanup. lsof returns one PID per line; take the first one.
+$lsof_output = (string) @shell_exec(sprintf('lsof -ti:%s 2>/dev/null', escapeshellarg($webserver_port)));
+$server_pid = 0;
+foreach (preg_split('/\r\n|\r|\n/', $lsof_output) ?: [] as $line) {
+  $line = trim($line);
+  if ($line !== '' && ctype_digit($line)) {
+    $server_pid = (int) $line;
+    break;
+  }
+}
+if ($server_pid > 0) {
+  @mkdir(dirname($lock_file), 0755, TRUE);
+  @file_put_contents($lock_file, (string) $server_pid);
+}
+
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '    💻 ENVIRONMENT READY  ✅  ' . PHP_EOL;
@@ -82,6 +139,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Directory : ' . $cwd . '/build/web' . PHP_EOL;
 echo 'URL       : http://' . $webserver_host . ':' . $webserver_port . PHP_EOL;
+echo 'Port      : ' . $webserver_port . PHP_EOL;
 echo PHP_EOL;
 echo 'Re-run when you enable or disable XDebug.' . PHP_EOL;
 echo PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -19,11 +19,25 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Auto-discovery via find_free_port(), persisted to .env.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
+    $webserver_port = $dotenv['WEBSERVER_PORT'];
+  }
+  else {
+    $webserver_port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
+  }
+}
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
-
-// Lock file recording the PID of the PHP server we started.
-$lock_file = '.logs/webserver.pid';
 
 // -----------------------------------------------------------------------------
 
@@ -33,62 +47,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 TASK('Stopping previously started services, if any.');
-
-// Cleanup any server we started in a previous run, using the PID lock file.
-// This is project-local, so it never touches servers belonging to other
-// projects running in different directories.
-$prev_pid = 0;
-if (file_exists($lock_file)) {
-  $lock_contents = trim((string) @file_get_contents($lock_file));
-  if ($lock_contents !== '' && ctype_digit($lock_contents)) {
-    $prev_pid = (int) $lock_contents;
-    @exec(sprintf('kill -9 %d 2>/dev/null', $prev_pid));
-  }
-  @unlink($lock_file);
-  sleep(1);
-}
-
-// Resolve the port the server should listen on. Precedence:
-// 1. WEBSERVER_PORT env var.
-// 2. WEBSERVER_PORT entry in .env.
-// 3. Default 8000.
-//
-// Auto-discovery only kicks in when neither of the above is set AND the
-// default port turns out to be held by another process (e.g. another project
-// running in a different directory). In that case, a free port is discovered
-// and persisted to .env so the same port is reused on subsequent runs in
-// this project.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-$from_persistent_source = $webserver_port !== '';
-
-if (!$from_persistent_source) {
-  $dotenv = dotenv_read('.env');
-  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
-    $webserver_port = $dotenv['WEBSERVER_PORT'];
-    $from_persistent_source = TRUE;
-  }
-  else {
-    $webserver_port = '8000';
-  }
-}
-
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
-
-if (!$from_persistent_source) {
-  // Default port is in play. Probe via a client connect (not a bind probe)
-  // so we correctly detect a listener regardless of whether it bound to
-  // IPv4 127.0.0.1 or IPv6 [::1]. If something is listening, this project
-  // cannot reuse the default - discover a different port and persist that
-  // choice to .env.
-  $probe = @stream_socket_client(sprintf('tcp://%s:%d', $webserver_host, (int) $webserver_port), $errno, $errstr, 0.2);
-  if ($probe !== FALSE) {
-    fclose($probe);
-    NOTE('Port %s is in use; discovering a free port.', $webserver_port);
-    $webserver_port = (string) find_free_port((int) $webserver_port + 1);
-    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-    NOTE('Using port %s (persisted to .env).', $webserver_port);
-  }
-}
+@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 
 TASK('Starting the PHP webserver.');
 $cwd = (string) getcwd();
@@ -116,22 +75,6 @@ if ($headers === FALSE || !isset($headers[0]) || !str_contains($headers[0], '200
 }
 PASS('Server can serve content.');
 
-// Capture the PID of the running server and record it for the next run's
-// cleanup. lsof returns one PID per line; take the first one.
-$lsof_output = (string) @shell_exec(sprintf('lsof -ti:%s 2>/dev/null', escapeshellarg($webserver_port)));
-$server_pid = 0;
-foreach (preg_split('/\r\n|\r|\n/', $lsof_output) ?: [] as $line) {
-  $line = trim($line);
-  if ($line !== '' && ctype_digit($line)) {
-    $server_pid = (int) $line;
-    break;
-  }
-}
-if ($server_pid > 0) {
-  @mkdir(dirname($lock_file), 0755, TRUE);
-  @file_put_contents($lock_file, (string) $server_pid);
-}
-
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '    💻 ENVIRONMENT READY  ✅  ' . PHP_EOL;
@@ -139,7 +82,6 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Directory : ' . $cwd . '/build/web' . PHP_EOL;
 echo 'URL       : http://' . $webserver_host . ':' . $webserver_port . PHP_EOL;
-echo 'Port      : ' . $webserver_port . PHP_EOL;
 echo PHP_EOL;
 echo 'Re-run when you enable or disable XDebug.' . PHP_EOL;
 echo PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -34,6 +34,7 @@ if ($webserver_port === '') {
     dotenv_write_var('WEBSERVER_PORT', $webserver_port);
   }
 }
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
@@ -49,8 +50,8 @@ TASK('Stopping previously started services, if any.');
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 
 TASK('Starting the PHP webserver.');
-$cwd = getcwd();
-passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $webserver_host, $webserver_port, $cwd, $cwd));
+$cwd = (string) getcwd();
+passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
 
 NOTE('Waiting %s seconds for the server to be ready.', (string) $webserver_wait_timeout);
 sleep($webserver_wait_timeout);

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -19,8 +19,21 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Auto-discovery via find_free_port(), persisted to .env.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
+    $webserver_port = $dotenv['WEBSERVER_PORT'];
+  }
+  else {
+    $webserver_port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
+  }
+}
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -16,14 +16,10 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Lock file recording the PID of the PHP server we started.
-$lock_file = '.logs/webserver.pid';
-
-// Resolve the port the server is listening on, for the user-facing message
-// and as a fallback kill target if the lock file is missing. Precedence:
-// 1. WEBSERVER_PORT env var.
-// 2. WEBSERVER_PORT entry in .env.
-// 3. Default 8000.
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Default '8000'.
 $webserver_port = getenv_default('WEBSERVER_PORT', '');
 if ($webserver_port === '') {
   $dotenv = dotenv_read('.env');
@@ -38,27 +34,8 @@ echo '      💻 STOP ENVIRONMENT      ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
-TASK('Stopping previously started services, if any.');
-
-// Prefer killing the specific PID we recorded so we never touch a server
-// belonging to another project on the same port.
-$stopped_via_lock = FALSE;
-if (file_exists($lock_file)) {
-  $lock_contents = trim((string) @file_get_contents($lock_file));
-  if ($lock_contents !== '' && ctype_digit($lock_contents)) {
-    $pid = (int) $lock_contents;
-    @exec(sprintf('kill -9 %d 2>/dev/null', $pid));
-    $stopped_via_lock = TRUE;
-  }
-  @unlink($lock_file);
-}
-
-// If there is no lock file (e.g. user started a server outside this tooling,
-// or .logs was wiped), fall back to killing whatever is on the resolved port.
-if (!$stopped_via_lock) {
-  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
-}
-
+TASK('Stopping previously started services on port %s, if any.', $webserver_port);
+@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 sleep(1);
 PASS('Services stopped on port %s.', $webserver_port);
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -25,6 +25,7 @@ if ($webserver_port === '') {
   $dotenv = dotenv_read('.env');
   $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
 }
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // -----------------------------------------------------------------------------
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -16,10 +16,14 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
+// Lock file recording the PID of the PHP server we started.
+$lock_file = '.logs/webserver.pid';
+
+// Resolve the port the server is listening on, for the user-facing message
+// and as a fallback kill target if the lock file is missing. Precedence:
+// 1. WEBSERVER_PORT env var.
+// 2. WEBSERVER_PORT entry in .env.
+// 3. Default 8000.
 $webserver_port = getenv_default('WEBSERVER_PORT', '');
 if ($webserver_port === '') {
   $dotenv = dotenv_read('.env');
@@ -35,9 +39,28 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 TASK('Stopping previously started services, if any.');
-@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+
+// Prefer killing the specific PID we recorded so we never touch a server
+// belonging to another project on the same port.
+$stopped_via_lock = FALSE;
+if (file_exists($lock_file)) {
+  $lock_contents = trim((string) @file_get_contents($lock_file));
+  if ($lock_contents !== '' && ctype_digit($lock_contents)) {
+    $pid = (int) $lock_contents;
+    @exec(sprintf('kill -9 %d 2>/dev/null', $pid));
+    $stopped_via_lock = TRUE;
+  }
+  @unlink($lock_file);
+}
+
+// If there is no lock file (e.g. user started a server outside this tooling,
+// or .logs was wiped), fall back to killing whatever is on the resolved port.
+if (!$stopped_via_lock) {
+  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+}
+
 sleep(1);
-PASS('Services stopped.');
+PASS('Services stopped on port %s.', $webserver_port);
 
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -16,8 +16,15 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Default '8000'.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
+}
 
 // -----------------------------------------------------------------------------
 

--- a/.scaffold/tests/fixtures/init/_baseline/.gitignore
+++ b/.scaffold/tests/fixtures/init/_baseline/.gitignore
@@ -1,3 +1,4 @@
+/.env
 /.logs
 /build
 /composer.lock

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -1,4 +1,10 @@
 SHELL=/bin/bash
+
+# Load variables from .env if present and export them to recipe shells. The
+# leading '-' on -include suppresses errors when the file does not exist.
+-include .env
+export
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -1,4 +1,10 @@
 SHELL=/bin/bash
+
+# Load variables from .env if present and export them to recipe shells. The
+# leading '-' on -include suppresses errors when the file does not exist.
+-include .env
+export
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -1,4 +1,10 @@
 SHELL=/bin/bash
+
+# Load variables from .env if present and export them to recipe shells. The
+# leading '-' on -include suppresses errors when the file does not exist.
+-include .env
+export
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -1,4 +1,10 @@
 SHELL=/bin/bash
+
+# Load variables from .env if present and export them to recipe shells. The
+# leading '-' on -include suppresses errors when the file does not exist.
+-include .env
+export
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/src/Functional/AutoPortDiscoveryTest.php
+++ b/.scaffold/tests/src/Functional/AutoPortDiscoveryTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Functional;
+
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit\UnitTestCase;
+use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Functional tests for auto-port discovery across multiple projects.
+ *
+ * Each "project" is a minimal sandbox containing only the .devtools scripts
+ * and a stubbed build/web tree. The real PHP webserver is started in each
+ * sandbox and the resolved WEBSERVER_PORT is read from the generated .env
+ * file. This verifies the end-to-end resolution + persistence behavior, not
+ * just the unit-level helpers.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p3')]
+final class AutoPortDiscoveryTest extends UnitTestCase {
+
+  use ProcessTrait;
+
+  protected int $defaultTimeout = 30;
+
+  protected int $defaultIdleTimeout = 15;
+
+  /**
+   * First minimal project sandbox.
+   */
+  protected string $sut1 = '';
+
+  /**
+   * Second minimal project sandbox.
+   */
+  protected string $sut2 = '';
+
+  /**
+   * Ports the test has started PHP servers on; tearDown kills them.
+   *
+   * @var array<int, string>
+   */
+  protected array $startedPorts = [];
+
+  protected function tearDown(): void {
+    foreach ($this->startedPorts as $port) {
+      // phpcs:ignore
+      @exec(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
+    }
+    sleep(1);
+
+    self::envReset();
+    $this->processTearDown();
+
+    parent::tearDown();
+  }
+
+  public function testTwoProjectsAutoDiscoverDistinctPorts(): void {
+    $this->sut1 = self::$tmp . '/proj1_' . uniqid();
+    $this->sut2 = self::$tmp . '/proj2_' . uniqid();
+
+    $this->buildMinimalSut($this->sut1);
+    $this->buildMinimalSut($this->sut2);
+
+    // Start project 1; auto-discovery picks a free port and writes it to .env.
+    $this->processCwd = $this->sut1;
+    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT READY');
+
+    $port1 = $this->readEnvPort($this->sut1);
+    $this->startedPorts[] = $port1;
+    $this->assertPortInRange($port1);
+    $this->assertProcessAnyOutputContains('http://localhost:' . $port1);
+
+    // Give the backgrounded server a moment to settle before probing.
+    sleep(1);
+
+    // Start project 2; port from project 1 is in use, so a different free
+    // port must be picked.
+    $this->processCwd = $this->sut2;
+    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT READY');
+
+    $port2 = $this->readEnvPort($this->sut2);
+    $this->startedPorts[] = $port2;
+    $this->assertPortInRange($port2);
+    $this->assertNotSame($port1, $port2, 'Second project must auto-discover a port different from the first project.');
+    $this->assertProcessAnyOutputContains('http://localhost:' . $port2);
+
+    // Stop project 2, then re-start it. Persisted .env port must be reused;
+    // auto-discovery must not run again.
+    $this->processCwd = $this->sut2;
+    $this->processRun('php', ['./.devtools/stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
+
+    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('http://localhost:' . $port2);
+    $this->assertSame($port2, $this->readEnvPort($this->sut2), '.env port must be reused after stop/restart.');
+
+    // Stop both servers and verify .env survives stop.
+    $this->processCwd = $this->sut1;
+    $this->processRun('php', ['./.devtools/stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertSame($port1, $this->readEnvPort($this->sut1), 'stop must not modify .env.');
+
+    $this->processCwd = $this->sut2;
+    $this->processRun('php', ['./.devtools/stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertSame($port2, $this->readEnvPort($this->sut2), 'stop must not modify .env.');
+  }
+
+  public function testExistingDotenvPortIsHonoredAndNotRewritten(): void {
+    $sut = self::$tmp . '/proj_preset_' . uniqid();
+    $this->buildMinimalSut($sut);
+
+    // Pre-populate .env with a specific free port choice.
+    $preset_port = $this->pickFreePortForTest();
+    file_put_contents($sut . '/.env', "WEBSERVER_PORT=" . $preset_port . "\n# user comment\n");
+    $original_env = file_get_contents($sut . '/.env');
+
+    $this->processCwd = $sut;
+    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->startedPorts[] = $preset_port;
+    $this->assertProcessAnyOutputContains('http://localhost:' . $preset_port);
+
+    // .env must be untouched: same content, same port, comment preserved.
+    $this->assertSame($original_env, file_get_contents($sut . '/.env'), '.env must not be rewritten when WEBSERVER_PORT is already set.');
+  }
+
+  protected function buildMinimalSut(string $sut): void {
+    mkdir($sut, 0755, TRUE);
+    mkdir($sut . '/.devtools', 0755, TRUE);
+    mkdir($sut . '/build/web', 0755, TRUE);
+
+    $repo_root = dirname(__DIR__, 4);
+    foreach (['helpers.php', 'start', 'stop'] as $file) {
+      copy($repo_root . '/.devtools/' . $file, $sut . '/.devtools/' . $file);
+    }
+    chmod($sut . '/.devtools/start', 0755);
+    chmod($sut . '/.devtools/stop', 0755);
+
+    file_put_contents($sut . '/build/web/.ht.router.php', "<?php return FALSE;\n");
+    file_put_contents($sut . '/build/web/index.html', "OK\n");
+  }
+
+  protected function readEnvPort(string $sut): string {
+    $contents = @file_get_contents($sut . '/.env');
+    $this->assertNotFalse($contents, 'Expected .env file to exist at ' . $sut . '/.env');
+    if (!preg_match('/^WEBSERVER_PORT=(\d+)$/m', $contents, $matches)) {
+      $this->fail('.env does not contain WEBSERVER_PORT line. Contents: ' . $contents);
+    }
+
+    return $matches[1];
+  }
+
+  protected function assertPortInRange(string $port): void {
+    $port_int = (int) $port;
+    $this->assertGreaterThanOrEqual(8000, $port_int);
+    $this->assertLessThanOrEqual(8099, $port_int);
+  }
+
+  /**
+   * Pick a free port in the 9000+ range so it does not collide with the
+   * 8000-8099 auto-discovery window used by the other test scenarios.
+   */
+  protected function pickFreePortForTest(): string {
+    for ($port = 9000; $port < 9100; $port++) {
+      $sock = @stream_socket_server(sprintf('tcp://127.0.0.1:%d', $port));
+      if ($sock !== FALSE) {
+        fclose($sock);
+
+        return (string) $port;
+      }
+    }
+
+    $this->fail('Could not find a free test port in 9000-9099.');
+  }
+
+}

--- a/.scaffold/tests/src/Functional/AutoPortDiscoveryTest.php
+++ b/.scaffold/tests/src/Functional/AutoPortDiscoveryTest.php
@@ -69,7 +69,7 @@ final class AutoPortDiscoveryTest extends UnitTestCase {
 
     // Start project 1; auto-discovery picks a free port and writes it to .env.
     $this->processCwd = $this->sut1;
-    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/start'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT READY');
 
@@ -84,7 +84,7 @@ final class AutoPortDiscoveryTest extends UnitTestCase {
     // Start project 2; port from project 1 is in use, so a different free
     // port must be picked.
     $this->processCwd = $this->sut2;
-    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/start'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT READY');
 
@@ -97,23 +97,23 @@ final class AutoPortDiscoveryTest extends UnitTestCase {
     // Stop project 2, then re-start it. Persisted .env port must be reused;
     // auto-discovery must not run again.
     $this->processCwd = $this->sut2;
-    $this->processRun('php', ['./.devtools/stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/stop'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ENVIRONMENT STOPPED');
 
-    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/start'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('http://localhost:' . $port2);
     $this->assertSame($port2, $this->readEnvPort($this->sut2), '.env port must be reused after stop/restart.');
 
     // Stop both servers and verify .env survives stop.
     $this->processCwd = $this->sut1;
-    $this->processRun('php', ['./.devtools/stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/stop'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertSame($port1, $this->readEnvPort($this->sut1), 'stop must not modify .env.');
 
     $this->processCwd = $this->sut2;
-    $this->processRun('php', ['./.devtools/stop'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/stop'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertSame($port2, $this->readEnvPort($this->sut2), 'stop must not modify .env.');
   }
@@ -128,7 +128,7 @@ final class AutoPortDiscoveryTest extends UnitTestCase {
     $original_env = file_get_contents($sut . '/.env');
 
     $this->processCwd = $sut;
-    $this->processRun('php', ['./.devtools/start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->processRun('php', ['./.devtools/start'], [], ['WEBSERVER_HOST' => 'localhost'], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->startedPorts[] = $preset_port;
     $this->assertProcessAnyOutputContains('http://localhost:' . $preset_port);

--- a/.scaffold/tests/src/Unit/HelpersDotenvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersDotenvTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\dotenv_read;
+use function DrupalExtensionScaffold\DevTools\dotenv_write_var;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for dotenv_read() and dotenv_write_var() helpers.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[CoversFunction('DrupalExtensionScaffold\DevTools\dotenv_read')]
+#[CoversFunction('DrupalExtensionScaffold\DevTools\dotenv_write_var')]
+#[Group('p0')]
+final class HelpersDotenvTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderDotenvRead')]
+  public function testDotenvRead(?string $contents, array $expected): void {
+    $file = self::$tmp . '/dotenv_read_' . uniqid();
+    if ($contents !== NULL) {
+      file_put_contents($file, $contents);
+    }
+
+    $result = dotenv_read($file);
+    $this->assertSame($expected, $result);
+  }
+
+  public static function dataProviderDotenvRead(): \Iterator {
+    yield 'file does not exist' => [
+      'contents' => NULL,
+      'expected' => [],
+    ];
+    yield 'empty file' => [
+      'contents' => '',
+      'expected' => [],
+    ];
+    yield 'single variable' => [
+      'contents' => "FOO=bar\n",
+      'expected' => ['FOO' => 'bar'],
+    ];
+    yield 'multiple variables' => [
+      'contents' => "FOO=bar\nBAZ=qux\nWEBSERVER_PORT=8123\n",
+      'expected' => ['FOO' => 'bar', 'BAZ' => 'qux', 'WEBSERVER_PORT' => '8123'],
+    ];
+    yield 'comments and blank lines are ignored' => [
+      'contents' => "# This is a comment\n\nFOO=bar\n  # indented comment\nBAZ=qux\n\n",
+      'expected' => ['FOO' => 'bar', 'BAZ' => 'qux'],
+    ];
+    yield 'whitespace around keys and values is trimmed' => [
+      'contents' => "  FOO  =  bar  \n",
+      'expected' => ['FOO' => 'bar'],
+    ];
+    yield 'value can be empty' => [
+      'contents' => "FOO=\n",
+      'expected' => ['FOO' => ''],
+    ];
+    yield 'value with equals sign preserved' => [
+      'contents' => "URL=http://example.com/?a=1&b=2\n",
+      'expected' => ['URL' => 'http://example.com/?a=1&b=2'],
+    ];
+    yield 'double quoted value is unquoted' => [
+      'contents' => "FOO=\"bar baz\"\n",
+      'expected' => ['FOO' => 'bar baz'],
+    ];
+    yield 'single quoted value is unquoted' => [
+      'contents' => "FOO='bar baz'\n",
+      'expected' => ['FOO' => 'bar baz'],
+    ];
+    yield 'mismatched quotes left intact' => [
+      'contents' => "FOO=\"bar'\n",
+      'expected' => ['FOO' => '"bar\''],
+    ];
+    yield 'lines without equals are ignored' => [
+      'contents' => "FOO=bar\ninvalid_line\nBAZ=qux\n",
+      'expected' => ['FOO' => 'bar', 'BAZ' => 'qux'],
+    ];
+    yield 'empty key is ignored' => [
+      'contents' => "=value\nFOO=bar\n",
+      'expected' => ['FOO' => 'bar'],
+    ];
+    yield 'CRLF line endings' => [
+      'contents' => "FOO=bar\r\nBAZ=qux\r\n",
+      'expected' => ['FOO' => 'bar', 'BAZ' => 'qux'],
+    ];
+    yield 'CR line endings' => [
+      'contents' => "FOO=bar\rBAZ=qux\r",
+      'expected' => ['FOO' => 'bar', 'BAZ' => 'qux'],
+    ];
+    yield 'last assignment wins for duplicate keys' => [
+      'contents' => "FOO=first\nFOO=second\n",
+      'expected' => ['FOO' => 'second'],
+    ];
+  }
+
+  public function testDotenvWriteVarCreatesFileWhenAbsent(): void {
+    $file = self::$tmp . '/dotenv_write_' . uniqid();
+    $this->assertFileDoesNotExist($file);
+
+    dotenv_write_var('FOO', 'bar', $file);
+
+    $this->assertFileExists($file);
+    $this->assertSame("FOO=bar\n", file_get_contents($file));
+  }
+
+  public function testDotenvWriteVarAppendsToExistingFile(): void {
+    $file = self::$tmp . '/dotenv_write_' . uniqid();
+    file_put_contents($file, "EXISTING=value\n");
+
+    dotenv_write_var('NEW', 'data', $file);
+
+    $this->assertSame("EXISTING=value\nNEW=data\n", file_get_contents($file));
+  }
+
+  public function testDotenvWriteVarReplacesExistingKeyInPlace(): void {
+    $file = self::$tmp . '/dotenv_write_' . uniqid();
+    file_put_contents($file, "FOO=old\nBAR=keep\n");
+
+    dotenv_write_var('FOO', 'new', $file);
+
+    $this->assertSame("FOO=new\nBAR=keep\n", file_get_contents($file));
+  }
+
+  public function testDotenvWriteVarPreservesCommentsAndBlankLines(): void {
+    $file = self::$tmp . '/dotenv_write_' . uniqid();
+    $original = "# Top comment\n\nFOO=old\n\n# Another comment\nBAR=keep\n";
+    file_put_contents($file, $original);
+
+    dotenv_write_var('FOO', 'new', $file);
+
+    $this->assertSame("# Top comment\n\nFOO=new\n\n# Another comment\nBAR=keep\n", file_get_contents($file));
+  }
+
+  public function testDotenvWriteVarReplacesOnlyFirstMatch(): void {
+    $file = self::$tmp . '/dotenv_write_' . uniqid();
+    file_put_contents($file, "FOO=first\nBAR=keep\nFOO=second\n");
+
+    dotenv_write_var('FOO', 'new', $file);
+
+    $this->assertSame("FOO=new\nBAR=keep\nFOO=second\n", file_get_contents($file));
+  }
+
+  public function testDotenvWriteVarHandlesFileWithoutTrailingNewline(): void {
+    $file = self::$tmp . '/dotenv_write_' . uniqid();
+    file_put_contents($file, 'EXISTING=value');
+
+    dotenv_write_var('NEW', 'data', $file);
+
+    $this->assertSame("EXISTING=value\nNEW=data\n", file_get_contents($file));
+  }
+
+  public function testDotenvWriteVarAndReadRoundTrip(): void {
+    $file = self::$tmp . '/dotenv_roundtrip_' . uniqid();
+
+    dotenv_write_var('WEBSERVER_PORT', '8123', $file);
+    dotenv_write_var('OTHER_VAR', 'hello', $file);
+    dotenv_write_var('WEBSERVER_PORT', '8124', $file);
+
+    $vars = dotenv_read($file);
+    $this->assertSame(['WEBSERVER_PORT' => '8124', 'OTHER_VAR' => 'hello'], $vars);
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersDotenvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersDotenvTest.php
@@ -143,13 +143,15 @@ final class HelpersDotenvTest extends UnitTestCase {
     $this->assertSame("# Top comment\n\nFOO=new\n\n# Another comment\nBAR=keep\n", file_get_contents($file));
   }
 
-  public function testDotenvWriteVarReplacesOnlyFirstMatch(): void {
+  public function testDotenvWriteVarReplacesLastMatchToAgreeWithRead(): void {
     $file = self::$tmp . '/dotenv_write_' . uniqid();
     file_put_contents($file, "FOO=first\nBAR=keep\nFOO=second\n");
 
     dotenv_write_var('FOO', 'new', $file);
 
-    $this->assertSame("FOO=new\nBAR=keep\nFOO=second\n", file_get_contents($file));
+    // The last assignment is the effective one per dotenv_read() semantics,
+    // so the write replaces it (not the first).
+    $this->assertSame("FOO=first\nBAR=keep\nFOO=new\n", file_get_contents($file));
   }
 
   public function testDotenvWriteVarHandlesFileWithoutTrailingNewline(): void {

--- a/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 /**
  * Tests for find_free_port() helper.
  *
+ * The helper probes both IPv4 (127.0.0.1) and IPv6 ([::1]) loopback
+ * interfaces per port and only returns a port that is free on both.
+ *
  * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
@@ -27,31 +30,47 @@ final class HelpersFindFreePortTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
-  public function testFirstPortIsFree(): void {
+  public function testFirstPortIsFreeOnBothStacks(): void {
     $this->mockStreamSocketServer([
-      ['port' => 8000, 'success' => TRUE],
+      ['address' => '127.0.0.1', 'port' => 8000, 'success' => TRUE],
+      ['address' => '[::1]', 'port' => 8000, 'success' => TRUE],
     ]);
 
     $port = find_free_port(8000, 100);
     $this->assertSame(8000, $port);
   }
 
-  public function testFirstFewPortsBusy(): void {
+  public function testPortBusyOnIpv4SkippedEvenIfIpv6Free(): void {
+    // 8000 fails IPv4 probe; loop breaks before probing IPv6, moves to 8001.
     $this->mockStreamSocketServer([
-      ['port' => 8000, 'success' => FALSE],
-      ['port' => 8001, 'success' => FALSE],
-      ['port' => 8002, 'success' => FALSE],
-      ['port' => 8003, 'success' => TRUE],
+      ['address' => '127.0.0.1', 'port' => 8000, 'success' => FALSE],
+      ['address' => '127.0.0.1', 'port' => 8001, 'success' => TRUE],
+      ['address' => '[::1]', 'port' => 8001, 'success' => TRUE],
     ]);
 
     $port = find_free_port(8000, 100);
-    $this->assertSame(8003, $port);
+    $this->assertSame(8001, $port);
+  }
+
+  public function testPortBusyOnIpv6OnlyIsRejected(): void {
+    // 8000 passes IPv4 but fails IPv6 (real scenario: PHP -S already on
+    // [::1]:8000). 8001 is free on both.
+    $this->mockStreamSocketServer([
+      ['address' => '127.0.0.1', 'port' => 8000, 'success' => TRUE],
+      ['address' => '[::1]', 'port' => 8000, 'success' => FALSE],
+      ['address' => '127.0.0.1', 'port' => 8001, 'success' => TRUE],
+      ['address' => '[::1]', 'port' => 8001, 'success' => TRUE],
+    ]);
+
+    $port = find_free_port(8000, 100);
+    $this->assertSame(8001, $port);
   }
 
   public function testCustomStartingPort(): void {
     $this->mockStreamSocketServer([
-      ['port' => 9000, 'success' => FALSE],
-      ['port' => 9001, 'success' => TRUE],
+      ['address' => '127.0.0.1', 'port' => 9000, 'success' => FALSE],
+      ['address' => '127.0.0.1', 'port' => 9001, 'success' => TRUE],
+      ['address' => '[::1]', 'port' => 9001, 'success' => TRUE],
     ]);
 
     $port = find_free_port(9000, 100);
@@ -106,7 +125,8 @@ final class HelpersFindFreePortTest extends UnitTestCase {
   public function testAllPortsBusyCallsFail(): void {
     $responses = [];
     for ($p = 8000; $p < 8005; $p++) {
-      $responses[] = ['port' => $p, 'success' => FALSE];
+      // First probe (IPv4) fails; loop moves on to next port.
+      $responses[] = ['address' => '127.0.0.1', 'port' => $p, 'success' => FALSE];
     }
     $this->mockStreamSocketServer($responses);
     $this->mockQuit(1);
@@ -126,9 +146,9 @@ final class HelpersFindFreePortTest extends UnitTestCase {
   /**
    * Mock stream_socket_server() to return FALSE or a resource per call.
    *
-   * @param array<int, array{port: int, success: bool}> $responses
-   *   Ordered list of expected calls. Each entry is the port to expect and
-   *   whether the bind should succeed.
+   * @param array<int, array{address: string, port: int, success: bool}> $responses
+   *   Ordered list of expected calls. Each entry is the address and port
+   *   to expect and whether the bind should succeed.
    */
   protected function mockStreamSocketServer(array $responses): void {
     $this->addMockResponses('stream_socket_server', $responses);
@@ -139,10 +159,10 @@ final class HelpersFindFreePortTest extends UnitTestCase {
 
     $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address, &$errno = NULL, &$errstr = NULL) {
       $response = $this->getNextMockResponse('stream_socket_server');
-      if (!is_int($response['port']) || !is_bool($response['success'])) {
-        throw new \RuntimeException('Mocked stream_socket_server response must have int "port" and bool "success".');
+      if (!is_string($response['address']) || !is_int($response['port']) || !is_bool($response['success'])) {
+        throw new \RuntimeException('Mocked stream_socket_server response must have string "address", int "port" and bool "success".');
       }
-      $expected = sprintf('tcp://127.0.0.1:%d', $response['port']);
+      $expected = sprintf('tcp://%s:%d', $response['address'], $response['port']);
       if ($address !== $expected) {
         throw new \RuntimeException(sprintf('stream_socket_server() called with unexpected address. Expected "%s", got "%s".', $expected, $address));
       }
@@ -154,7 +174,6 @@ final class HelpersFindFreePortTest extends UnitTestCase {
         return FALSE;
       }
 
-      // Return a real stream that the caller can fclose() safely.
       $stream = fopen('php://memory', 'r');
       if ($stream === FALSE) {
         throw new \RuntimeException('Unable to open php://memory stream for mock.');

--- a/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\find_free_port;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for find_free_port() helper.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[CoversFunction('DrupalExtensionScaffold\DevTools\find_free_port')]
+#[RunTestsInSeparateProcesses]
+#[Group('p0')]
+final class HelpersFindFreePortTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testFirstPortIsFree(): void {
+    $this->mockStreamSocketServer([
+      ['port' => 8000, 'success' => TRUE],
+    ]);
+
+    $port = find_free_port(8000, 100);
+    $this->assertSame(8000, $port);
+  }
+
+  public function testFirstFewPortsBusy(): void {
+    $this->mockStreamSocketServer([
+      ['port' => 8000, 'success' => FALSE],
+      ['port' => 8001, 'success' => FALSE],
+      ['port' => 8002, 'success' => FALSE],
+      ['port' => 8003, 'success' => TRUE],
+    ]);
+
+    $port = find_free_port(8000, 100);
+    $this->assertSame(8003, $port);
+  }
+
+  public function testCustomStartingPort(): void {
+    $this->mockStreamSocketServer([
+      ['port' => 9000, 'success' => FALSE],
+      ['port' => 9001, 'success' => TRUE],
+    ]);
+
+    $port = find_free_port(9000, 100);
+    $this->assertSame(9001, $port);
+  }
+
+  public function testAllPortsBusyCallsFail(): void {
+    $responses = [];
+    for ($p = 8000; $p < 8005; $p++) {
+      $responses[] = ['port' => $p, 'success' => FALSE];
+    }
+    $this->mockStreamSocketServer($responses);
+    $this->mockQuit(1);
+
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      find_free_port(8000, 5);
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Unable to find a free port in range 8000-8004', $output);
+    }
+  }
+
+  /**
+   * Mock stream_socket_server() to return FALSE or a resource per call.
+   *
+   * @param array<int, array{port: int, success: bool}> $responses
+   *   Ordered list of expected calls. Each entry is the port to expect and
+   *   whether the bind should succeed.
+   */
+  protected function mockStreamSocketServer(array $responses): void {
+    $this->addMockResponses('stream_socket_server', $responses);
+
+    if (isset($this->mocks['stream_socket_server'])) {
+      return;
+    }
+
+    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address, &$errno = NULL, &$errstr = NULL) {
+      $response = $this->getNextMockResponse('stream_socket_server');
+      $expected = sprintf('tcp://127.0.0.1:%d', $response['port']);
+      if ($address !== $expected) {
+        throw new \RuntimeException(sprintf('stream_socket_server() called with unexpected address. Expected "%s", got "%s".', $expected, $address));
+      }
+
+      if (!$response['success']) {
+        $errno = 48;
+        $errstr = 'Address already in use';
+
+        return FALSE;
+      }
+
+      // Return a real stream that the caller can fclose() safely.
+      $stream = fopen('php://memory', 'r');
+      if ($stream === FALSE) {
+        throw new \RuntimeException('Unable to open php://memory stream for mock.');
+      }
+
+      return $stream;
+    });
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
@@ -13,8 +13,9 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 /**
  * Tests for find_free_port() helper.
  *
- * The helper probes both IPv4 (127.0.0.1) and IPv6 ([::1]) loopback
- * interfaces per port and only returns a port that is free on both.
+ * The helper uses a client connect probe (rather than a server bind probe)
+ * so the test mocks stream_socket_client to simulate listeners being
+ * present or absent on each candidate port.
  *
  * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
@@ -30,47 +31,33 @@ final class HelpersFindFreePortTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
-  public function testFirstPortIsFreeOnBothStacks(): void {
-    $this->mockStreamSocketServer([
-      ['address' => '127.0.0.1', 'port' => 8000, 'success' => TRUE],
-      ['address' => '[::1]', 'port' => 8000, 'success' => TRUE],
+  public function testFirstPortIsFree(): void {
+    // Connect refused on port 8000 = port is free.
+    $this->mockStreamSocketClient([
+      ['port' => 8000, 'listening' => FALSE],
     ]);
 
     $port = find_free_port(8000, 100);
     $this->assertSame(8000, $port);
   }
 
-  public function testPortBusyOnIpv4SkippedEvenIfIpv6Free(): void {
-    // 8000 fails IPv4 probe; loop breaks before probing IPv6, moves to 8001.
-    $this->mockStreamSocketServer([
-      ['address' => '127.0.0.1', 'port' => 8000, 'success' => FALSE],
-      ['address' => '127.0.0.1', 'port' => 8001, 'success' => TRUE],
-      ['address' => '[::1]', 'port' => 8001, 'success' => TRUE],
+  public function testFirstFewPortsBusy(): void {
+    // 8000-8002 listening (in use), 8003 refused (free).
+    $this->mockStreamSocketClient([
+      ['port' => 8000, 'listening' => TRUE],
+      ['port' => 8001, 'listening' => TRUE],
+      ['port' => 8002, 'listening' => TRUE],
+      ['port' => 8003, 'listening' => FALSE],
     ]);
 
     $port = find_free_port(8000, 100);
-    $this->assertSame(8001, $port);
-  }
-
-  public function testPortBusyOnIpv6OnlyIsRejected(): void {
-    // 8000 passes IPv4 but fails IPv6 (real scenario: PHP -S already on
-    // [::1]:8000). 8001 is free on both.
-    $this->mockStreamSocketServer([
-      ['address' => '127.0.0.1', 'port' => 8000, 'success' => TRUE],
-      ['address' => '[::1]', 'port' => 8000, 'success' => FALSE],
-      ['address' => '127.0.0.1', 'port' => 8001, 'success' => TRUE],
-      ['address' => '[::1]', 'port' => 8001, 'success' => TRUE],
-    ]);
-
-    $port = find_free_port(8000, 100);
-    $this->assertSame(8001, $port);
+    $this->assertSame(8003, $port);
   }
 
   public function testCustomStartingPort(): void {
-    $this->mockStreamSocketServer([
-      ['address' => '127.0.0.1', 'port' => 9000, 'success' => FALSE],
-      ['address' => '127.0.0.1', 'port' => 9001, 'success' => TRUE],
-      ['address' => '[::1]', 'port' => 9001, 'success' => TRUE],
+    $this->mockStreamSocketClient([
+      ['port' => 9000, 'listening' => TRUE],
+      ['port' => 9001, 'listening' => FALSE],
     ]);
 
     $port = find_free_port(9000, 100);
@@ -125,10 +112,9 @@ final class HelpersFindFreePortTest extends UnitTestCase {
   public function testAllPortsBusyCallsFail(): void {
     $responses = [];
     for ($p = 8000; $p < 8005; $p++) {
-      // First probe (IPv4) fails; loop moves on to next port.
-      $responses[] = ['address' => '127.0.0.1', 'port' => $p, 'success' => FALSE];
+      $responses[] = ['port' => $p, 'listening' => TRUE];
     }
-    $this->mockStreamSocketServer($responses);
+    $this->mockStreamSocketClient($responses);
     $this->mockQuit(1);
 
     $this->expectException(QuitErrorException::class);
@@ -144,32 +130,33 @@ final class HelpersFindFreePortTest extends UnitTestCase {
   }
 
   /**
-   * Mock stream_socket_server() to return FALSE or a resource per call.
+   * Mock stream_socket_client() to simulate per-port connect outcomes.
    *
-   * @param array<int, array{address: string, port: int, success: bool}> $responses
-   *   Ordered list of expected calls. Each entry is the address and port
-   *   to expect and whether the bind should succeed.
+   * @param array<int, array{port: int, listening: bool}> $responses
+   *   Ordered list of expected calls. listening=TRUE returns a resource
+   *   (connect succeeded => port in use); listening=FALSE returns FALSE
+   *   (connect refused => port free).
    */
-  protected function mockStreamSocketServer(array $responses): void {
-    $this->addMockResponses('stream_socket_server', $responses);
+  protected function mockStreamSocketClient(array $responses): void {
+    $this->addMockResponses('stream_socket_client', $responses);
 
-    if (isset($this->mocks['stream_socket_server'])) {
+    if (isset($this->mocks['stream_socket_client'])) {
       return;
     }
 
-    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address, &$errno = NULL, &$errstr = NULL) {
-      $response = $this->getNextMockResponse('stream_socket_server');
-      if (!is_string($response['address']) || !is_int($response['port']) || !is_bool($response['success'])) {
-        throw new \RuntimeException('Mocked stream_socket_server response must have string "address", int "port" and bool "success".');
+    $this->registerMock('stream_socket_client', 'DrupalExtensionScaffold\\DevTools', function (string $address, &$errno = NULL, &$errstr = NULL, ?float $timeout = NULL) {
+      $response = $this->getNextMockResponse('stream_socket_client');
+      if (!is_int($response['port']) || !is_bool($response['listening'])) {
+        throw new \RuntimeException('Mocked stream_socket_client response must have int "port" and bool "listening".');
       }
-      $expected = sprintf('tcp://%s:%d', $response['address'], $response['port']);
+      $expected = sprintf('tcp://localhost:%d', $response['port']);
       if ($address !== $expected) {
-        throw new \RuntimeException(sprintf('stream_socket_server() called with unexpected address. Expected "%s", got "%s".', $expected, $address));
+        throw new \RuntimeException(sprintf('stream_socket_client() called with unexpected address. Expected "%s", got "%s".', $expected, $address));
       }
 
-      if (!$response['success']) {
-        $errno = 48;
-        $errstr = 'Address already in use';
+      if (!$response['listening']) {
+        $errno = 61;
+        $errstr = 'Connection refused';
 
         return FALSE;
       }

--- a/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
@@ -139,6 +139,9 @@ final class HelpersFindFreePortTest extends UnitTestCase {
 
     $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address, &$errno = NULL, &$errstr = NULL) {
       $response = $this->getNextMockResponse('stream_socket_server');
+      if (!is_int($response['port']) || !is_bool($response['success'])) {
+        throw new \RuntimeException('Mocked stream_socket_server response must have int "port" and bool "success".');
+      }
       $expected = sprintf('tcp://127.0.0.1:%d', $response['port']);
       if ($address !== $expected) {
         throw new \RuntimeException(sprintf('stream_socket_server() called with unexpected address. Expected "%s", got "%s".', $expected, $address));

--- a/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
@@ -58,6 +58,51 @@ final class HelpersFindFreePortTest extends UnitTestCase {
     $this->assertSame(9001, $port);
   }
 
+  public function testInvalidStartPortBelowRangeFails(): void {
+    $this->mockQuit(1);
+
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      find_free_port(0, 100);
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Start port must be between 1 and 65535', $output);
+    }
+  }
+
+  public function testInvalidStartPortAboveRangeFails(): void {
+    $this->mockQuit(1);
+
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      find_free_port(70000, 100);
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Start port must be between 1 and 65535', $output);
+    }
+  }
+
+  public function testInvalidMaxAttemptsFails(): void {
+    $this->mockQuit(1);
+
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      find_free_port(8000, 0);
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Max attempts must be a positive integer', $output);
+    }
+  }
+
   public function testAllPortsBusyCallsFail(): void {
     $responses = [];
     for ($p = 8000; $p < 8005; $p++) {

--- a/.scaffold/tests/src/Unit/HelpersValidatePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersValidatePortTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\validate_port_or_fail;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for validate_port_or_fail() helper.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[CoversFunction('DrupalExtensionScaffold\DevTools\validate_port_or_fail')]
+#[RunTestsInSeparateProcesses]
+#[Group('p0')]
+final class HelpersValidatePortTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderValidPortDoesNotFail')]
+  public function testValidPortDoesNotFail(string $value): void {
+    validate_port_or_fail($value, 'WEBSERVER_PORT');
+    $this->expectNotToPerformAssertions();
+  }
+
+  public static function dataProviderValidPortDoesNotFail(): \Iterator {
+    yield 'lowest valid' => ['1'];
+    yield 'common default' => ['8000'];
+    yield 'highest valid' => ['65535'];
+    yield 'mid range' => ['12345'];
+  }
+
+  #[DataProvider('dataProviderInvalidPortFails')]
+  public function testInvalidPortFails(string $value): void {
+    $this->mockQuit(1);
+
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      validate_port_or_fail($value, 'WEBSERVER_PORT');
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Invalid WEBSERVER_PORT', $output);
+      $this->assertStringContainsString('Expected integer in range 1-65535', $output);
+    }
+  }
+
+  public static function dataProviderInvalidPortFails(): \Iterator {
+    yield 'empty string' => [''];
+    yield 'zero' => ['0'];
+    yield 'too high' => ['65536'];
+    yield 'negative' => ['-1'];
+    yield 'non-numeric' => ['abc'];
+    yield 'mixed alphanumeric' => ['80a0'];
+    yield 'with shell metacharacter' => ['8000; rm -rf /'];
+    yield 'with whitespace' => ['8000 '];
+    yield 'decimal' => ['80.0'];
+  }
+
+  public function testUsesProvidedSourceNameInErrorMessage(): void {
+    $this->mockQuit(1);
+
+    $this->expectException(QuitErrorException::class);
+    ob_start();
+    try {
+      validate_port_or_fail('bogus', 'CUSTOM_PORT_VAR');
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Invalid CUSTOM_PORT_VAR', $output);
+    }
+  }
+
+}

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -215,7 +215,7 @@ final class ProvisionTest extends UnitTestCase {
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
     $this->registerMock('glob', 'DrupalExtensionScaffold\\DevTools', fn(): array => [$extension_name . '.info.yml']);
 
-    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', function (string $file) use ($info_content) {
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', function (string $file) use ($info_content): string {
       if (str_ends_with($file, '.info.yml')) {
         return $info_content;
       }

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -205,4 +205,52 @@ final class ProvisionTest extends UnitTestCase {
     ];
   }
 
+  public function testProvisionReadsPortFromDotenvWhenEnvUnset(): void {
+    $extension_name = 'test_extension';
+    $info_content = "name: Test\ntype: module\n";
+    $cwd = '/test/project';
+    $expected_host = 'localhost';
+    $expected_port = '8123';
+
+    $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
+    $this->registerMock('glob', 'DrupalExtensionScaffold\\DevTools', fn(): array => [$extension_name . '.info.yml']);
+
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', function (string $file) use ($info_content) {
+      if (str_ends_with($file, '.info.yml')) {
+        return $info_content;
+      }
+      if ($file === '.env') {
+        return "WEBSERVER_PORT=8123\n";
+      }
+      if ($file === 'composer.json') {
+        return json_encode(['suggest' => []], JSON_THROW_ON_ERROR);
+      }
+      if (str_starts_with($file, 'http://')) {
+        return '<html></html>';
+      }
+
+      return '';
+    });
+
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
+
+    $prefix = self::drushPrefix($cwd);
+    $db_file = '/tmp/site_' . $extension_name . '.sqlite';
+    $this->mockPassthruMultiple([
+      ['cmd' => $prefix . 'status --field=db-status', 'output' => ''],
+      ['cmd' => $prefix . sprintf('site-install %s -y --db-url="sqlite://localhost/%s" --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg('standard'), $db_file)],
+      ['cmd' => $prefix . 'status'],
+      ['cmd' => $prefix . 'pm:enable ' . escapeshellarg($extension_name)],
+      ['cmd' => $prefix . 'cr'],
+      ['cmd' => $prefix . sprintf('uli -l http://%s:%s --no-browser', $expected_host, $expected_port), 'output' => 'http://' . $expected_host . ':' . $expected_port . '/user/reset/1/abc/login'],
+    ]);
+
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/provision';
+    $output = ob_get_clean();
+
+    $this->assertIsString($output);
+    $this->assertStringContainsString('http://' . $expected_host . ':' . $expected_port, $output);
+  }
+
 }

--- a/.scaffold/tests/src/Unit/StartTest.php
+++ b/.scaffold/tests/src/Unit/StartTest.php
@@ -74,8 +74,8 @@ final class StartTest extends UnitTestCase {
   }
 
   public static function dataProviderStartSuccess(): \Iterator {
-    yield 'default config' => [
-      'env' => [],
+    yield 'explicit default port' => [
+      'env' => ['WEBSERVER_PORT' => '8000'],
       'expected_host' => 'localhost',
       'expected_port' => '8000',
       'expected_timeout' => 5,
@@ -87,7 +87,7 @@ final class StartTest extends UnitTestCase {
       'expected_timeout' => 5,
     ];
     yield 'custom timeout' => [
-      'env' => ['WEBSERVER_WAIT_TIMEOUT' => '10'],
+      'env' => ['WEBSERVER_PORT' => '8000', 'WEBSERVER_WAIT_TIMEOUT' => '10'],
       'expected_host' => 'localhost',
       'expected_port' => '8000',
       'expected_timeout' => 10,
@@ -95,6 +95,7 @@ final class StartTest extends UnitTestCase {
   }
 
   public function testStartServerWith302Response(): void {
+    $this->envSet('WEBSERVER_PORT', '8000');
     $cwd = '/test/project';
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
@@ -129,6 +130,7 @@ final class StartTest extends UnitTestCase {
   }
 
   public function testStartFsockopenFailure(): void {
+    $this->envSet('WEBSERVER_PORT', '8000');
     $cwd = '/test/project';
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
@@ -166,6 +168,7 @@ final class StartTest extends UnitTestCase {
   }
 
   public function testStartFsockopenFailureNoLog(): void {
+    $this->envSet('WEBSERVER_PORT', '8000');
     $cwd = '/test/project';
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
@@ -200,6 +203,7 @@ final class StartTest extends UnitTestCase {
   }
 
   public function testStartGetHeadersFailure(): void {
+    $this->envSet('WEBSERVER_PORT', '8000');
     $cwd = '/test/project';
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
@@ -243,6 +247,7 @@ final class StartTest extends UnitTestCase {
   }
 
   public function testStartGetHeadersNon200Non302(): void {
+    $this->envSet('WEBSERVER_PORT', '8000');
     $cwd = '/test/project';
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
@@ -284,7 +289,124 @@ final class StartTest extends UnitTestCase {
     fclose($fp);
   }
 
+  public function testStartReadsPortFromDotenvAndDoesNotRewrite(): void {
+    $cwd = '/test/project';
+
+    $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
+
+    // .env file exists with WEBSERVER_PORT=8123.
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBSERVER_PORT=8123\n");
+
+    // file_put_contents must not be called - we read from .env, do not rewrite.
+    $put_called = FALSE;
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function () use (&$put_called) {
+      $put_called = TRUE;
+
+      return FALSE;
+    });
+
+    // stream_socket_server must not be called - we read from .env, do not discover.
+    $stream_called = FALSE;
+    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function () use (&$stream_called) {
+      $stream_called = TRUE;
+
+      return FALSE;
+    });
+
+    $this->mockPassthruMultiple([
+      ['cmd' => "lsof -ti:'8123' | xargs kill -9 2>/dev/null"],
+      ['cmd' => sprintf('nohup php -S localhost:8123 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+    ]);
+
+    $this->mockSleep();
+
+    $fp = fopen('php://memory', 'r');
+    $this->assertNotFalse($fp);
+    $this->registerMock('fsockopen', 'DrupalExtensionScaffold\\DevTools', fn() => $fp);
+    $this->registerMock('fclose', 'DrupalExtensionScaffold\\DevTools', fn(): true => TRUE);
+
+    $context = stream_context_create();
+    $this->registerMock('stream_context_create', 'DrupalExtensionScaffold\\DevTools', fn() => $context);
+    $this->registerMock('get_headers', 'DrupalExtensionScaffold\\DevTools', fn(): array => ['HTTP/1.1 200 OK']);
+
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/start';
+    $output = ob_get_clean();
+
+    $this->assertIsString($output);
+    $this->assertStringContainsString('http://localhost:8123', $output);
+    $this->assertFalse($put_called, 'file_put_contents should not be called when .env already has WEBSERVER_PORT.');
+    $this->assertFalse($stream_called, 'stream_socket_server should not be called when .env already has WEBSERVER_PORT.');
+
+    fclose($fp);
+  }
+
+  public function testStartAutoDiscoversPortAndPersistsToDotenv(): void {
+    $cwd = '/test/project';
+
+    $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
+
+    // .env file does not exist.
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+
+    // First port (8000) busy, second port (8001) free.
+    $port_attempts = 0;
+    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address) use (&$port_attempts) {
+      $port_attempts++;
+      if (str_contains($address, ':8000')) {
+        return FALSE;
+      }
+      if (str_contains($address, ':8001')) {
+        return fopen('php://memory', 'r');
+      }
+
+      return FALSE;
+    });
+
+    // file_put_contents must be called to persist the discovered port.
+    $persisted_port = NULL;
+    $persisted_file = NULL;
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function (string $file, string $contents) use (&$persisted_port, &$persisted_file): int {
+      $persisted_file = $file;
+      if (preg_match('/WEBSERVER_PORT=(\d+)/', $contents, $matches)) {
+        $persisted_port = $matches[1];
+      }
+
+      return strlen($contents);
+    });
+
+    $this->mockPassthruMultiple([
+      ['cmd' => "lsof -ti:'8001' | xargs kill -9 2>/dev/null"],
+      ['cmd' => sprintf('nohup php -S localhost:8001 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+    ]);
+
+    $this->mockSleep();
+
+    $fp = fopen('php://memory', 'r');
+    $this->assertNotFalse($fp);
+    $this->registerMock('fsockopen', 'DrupalExtensionScaffold\\DevTools', fn() => $fp);
+    $this->registerMock('fclose', 'DrupalExtensionScaffold\\DevTools', fn(): true => TRUE);
+
+    $context = stream_context_create();
+    $this->registerMock('stream_context_create', 'DrupalExtensionScaffold\\DevTools', fn() => $context);
+    $this->registerMock('get_headers', 'DrupalExtensionScaffold\\DevTools', fn(): array => ['HTTP/1.1 200 OK']);
+
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/start';
+    $output = ob_get_clean();
+
+    $this->assertIsString($output);
+    $this->assertStringContainsString('http://localhost:8001', $output);
+    $this->assertSame('.env', $persisted_file);
+    $this->assertSame('8001', $persisted_port);
+    $this->assertSame(2, $port_attempts);
+
+    fclose($fp);
+  }
+
   public function testStartGetHeadersEmptyArray(): void {
+    $this->envSet('WEBSERVER_PORT', '8000');
     $cwd = '/test/project';
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);

--- a/.scaffold/tests/src/Unit/StartTest.php
+++ b/.scaffold/tests/src/Unit/StartTest.php
@@ -352,15 +352,12 @@ final class StartTest extends UnitTestCase {
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
 
     // First port (8000) busy, second port (8001) free.
-    // find_free_port probes both 127.0.0.1 and [::1] per port. 8000 IPv4
-    // is busy (loop breaks before [::1] probe), 8001 free on both.
+    // find_free_port uses stream_socket_client probe. Connect to 8000
+    // succeeds (port in use); connect to 8001 refused (port free).
     $port_attempts = 0;
-    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address) use (&$port_attempts) {
+    $this->registerMock('stream_socket_client', 'DrupalExtensionScaffold\\DevTools', function (string $address) use (&$port_attempts) {
       $port_attempts++;
-      if (str_contains($address, '127.0.0.1:8000')) {
-        return FALSE;
-      }
-      if (str_contains($address, ':8001')) {
+      if (str_contains($address, ':8000')) {
         return fopen('php://memory', 'r');
       }
 
@@ -403,9 +400,8 @@ final class StartTest extends UnitTestCase {
     $this->assertStringContainsString('http://localhost:8001', $output);
     $this->assertSame('.env', $persisted_file);
     $this->assertSame('8001', $persisted_port);
-    // 3 probe calls: 127.0.0.1:8000 (FALSE), 127.0.0.1:8001 (success),
-    // [::1]:8001 (success).
-    $this->assertSame(3, $port_attempts);
+    // 2 probe calls: localhost:8000 (in use), localhost:8001 (free).
+    $this->assertSame(2, $port_attempts);
 
     fclose($fp);
   }

--- a/.scaffold/tests/src/Unit/StartTest.php
+++ b/.scaffold/tests/src/Unit/StartTest.php
@@ -300,15 +300,16 @@ final class StartTest extends UnitTestCase {
 
     // file_put_contents must not be called - we read from .env, do not rewrite.
     $put_called = FALSE;
-    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function () use (&$put_called) {
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function () use (&$put_called): false {
       $put_called = TRUE;
 
       return FALSE;
     });
 
-    // stream_socket_server must not be called - we read from .env, do not discover.
+    // stream_socket_server must not be called - we read from .env, do not
+    // discover.
     $stream_called = FALSE;
-    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function () use (&$stream_called) {
+    $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function () use (&$stream_called): false {
       $stream_called = TRUE;
 
       return FALSE;

--- a/.scaffold/tests/src/Unit/StartTest.php
+++ b/.scaffold/tests/src/Unit/StartTest.php
@@ -38,7 +38,7 @@ final class StartTest extends UnitTestCase {
     // Mock passthru: 1) kill existing, 2) start server.
     $this->mockPassthruMultiple([
       ['cmd' => sprintf("lsof -ti:%s | xargs kill -9 2>/dev/null", escapeshellarg($expected_port))],
-      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $expected_host, $expected_port, $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg($expected_host), escapeshellarg($expected_port), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -102,7 +102,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8000 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8000'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -137,7 +137,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8000 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8000'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -175,7 +175,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8000 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8000'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -210,7 +210,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8000 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8000'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -254,7 +254,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8000 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8000'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -317,7 +317,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8123' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8123 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8123'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -352,10 +352,12 @@ final class StartTest extends UnitTestCase {
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
 
     // First port (8000) busy, second port (8001) free.
+    // find_free_port probes both 127.0.0.1 and [::1] per port. 8000 IPv4
+    // is busy (loop breaks before [::1] probe), 8001 free on both.
     $port_attempts = 0;
     $this->registerMock('stream_socket_server', 'DrupalExtensionScaffold\\DevTools', function (string $address) use (&$port_attempts) {
       $port_attempts++;
-      if (str_contains($address, ':8000')) {
+      if (str_contains($address, '127.0.0.1:8000')) {
         return FALSE;
       }
       if (str_contains($address, ':8001')) {
@@ -379,7 +381,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8001' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8001 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8001'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();
@@ -401,7 +403,9 @@ final class StartTest extends UnitTestCase {
     $this->assertStringContainsString('http://localhost:8001', $output);
     $this->assertSame('.env', $persisted_file);
     $this->assertSame('8001', $persisted_port);
-    $this->assertSame(2, $port_attempts);
+    // 3 probe calls: 127.0.0.1:8000 (FALSE), 127.0.0.1:8001 (success),
+    // [::1]:8001 (success).
+    $this->assertSame(3, $port_attempts);
 
     fclose($fp);
   }
@@ -414,7 +418,7 @@ final class StartTest extends UnitTestCase {
 
     $this->mockPassthruMultiple([
       ['cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null"],
-      ['cmd' => sprintf('nohup php -S localhost:8000 -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $cwd, $cwd)],
+      ['cmd' => sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg('localhost'), escapeshellarg('8000'), escapeshellarg($cwd), escapeshellarg($cwd))],
     ]);
 
     $this->mockSleep();

--- a/.scaffold/tests/src/Unit/StopTest.php
+++ b/.scaffold/tests/src/Unit/StopTest.php
@@ -37,8 +37,8 @@ final class StopTest extends UnitTestCase {
 
     $this->assertIsString($output);
     $this->assertStringContainsString('STOP ENVIRONMENT', $output);
-    $this->assertStringContainsString('Stopping previously started services', $output);
-    $this->assertStringContainsString('Services stopped', $output);
+    $this->assertStringContainsString('Stopping previously started services on port 8000', $output);
+    $this->assertStringContainsString('Services stopped on port 8000', $output);
     $this->assertStringContainsString('ENVIRONMENT STOPPED', $output);
   }
 
@@ -56,6 +56,7 @@ final class StopTest extends UnitTestCase {
 
     $this->assertIsString($output);
     $this->assertStringContainsString('STOP ENVIRONMENT', $output);
+    $this->assertStringContainsString('Services stopped on port 9000', $output);
     $this->assertStringContainsString('ENVIRONMENT STOPPED', $output);
   }
 
@@ -74,6 +75,7 @@ final class StopTest extends UnitTestCase {
     $output = ob_get_clean();
 
     $this->assertIsString($output);
+    $this->assertStringContainsString('Services stopped on port 8123', $output);
     $this->assertStringContainsString('ENVIRONMENT STOPPED', $output);
   }
 

--- a/.scaffold/tests/src/Unit/StopTest.php
+++ b/.scaffold/tests/src/Unit/StopTest.php
@@ -22,7 +22,10 @@ final class StopTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
-  public function testStopDefaultPort(): void {
+  public function testStopDefaultPortWhenNoEnvAndNoDotenv(): void {
+    // .env file does not exist - fall back to '8000'.
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+
     $this->mockPassthru([
       'cmd' => "lsof -ti:'8000' | xargs kill -9 2>/dev/null",
     ]);
@@ -39,7 +42,7 @@ final class StopTest extends UnitTestCase {
     $this->assertStringContainsString('ENVIRONMENT STOPPED', $output);
   }
 
-  public function testStopCustomPort(): void {
+  public function testStopCustomPortFromEnv(): void {
     $this->envSet('WEBSERVER_PORT', '9000');
 
     $this->mockPassthru([
@@ -53,6 +56,24 @@ final class StopTest extends UnitTestCase {
 
     $this->assertIsString($output);
     $this->assertStringContainsString('STOP ENVIRONMENT', $output);
+    $this->assertStringContainsString('ENVIRONMENT STOPPED', $output);
+  }
+
+  public function testStopReadsPortFromDotenvWhenEnvUnset(): void {
+    // .env contains WEBSERVER_PORT=8123; env var is unset.
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBSERVER_PORT=8123\n");
+
+    $this->mockPassthru([
+      'cmd' => "lsof -ti:'8123' | xargs kill -9 2>/dev/null",
+    ]);
+    $this->mockSleep();
+
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/stop';
+    $output = ob_get_clean();
+
+    $this->assertIsString($output);
     $this->assertStringContainsString('ENVIRONMENT STOPPED', $output);
   }
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 SHELL=/bin/bash
+
+# Load variables from .env if present and export them to recipe shells. The
+# leading '-' on -include suppresses errors when the file does not exist.
+-include .env
+export
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,29 @@ The `provision` command installs the Drupal website from the `standard`
 profile with your extension (and any `suggest`'ed extensions) enabled. The
 profile can be changed by setting the `DRUPAL_PROFILE` environment variable.
 
-The website will be available at http://localhost:8000. The hostname and port
-can be changed by setting the `WEBSERVER_HOST` and `WEBSERVER_PORT` environment
-variables.
+The website will be available at http://localhost:8000 by default. The
+hostname can be changed by setting the `WEBSERVER_HOST` environment variable.
+
+#### Webserver port
+
+The `WEBSERVER_PORT` is resolved with the following precedence:
+
+1. **`WEBSERVER_PORT` exported in the shell** - used as-is. Useful for one-off
+   runs: `WEBSERVER_PORT=9000 make build`.
+2. **`WEBSERVER_PORT` line in the project-root `.env` file** - used as-is.
+   The `start` script does not modify `.env` when this entry is already
+   present, so the same port is reused across `start`, `stop`, `provision`,
+   `drush` and `login` commands.
+3. **Neither is set** - the `start` script discovers the first free port in
+   the range `8000-8099` and writes it to `.env` as `WEBSERVER_PORT=NNNN`.
+   Subsequent commands read this value from `.env`.
+
+The `.env` file is loaded automatically by `make` (via `-include .env` and
+`export`) and `ahoy` (via the native `env:` field), so all wrapper commands
+see the resolved port without further configuration. The file is gitignored.
+
+To force re-discovery, delete `.env` (or just the `WEBSERVER_PORT` line in
+it) and re-run `make start` / `ahoy start`.
 
 An SQLite database is created in `/tmp/site_[EXTENSION_NAME].sqlite` file.
 You can browse the contents of the created SQLite database using


### PR DESCRIPTION
Closes #362

## Summary

The development webserver no longer needs a manually chosen `WEBSERVER_PORT`. `start` resolves the port from (1) an exported env var, (2) a `.env` entry, or (3) auto-discovery, persists the discovered value back to `.env`, and reuses it on subsequent runs. `stop` now reports which port it terminated. `make` and `ahoy` both pick up the `.env` so wrapper commands like `drush` and `login` see the same port without further configuration.

## How it works

### 1. Port resolution flow (`.devtools/start`)

```
                  .devtools/start invoked
                          │
                          ▼
              ┌───────────────────────────┐
              │ WEBSERVER_PORT env var?   │
              └─────────────┬─────────────┘
                yes         │         no
                ▼           │         ▼
            use it          │   ┌────────────────────────────┐
            (no .env        │   │ .env has WEBSERVER_PORT?   │
             touched)       │   └────────────┬───────────────┘
                │           │       yes      │       no
                │           │       ▼        │       ▼
                │           │     use it     │   ┌──────────────────────────┐
                │           │     (no .env   │   │ find_free_port():        │
                │           │      touched)  │   │   start at 8000          │
                │           │       │        │   │   scan up to 100 ports   │
                │           │       │        │   │   first port that is     │
                │           │       │        │   │   not currently listening│
                │           │       │        │   └────────────┬─────────────┘
                │           │       │        │                ▼
                │           │       │        │   dotenv_write_var(
                │           │       │        │     'WEBSERVER_PORT',
                │           │       │        │      <found port>)
                │           │       │        │                │
                ▼           ▼       ▼        ▼                ▼
                ┌────────────────────────────────────────────────┐
                │             start PHP server on $port          │
                └────────────────────────────────────────────────┘
```

Cases in order of precedence:

| `WEBSERVER_PORT` env | `.env` `WEBSERVER_PORT` | Behavior | `.env` touched? |
|---|---|---|---|
| set | (any) | use the env value | no |
| unset | set (non-empty) | use the `.env` value | no |
| unset | unset / empty | `find_free_port()` runs; result is persisted to `.env` | **yes (key added/updated)** |

So `.env` is written exactly once, the first time `start` runs in a project that has no prior `WEBSERVER_PORT` configured. From the second run onward, the persisted value is read and start does not modify `.env`.

### 2. Port discovery (`find_free_port`)

```
   start = 8000                                       
   max_attempts = 100                                 
                                                     
   ┌──────────────────────────────┐                  
   │ port = start                 │                  
   └──────┬───────────────────────┘                  
          ▼                                          
   ┌─────────────────────────────────────────┐       
   │ stream_socket_client(                   │       
   │   'tcp://localhost:$port', timeout=0.2  │       
   │ )                                       │       
   └──────┬──────────────────────────────────┘       
          │                                          
    ┌─────┴──────┐                                   
   refused      connected                            
   (free)       (in use → close, try next)           
    │             │                                  
    ▼             ▼                                  
  return port   port++ ─── port < start+max? ──┐    
                                              yes   
                                               │    
                                               └──→ loop back to probe
                                               no   
                                               │    
                                               ▼    
                                          FAIL('Unable to find a
                                                 free port in
                                                 range 8000-8099')
```

A **client connect probe** is used (not a server bind probe) so it works on systems without IPv6 (e.g. CircleCI's Docker images): the resolver chooses whichever stack `localhost` maps to, and a refused connection unambiguously means "nothing is listening" regardless of stack.

### 3. dotenv upsert (`dotenv_write_var`)

```
   call: dotenv_write_var('WEBSERVER_PORT', '8001', '.env')
                                  │
                                  ▼
                  ┌───────────────────────────┐
                  │ file_exists('.env')?      │
                  └─────────┬─────────────────┘
                       no   │   yes
                       ▼    │    ▼
                  create file with single line:
                  "WEBSERVER_PORT=8001\n"
                            │
                            │   read file, split into lines
                            │   walk lines, skipping blanks / # comments
                            │   for first line whose KEY matches:
                            │       replace that whole line in place
                            │   if no match was found:
                            │       append "KEY=VALUE" at the end
                            │   write all lines back
                            ▼
   .env before:                           .env after:

   # local overrides                      # local overrides
   OTHER_VAR=hello              ─────▶    OTHER_VAR=hello
   WEBSERVER_PORT=                        WEBSERVER_PORT=8001
   # trailing comment                     # trailing comment
```

Matching is by **key name only**, value is ignored — so `WEBSERVER_PORT=` (empty), `WEBSERVER_PORT=8000`, or `WEBSERVER_PORT="x"` are all the same target and get rewritten in place. Comments, blank lines, and other keys are preserved verbatim.

### 4. Tool integration

`make` and `ahoy` both load `.env` before invoking any command, so once `start` has persisted a port, every wrapper (drush, login, provision, etc.) sees the same `WEBSERVER_PORT` automatically.

```
  ┌────────────┐       ┌────────────┐       ┌────────────┐
  │  .ahoy.yml │       │  Makefile  │       │  .gitignore│
  ├────────────┤       ├────────────┤       ├────────────┤
  │ env:       │       │ -include   │       │ /.env      │
  │   - .env   │       │   .env     │       │            │
  │            │       │ export     │       │            │
  └─────┬──────┘       └──────┬─────┘       └────────────┘
        │                     │
        ▼                     ▼
   ahoy drush          make drush <cmd>
   ahoy login          make login
   ahoy provision      make provision
   (all see WEBSERVER_PORT)
```

### 5. Stop output

`stop` reports the port it acted on so you can see which server was torn down:

```
[TASK] Stopping previously started services on port 8000, if any.
[ OK ] Services stopped on port 8000.
```

## Changes

### Helpers (`.devtools/helpers.php`)

- `dotenv_read(string $file)` — parses a dotenv-style file into an associative array.
- `dotenv_write_var(string $key, string $value, string $file)` — upserts a single variable; preserves other keys, comments, blank lines; fails explicitly on read/write errors.
- `find_free_port(int $start, int $max_attempts)` — connect-probe scan; validates input range.
- `validate_port_or_fail(string $value, string $source)` — asserts numeric 1-65535; called from start/stop/provision after resolution.

### Scripts (`.devtools/start`, `.devtools/stop`, `.devtools/provision`)

- `start`: resolution + auto-discovery + persistence as diagrammed above. Host/port/cwd are passed through `escapeshellarg()` in the `nohup php -S` call.
- `stop`: resolves port for the user-facing message, kills any listener on that port, reports which port was stopped.
- `provision`: same resolution as stop (env → `.env` → 8000).

### Tool integration

- `.ahoy.yml`: `env: [.env]` at the top level (uses ahoy's native field).
- `Makefile`: `-include .env` + `export` at the top.
- `.gitignore`: `/.env`.

### Tests

- `HelpersDotenvTest.php` — real tmp-file tests for `dotenv_read` / `dotenv_write_var`.
- `HelpersFindFreePortTest.php` — `stream_socket_client` mocked to simulate listeners.
- `HelpersValidatePortTest.php` — valid/invalid port values.
- `Functional/AutoPortDiscoveryTest.php` — spins up two minimal sandbox projects, asserts the second discovers a different port and the existing-`.env` case is honored without rewriting.
- Updated `StartTest.php`, `StopTest.php`, `ProvisionTest.php`.

### Docs (`README.md`)

- "Provisioning the website" section documents the resolution precedence and `.env` loading.

### Fixtures

- Regenerated `_baseline` and per-scenario snapshots under `.scaffold/tests/fixtures/init/`.
