### PR TITLE
[#363] Added shared Claude settings for downstream consumers.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ahoy:*)",
+      "Bash(composer:*)",
+      "Bash(make:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,10 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(ahoy:*)",
-      "Bash(composer:*)",
-      "Bash(make:*)"
-    ],
-    "deny": []
-  }
+    "permissions": {
+        "allow": [
+            "Bash(ahoy:*)",
+            "Bash(composer:*)",
+            "Bash(make:*)"
+        ],
+        "deny": []
+    }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 # Uncomment the lines below in your project.
 # AGENTS.md          export-ignore
 # CLAUDE.md          export-ignore
+# .claude            export-ignore
 # .ahoy.yml          export-ignore
 # .circleci          export-ignore
 # .devtools          export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 /composer.lock
 /node_modules
 /vendor
+
+# Ignore all Claude files by default. Custom files should be added explicitly.
+!.claude
+.claude/*
+!.claude/settings.json
+!.claude/skills/

--- a/.scaffold/tests/fixtures/init/_baseline/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/_baseline/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ahoy:*)",
+      "Bash(composer:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.scaffold/tests/fixtures/init/_baseline/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/_baseline/.claude/settings.json
@@ -1,9 +1,9 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(ahoy:*)",
-      "Bash(composer:*)"
-    ],
-    "deny": []
-  }
+    "permissions": {
+        "allow": [
+            "Bash(ahoy:*)",
+            "Bash(composer:*)"
+        ],
+        "deny": []
+    }
 }

--- a/.scaffold/tests/fixtures/init/_baseline/.gitattributes
+++ b/.scaffold/tests/fixtures/init/_baseline/.gitattributes
@@ -2,6 +2,7 @@
 
 AGENTS.md          export-ignore
 CLAUDE.md          export-ignore
+.claude            export-ignore
 .ahoy.yml          export-ignore
 .circleci          export-ignore
 .devtools          export-ignore

--- a/.scaffold/tests/fixtures/init/_baseline/.gitignore
+++ b/.scaffold/tests/fixtures/init/_baseline/.gitignore
@@ -4,3 +4,8 @@
 /composer.lock
 /node_modules
 /vendor
+
+# Ignore all Claude files by default. Custom files should be added explicitly.
+!.claude
+.claude/*
+!.claude/settings.json

--- a/.scaffold/tests/fixtures/init/_baseline/.ignorecontent
+++ b/.scaffold/tests/fixtures/init/_baseline/.ignorecontent
@@ -3,3 +3,8 @@
 ^logo.png
 ^package-lock.json
 init.php
+
+# User-local Claude files that may be present in local checkouts.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/artifacts/

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.claude/settings.json
@@ -1,0 +1,10 @@
+@@ -2,7 +2,8 @@
+   "permissions": {
+     "allow": [
+       "Bash(ahoy:*)",
+-      "Bash(composer:*)"
++      "Bash(composer:*)",
++      "Bash(make:*)"
+     ],
+     "deny": []
+   }

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.claude/settings.json
@@ -1,10 +1,10 @@
 @@ -2,7 +2,8 @@
-   "permissions": {
-     "allow": [
-       "Bash(ahoy:*)",
--      "Bash(composer:*)"
-+      "Bash(composer:*)",
-+      "Bash(make:*)"
-     ],
-     "deny": []
-   }
+     "permissions": {
+         "allow": [
+             "Bash(ahoy:*)",
+-            "Bash(composer:*)"
++            "Bash(composer:*)",
++            "Bash(make:*)"
+         ],
+         "deny": []
+     }

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.claude/settings.json
@@ -1,11 +1,11 @@
 @@ -1,8 +1,8 @@
  {
-   "permissions": {
-     "allow": [
--      "Bash(ahoy:*)",
--      "Bash(composer:*)"
-+      "Bash(composer:*)",
-+      "Bash(make:*)"
-     ],
-     "deny": []
-   }
+     "permissions": {
+         "allow": [
+-            "Bash(ahoy:*)",
+-            "Bash(composer:*)"
++            "Bash(composer:*)",
++            "Bash(make:*)"
+         ],
+         "deny": []
+     }

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.claude/settings.json
@@ -1,0 +1,11 @@
+@@ -1,8 +1,8 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(ahoy:*)",
+-      "Bash(composer:*)"
++      "Bash(composer:*)",
++      "Bash(make:*)"
+     ],
+     "deny": []
+   }

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.claude/settings.json
@@ -1,0 +1,8 @@
+@@ -1,7 +1,6 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(ahoy:*)",
+       "Bash(composer:*)"
+     ],
+     "deny": []

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.claude/settings.json
@@ -1,8 +1,8 @@
 @@ -1,7 +1,6 @@
  {
-   "permissions": {
-     "allow": [
--      "Bash(ahoy:*)",
-       "Bash(composer:*)"
-     ],
-     "deny": []
+     "permissions": {
+         "allow": [
+-            "Bash(ahoy:*)",
+             "Bash(composer:*)"
+         ],
+         "deny": []

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/.claude/settings.json
@@ -1,0 +1,10 @@
+@@ -2,7 +2,8 @@
+   "permissions": {
+     "allow": [
+       "Bash(ahoy:*)",
+-      "Bash(composer:*)"
++      "Bash(composer:*)",
++      "Bash(make:*)"
+     ],
+     "deny": []
+   }

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/.claude/settings.json
@@ -1,10 +1,10 @@
 @@ -2,7 +2,8 @@
-   "permissions": {
-     "allow": [
-       "Bash(ahoy:*)",
--      "Bash(composer:*)"
-+      "Bash(composer:*)",
-+      "Bash(make:*)"
-     ],
-     "deny": []
-   }
+     "permissions": {
+         "allow": [
+             "Bash(ahoy:*)",
+-            "Bash(composer:*)"
++            "Bash(composer:*)",
++            "Bash(make:*)"
+         ],
+         "deny": []
+     }

--- a/.scaffold/tests/fixtures/init/gha_makefile/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/gha_makefile/.claude/settings.json
@@ -1,11 +1,11 @@
 @@ -1,8 +1,8 @@
  {
-   "permissions": {
-     "allow": [
--      "Bash(ahoy:*)",
--      "Bash(composer:*)"
-+      "Bash(composer:*)",
-+      "Bash(make:*)"
-     ],
-     "deny": []
-   }
+     "permissions": {
+         "allow": [
+-            "Bash(ahoy:*)",
+-            "Bash(composer:*)"
++            "Bash(composer:*)",
++            "Bash(make:*)"
+         ],
+         "deny": []
+     }

--- a/.scaffold/tests/fixtures/init/gha_makefile/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/gha_makefile/.claude/settings.json
@@ -1,0 +1,11 @@
+@@ -1,8 +1,8 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(ahoy:*)",
+-      "Bash(composer:*)"
++      "Bash(composer:*)",
++      "Bash(make:*)"
+     ],
+     "deny": []
+   }

--- a/.scaffold/tests/fixtures/init/gha_no_command_wrapper/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/gha_no_command_wrapper/.claude/settings.json
@@ -1,0 +1,8 @@
+@@ -1,7 +1,6 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(ahoy:*)",
+       "Bash(composer:*)"
+     ],
+     "deny": []

--- a/.scaffold/tests/fixtures/init/gha_no_command_wrapper/.claude/settings.json
+++ b/.scaffold/tests/fixtures/init/gha_no_command_wrapper/.claude/settings.json
@@ -1,8 +1,8 @@
 @@ -1,7 +1,6 @@
  {
-   "permissions": {
-     "allow": [
--      "Bash(ahoy:*)",
-       "Bash(composer:*)"
-     ],
-     "deny": []
+     "permissions": {
+         "allow": [
+-            "Bash(ahoy:*)",
+             "Bash(composer:*)"
+         ],
+         "deny": []

--- a/.scaffold/tests/src/Functional/FunctionalTestCase.php
+++ b/.scaffold/tests/src/Functional/FunctionalTestCase.php
@@ -33,7 +33,6 @@ abstract class FunctionalTestCase extends UnitTestCase {
       '.logs',
       '.phpunit.cache',
       '.artifacts',
-      '.claude',
       'build',
     ]);
 

--- a/init.php
+++ b/init.php
@@ -187,6 +187,19 @@ function process(string $extension_name, string $extension_machine_name, string 
     @unlink('Makefile');
   }
 
+  // Trim wrapper-specific permissions from Claude settings to match selection.
+  $claude_settings = '.claude/settings.json';
+  if (file_exists($claude_settings)) {
+    $settings_content = (string) file_get_contents($claude_settings);
+    if (!in_array('ahoy', $command_wrapper, TRUE)) {
+      $settings_content = (string) preg_replace('/^[ \t]*"Bash\(ahoy:\*\)",?\n/m', '', $settings_content);
+    }
+    if (!in_array('makefile', $command_wrapper, TRUE)) {
+      $settings_content = (string) preg_replace('/,\n[ \t]*"Bash\(make:\*\)"/', '', $settings_content);
+    }
+    file_put_contents($claude_settings, $settings_content);
+  }
+
   process_readme($extension_name);
 
   process_internal($extension_name, $extension_machine_name, $extension_type);
@@ -257,6 +270,7 @@ function process_internal(string $extension_name, string $extension_machine_name
   remove_string_content('# Uncomment the lines below in your project.');
   uncomment_line('.gitattributes', 'AGENTS.md');
   uncomment_line('.gitattributes', 'CLAUDE.md');
+  uncomment_line('.gitattributes', '.claude');
   uncomment_line('.gitattributes', '.ahoy.yml');
   uncomment_line('.gitattributes', '.circleci');
   uncomment_line('.gitattributes', '.devtools');
@@ -309,6 +323,10 @@ function process_internal(string $extension_name, string $extension_machine_name
     @unlink($file);
   }
   remove_dir('.scaffold');
+
+  // Remove scaffold-only Claude skills placeholder and its gitignore entry.
+  remove_dir('.claude/skills');
+  remove_string_content('!.claude/skills/');
 
   remove_tokens_with_content('META');
   remove_special_comments();

--- a/init.php
+++ b/init.php
@@ -190,14 +190,34 @@ function process(string $extension_name, string $extension_machine_name, string 
   // Trim wrapper-specific permissions from Claude settings to match selection.
   $claude_settings = '.claude/settings.json';
   if (file_exists($claude_settings)) {
-    $settings_content = (string) file_get_contents($claude_settings);
-    if (!in_array('ahoy', $command_wrapper, TRUE)) {
-      $settings_content = (string) preg_replace('/^[ \t]*"Bash\(ahoy:\*\)",?\n/m', '', $settings_content);
+    $settings_content = file_get_contents($claude_settings);
+    if ($settings_content === FALSE) {
+      throw new \RuntimeException('Unable to read .claude/settings.json.');
     }
-    if (!in_array('makefile', $command_wrapper, TRUE)) {
-      $settings_content = (string) preg_replace('/,\n[ \t]*"Bash\(make:\*\)"/', '', $settings_content);
+
+    $settings = json_decode($settings_content, TRUE, 512, JSON_THROW_ON_ERROR);
+    $allow = $settings['permissions']['allow'] ?? [];
+    if (!is_array($allow)) {
+      throw new \RuntimeException('Invalid .claude/settings.json permissions.allow format.');
     }
-    file_put_contents($claude_settings, $settings_content);
+
+    $settings['permissions']['allow'] = array_values(array_filter(
+      $allow,
+      static function (string $permission) use ($command_wrapper): bool {
+        if ($permission === 'Bash(ahoy:*)' && !in_array('ahoy', $command_wrapper, TRUE)) {
+          return FALSE;
+        }
+        if ($permission === 'Bash(make:*)' && !in_array('makefile', $command_wrapper, TRUE)) {
+          return FALSE;
+        }
+        return TRUE;
+      },
+    ));
+
+    $encoded = json_encode($settings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    if ($encoded === FALSE || file_put_contents($claude_settings, $encoded . PHP_EOL) === FALSE) {
+      throw new \RuntimeException('Unable to write .claude/settings.json.');
+    }
   }
 
   process_readme($extension_name);

--- a/init.php
+++ b/init.php
@@ -196,26 +196,24 @@ function process(string $extension_name, string $extension_machine_name, string 
     }
 
     $settings = json_decode($settings_content, TRUE, 512, JSON_THROW_ON_ERROR);
-    $allow = $settings['permissions']['allow'] ?? [];
-    if (!is_array($allow)) {
-      throw new \RuntimeException('Invalid .claude/settings.json permissions.allow format.');
+    if (!is_array($settings) || !isset($settings['permissions']) || !is_array($settings['permissions']) || !isset($settings['permissions']['allow']) || !is_array($settings['permissions']['allow'])) {
+      throw new \RuntimeException('Invalid .claude/settings.json structure.');
     }
 
     $settings['permissions']['allow'] = array_values(array_filter(
-      $allow,
-      static function (string $permission) use ($command_wrapper): bool {
-        if ($permission === 'Bash(ahoy:*)' && !in_array('ahoy', $command_wrapper, TRUE)) {
-          return FALSE;
-        }
-        if ($permission === 'Bash(make:*)' && !in_array('makefile', $command_wrapper, TRUE)) {
-          return FALSE;
-        }
-        return TRUE;
+      $settings['permissions']['allow'],
+      static function ($permission) use ($command_wrapper): bool {
+        $wrapper = match ($permission) {
+          'Bash(ahoy:*)' => 'ahoy',
+          'Bash(make:*)' => 'makefile',
+          default => NULL,
+        };
+        return $wrapper === NULL || in_array($wrapper, $command_wrapper, TRUE);
       },
     ));
 
     $encoded = json_encode($settings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
-    if ($encoded === FALSE || file_put_contents($claude_settings, $encoded . PHP_EOL) === FALSE) {
+    if (file_put_contents($claude_settings, $encoded . PHP_EOL) === FALSE) {
       throw new \RuntimeException('Unable to write .claude/settings.json.');
     }
   }


### PR DESCRIPTION
Closes #363

## Summary

Adds a shared `.claude/settings.json` to the scaffold so downstream consumers inherit a baseline Claude Code permission set (`Bash(ahoy:*)`, `Bash(composer:*)`, `Bash(make:*)`) out of the box. A `.claude/skills/.gitkeep` placeholder is included so consumers can drop project-specific skills into that directory without any extra scaffolding. The `init.php` script trims the permission entries that do not apply to the consumer's chosen command wrapper and removes the scaffold-only skills placeholder. Distribution archives are updated to exclude the `.claude` directory via `.gitattributes`, matching the existing pattern for `AGENTS.md` and `CLAUDE.md`.

## Changes

**New files:**
- `.claude/settings.json` - baseline allow-list with `Bash(ahoy:*)`, `Bash(composer:*)`, and `Bash(make:*)` permissions
- `.claude/skills/.gitkeep` - empty placeholder so consumers can add their own skills

**`.gitignore`:**
- Added a block that ignores all `.claude/*` by default while explicitly re-allowing `settings.json` and `skills/` so only tracked config ships

**`.gitattributes`:**
- Added `# .claude export-ignore` (commented, uncommented by `init.php`) so release archives exclude Claude config, matching the `AGENTS.md`/`CLAUDE.md` pattern

**`init.php`:**
- Trims `Bash(ahoy:*)` from `settings.json` when `ahoy` is not in the consumer's `command_wrapper` selection
- Trims `Bash(make:*)` when `makefile` is not selected
- Uncomments `.claude export-ignore` in `.gitattributes`
- Removes `.claude/skills/` directory and its corresponding `!.claude/skills/` gitignore line after init

**Test fixtures:**
- Updated `_baseline` fixtures (`.gitattributes`, `.gitignore`, `.ignorecontent`, `.claude/settings.json`) to reflect the new baseline state
- Added per-variant `settings.json` snapshots for all 6 init scenarios (`circleci_both_wrappers`, `circleci_makefile`, `circleci_no_command_wrapper`, `gha_both_wrappers`, `gha_makefile`, `gha_no_command_wrapper`)
- Removed `.claude` from the copy-exclusion list in `FunctionalTestCase.php` so the directory is included in the SUT during snapshot tests
- Added user-local Claude files (`.claude/settings.local.json`, `.claude/scheduled_tasks.lock`, `.claude/artifacts/`) to `_baseline/.ignorecontent`

## Before / After

```
Before init.php:                     After init.php (ahoy-only example):
.claude/                             .claude/
  settings.json  (all 3 wrappers)      settings.json  (ahoy + composer only)
  skills/                            (skills/ removed)
.gitattributes   (# .claude ...)     .gitattributes   (.claude export-ignore)
.gitignore       (!.claude/skills/)  .gitignore       (skills/ line removed)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR introduces a shared Claude configuration scaffold to enable downstream consumers to inherit a baseline Claude Code permission set while allowing project-specific skill customization. The implementation aligns with existing patterns by excluding runtime artifacts from release archives and ignoring user-local files.

## Changes

**New Configuration Files:**
- `.claude/settings.json` — A baseline Claude settings file with a permissions allow-list containing `Bash(ahoy:*)`, `Bash(composer:*)`, and `Bash(make:*)` commands, plus an empty deny list.
- `.claude/skills/.gitkeep` — A placeholder directory for consumer-specific skills.

**Repository Configuration Updates:**
- `.gitattributes` — Added `# .claude export-ignore` entry (initially commented) to exclude Claude config from distribution archives, matching the existing behavior for AGENTS.md and CLAUDE.md.
- `.gitignore` — Added rules to ignore all `.claude/*` contents by default, while explicitly allowing `.claude/settings.json` and `.claude/skills/` to be tracked.

**Initialization Logic (init.php):**
- Removes `Bash(ahoy:*)` permission from settings.json when `ahoy` is not selected as the command wrapper.
- Removes `Bash(make:*)` permission when `makefile` is not selected.
- Uncomments the `.claude export-ignore` line in .gitattributes.
- Deletes the `.claude/skills/` directory post-init and removes the corresponding `!.claude/skills/` gitignore rule.

**Test Fixtures and Infrastructure:**
- Updated baseline fixtures (`.gitattributes`, `.gitignore`, `.ignorecontent`) to reflect new Claude configuration.
- Added six per-variant `settings.json` snapshots for different initialization scenarios (CircleCI/GitHub Actions × both wrappers/makefile-only/no wrapper).
- Extended `.ignorecontent` baseline to include user-local Claude entries (`.settings.local.json`, `.scheduled_tasks.lock`, `artifacts/`).
- Modified `FunctionalTestCase.php` to include `.claude` in the test system-under-test by removing it from the copy-exclusion list.

## Related Issues

Resolves `#363`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlexSkrypnyk/drupal_extension_scaffold/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->