### PR TITLE
[#369] Added PHP 8.5 support for Drupal 11.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ job-test: &job-test
           echo -e "extension=pcov.so\npcov.enabled=1" | sudo tee -a /usr/local/etc/php/conf.d/pcov.ini
 
     - run:
-        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         command: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $BASH_ENV
           fi
 
@@ -256,6 +256,34 @@ jobs:
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
+  test-php-8.5-d11-legacy:
+    <<: *container_config
+    docker:
+      - image: cimg/php:8.5-browsers@sha256:9307ddf83e336d92aeb8191f9f676d36147dc5719a331669b02576aa38558e02
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3 # Lowest Drupal version that supports PHP 8.5.
+    <<: *job-test
+
+  test-php-8.5-d11-stable:
+    <<: *container_config
+    docker:
+      - image: cimg/php:8.5-browsers@sha256:9307ddf83e336d92aeb8191f9f676d36147dc5719a331669b02576aa38558e02
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3
+    <<: *job-test
+
+  test-php-8.5-d11-canary:
+    <<: *container_config
+    docker:
+      - image: cimg/php:8.5-browsers@sha256:9307ddf83e336d92aeb8191f9f676d36147dc5719a331669b02576aa38558e02
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11@beta
+      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
+    <<: *job-test
+
   deploy:
     <<: *container_config
 
@@ -338,6 +366,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-php-8.5-d11-legacy:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-stable:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-canary:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test-php-8.2-d10-legacy
@@ -355,6 +395,9 @@ workflows:
             - test-php-8.4-d11-legacy
             - test-php-8.4-d11-stable
             - test-php-8.4-d11-canary
+            - test-php-8.5-d11-legacy
+            - test-php-8.5-d11-stable
+            - test-php-8.5-d11-canary
           filters:
             tags:
               only: /.*/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: gd, sqlite, pdo_sqlite
 
       - name: Assemble the codebase
@@ -131,6 +131,18 @@ jobs:
             php-version: 8.4
             drupal-version: 11@beta
 
+          - name: test-php-8.5-d11-legacy
+            php-version: 8.5
+            drupal-version: 11.3 # Lowest Drupal version that supports PHP 8.5.
+
+          - name: test-php-8.5-d11-stable
+            php-version: 8.5
+            drupal-version: 11.3
+
+          - name: test-php-8.5-d11-canary
+            php-version: 8.5
+            drupal-version: 11@beta
+
     services:
       chrome:
         image: selenium/standalone-chromium:latest@sha256:8c5a8629c96104c0d73df94c6437af9ab9059c4e16aa32e35b330b7d77defe0b
@@ -169,11 +181,11 @@ jobs:
           coverage: pcov
 
       # Disable Symfony deprecations helper for PHP 8.4+ until minor
-      # versions of Drupal 10 and 11 fully support PHP 8.4.
+      # versions of Drupal 10 and 11 fully support newer PHP versions.
       # @see https://www.drupal.org/project/drupal/issues/1267246
-      - name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+      - name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         run: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> "$GITHUB_ENV"
           fi
 

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -1,0 +1,80 @@
+# Scaffold Maintenance
+
+Maintenance guide for the `drupal_extension_scaffold` template itself.
+
+This file documents how to regenerate the scaffold's own artefacts (animated
+README SVGs, snapshot fixtures) and how to run its self-tests. It does **not**
+apply to consumer projects produced by running `init.php`.
+
+## Layout
+
+- `.scaffold/assets/` - Source files for animated SVG demos used in the root `README.md` (`init.svg`, `build.svg`, `lint.svg`, `test.svg`) plus the `update-assets.php` generator and a small `svg-term` Node wrapper.
+- `.scaffold/tests/` - PHPUnit suite that validates the scaffold itself: the `init.php` interactive flow, the `.devtools/*` PHP helpers, and the resulting project structure. Snapshots live under `.scaffold/tests/fixtures/init/`.
+
+## Test groups
+
+PHPUnit tests are tagged with `#[Group('p0'..'p4')]` so CI can shard them across parallel jobs:
+
+- `p0` - Unit tests in `src/Unit/` (no I/O bound dependencies).
+- `p1` - `InitTest` (snapshot comparison of `init.php` output).
+- `p2` - `AssembleTest` (Drupal codebase assembly).
+- `p3` - `AhoyTest`, `AutoPortDiscoveryTest` (Ahoy command wrapper).
+- `p4` - `MakeTest` (Makefile command wrapper).
+
+## Running the tests
+
+All commands run from `.scaffold/tests/`. Install dependencies once with `composer --working-dir=.scaffold/tests install`.
+
+| Action                        | Command                                                                                  |
+|-------------------------------|------------------------------------------------------------------------------------------|
+| All tests                     | `composer --working-dir=.scaffold/tests test`                                            |
+| Single group                  | `composer --working-dir=.scaffold/tests test -- --group=p0`                              |
+| Single test class             | `composer --working-dir=.scaffold/tests test -- --filter=InitTest`                       |
+| With coverage                 | `composer --working-dir=.scaffold/tests test-coverage -- --group=p0`                     |
+| Lint (phpcs, phpstan, rector) | `composer --working-dir=.scaffold/tests lint`                                            |
+| Lint autofix                  | `composer --working-dir=.scaffold/tests lint-fix`                                        |
+
+`p2`-`p4` exercise the full build pipeline and need Selenium plus a Drupal-friendly PHP setup; they are the same jobs the GitHub Actions matrix runs (`.github/workflows/scaffold-test.yml`).
+
+## Regenerating snapshot fixtures
+
+`InitTest` runs `init.php` end-to-end and diffs the output against `fixtures/init/_baseline/` plus one fixture directory per dataset (`circleci/`, `gha_makefile/`, `theme/`, etc. - see `InitTest::dataProviderInit()`).
+
+When source files change (workflows, `.devtools/`, `init.php`, Claude settings, etc.), the fixtures fall out of date. Regenerate them:
+
+```bash
+composer --working-dir=.scaffold/tests update-snapshots
+```
+
+This wraps `vendor/bin/update-snapshots` from `alexskrypnyk/snapshot`. It:
+
+1. Runs the baseline dataset first and commits any baseline diff as its own commit.
+2. Runs the remaining datasets in parallel and amends the baseline commit with each fixture diff.
+3. Exits non-zero on the first run because the original tests failed against the stale snapshots - that is expected; the snapshots are now correct.
+
+Run `composer --working-dir=.scaffold/tests test -- --filter=InitTest` afterwards to confirm everything is green, then review the committed diffs before pushing.
+
+The trait that drives the diff-and-update behaviour is `SnapshotTrait` (see `tearDown()` in `InitTest`); it calls `snapshotUpdateOnFailure()` so a normal `test` run will also rewrite fixtures if you have not used the dedicated `update-snapshots` command.
+
+## Regenerating animated SVG assets
+
+The README demo SVGs are produced from real terminal recordings:
+
+```bash
+composer --working-dir=.scaffold/tests update-assets
+```
+
+This invokes `php .scaffold/assets/update-assets.php`, which:
+
+1. Creates a clean workspace, copies the scaffold into it, and installs `svg-term` via `npm install --prefix .scaffold/assets`.
+2. Records `init.php` and `ahoy build` sequentially using `asciinema` + `expect`.
+3. Records `ahoy lint` and `ahoy test` in parallel against the assembled workspace.
+4. Converts each `.cast` file to an animated SVG via `node .scaffold/assets/svg-term-render.js` and writes `init.svg`, `build.svg`, `lint.svg`, `test.svg` into `.scaffold/assets/`.
+
+Required tools: `asciinema`, `expect`, `node`, `npm`. The script checks for these and aborts if any are missing.
+
+Set `SCRIPT_QUIET=1` to suppress verbose progress messages. To record a single asset, pass `--record <name> --workspace <dir>`.
+
+## CI
+
+`.github/workflows/scaffold-test.yml` runs the suite across the `p0`-`p4` groups and validates `composer.json` (validate + normalize) plus the PHP lint step in `p0`. A second job (`scaffold-test-actions`) lints the workflow YAML with `yamllint` and `actionlint`.

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@__HASH__ # __VERSION__
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: gd, sqlite, pdo_sqlite
 
       - name: Assemble the codebase
@@ -131,6 +131,18 @@ jobs:
             php-version: 8.4
             drupal-version: 11@beta
 
+          - name: test-php-8.5-d11-legacy
+            php-version: 8.5
+            drupal-version: 11.3 # Lowest Drupal version that supports PHP 8.5.
+
+          - name: test-php-8.5-d11-stable
+            php-version: 8.5
+            drupal-version: 11.3
+
+          - name: test-php-8.5-d11-canary
+            php-version: 8.5
+            drupal-version: 11@beta
+
     services:
       chrome:
         image: selenium/standalone-chromium:latest@sha256:8c5a8629c96104c0d73df94c6437af9ab9059c4e16aa32e35b330b7d77defe0b
@@ -169,11 +181,11 @@ jobs:
           coverage: pcov
 
       # Disable Symfony deprecations helper for PHP 8.4+ until minor
-      # versions of Drupal 10 and 11 fully support PHP 8.4.
+      # versions of Drupal 10 and 11 fully support newer PHP versions.
       # @see https://www.drupal.org/project/drupal/issues/1267246
-      - name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+      - name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         run: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> "$GITHUB_ENV"
           fi
 

--- a/.scaffold/tests/fixtures/init/_baseline/README.md
+++ b/.scaffold/tests/fixtures/init/_baseline/README.md
@@ -19,6 +19,7 @@
 ![PHP 8.2](https://img.shields.io/badge/PHP-8.2-777BB4.svg)
 ![PHP 8.3](https://img.shields.io/badge/PHP-8.3-777BB4.svg)
 ![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4.svg)
+![PHP 8.5](https://img.shields.io/badge/PHP-8.5-777BB4.svg)
 ![Drupal 10](https://img.shields.io/badge/Drupal-10-009CDE.svg)
 ![Drupal 11](https://img.shields.io/badge/Drupal-11-006AA9.svg)
 

--- a/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
@@ -40,9 +40,9 @@ job-test: &job-test
           echo -e "extension=pcov.so\npcov.enabled=1" | sudo tee -a /usr/local/etc/php/conf.d/pcov.ini
 
     - run:
-        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         command: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $BASH_ENV
           fi
 
@@ -256,6 +256,34 @@ jobs:
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
+  test-php-8.5-d11-legacy:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3 # Lowest Drupal version that supports PHP 8.5.
+    <<: *job-test
+
+  test-php-8.5-d11-stable:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3
+    <<: *job-test
+
+  test-php-8.5-d11-canary:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11@beta
+      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
+    <<: *job-test
+
   deploy:
     <<: *container_config
 
@@ -338,6 +366,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-php-8.5-d11-legacy:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-stable:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-canary:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test-php-8.2-d10-legacy
@@ -355,6 +395,9 @@ workflows:
             - test-php-8.4-d11-legacy
             - test-php-8.4-d11-stable
             - test-php-8.4-d11-canary
+            - test-php-8.5-d11-legacy
+            - test-php-8.5-d11-stable
+            - test-php-8.5-d11-canary
           filters:
             tags:
               only: /.*/

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
@@ -40,9 +40,9 @@ job-test: &job-test
           echo -e "extension=pcov.so\npcov.enabled=1" | sudo tee -a /usr/local/etc/php/conf.d/pcov.ini
 
     - run:
-        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         command: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $BASH_ENV
           fi
 
@@ -256,6 +256,34 @@ jobs:
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
+  test-php-8.5-d11-legacy:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3 # Lowest Drupal version that supports PHP 8.5.
+    <<: *job-test
+
+  test-php-8.5-d11-stable:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3
+    <<: *job-test
+
+  test-php-8.5-d11-canary:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11@beta
+      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
+    <<: *job-test
+
   deploy:
     <<: *container_config
 
@@ -338,6 +366,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-php-8.5-d11-legacy:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-stable:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-canary:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test-php-8.2-d10-legacy
@@ -355,6 +395,9 @@ workflows:
             - test-php-8.4-d11-legacy
             - test-php-8.4-d11-stable
             - test-php-8.4-d11-canary
+            - test-php-8.5-d11-legacy
+            - test-php-8.5-d11-stable
+            - test-php-8.5-d11-canary
           filters:
             tags:
               only: /.*/

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
@@ -40,9 +40,9 @@ job-test: &job-test
           echo -e "extension=pcov.so\npcov.enabled=1" | sudo tee -a /usr/local/etc/php/conf.d/pcov.ini
 
     - run:
-        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         command: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $BASH_ENV
           fi
 
@@ -256,6 +256,34 @@ jobs:
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
+  test-php-8.5-d11-legacy:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3 # Lowest Drupal version that supports PHP 8.5.
+    <<: *job-test
+
+  test-php-8.5-d11-stable:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3
+    <<: *job-test
+
+  test-php-8.5-d11-canary:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11@beta
+      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
+    <<: *job-test
+
   deploy:
     <<: *container_config
 
@@ -338,6 +366,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-php-8.5-d11-legacy:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-stable:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-canary:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test-php-8.2-d10-legacy
@@ -355,6 +395,9 @@ workflows:
             - test-php-8.4-d11-legacy
             - test-php-8.4-d11-stable
             - test-php-8.4-d11-canary
+            - test-php-8.5-d11-legacy
+            - test-php-8.5-d11-stable
+            - test-php-8.5-d11-canary
           filters:
             tags:
               only: /.*/

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
@@ -40,9 +40,9 @@ job-test: &job-test
           echo -e "extension=pcov.so\npcov.enabled=1" | sudo tee -a /usr/local/etc/php/conf.d/pcov.ini
 
     - run:
-        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4
+        name: Update SYMFONY_DEPRECATIONS_HELPER for PHP 8.4+
         command: |
-          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" == "84" ]; then
+          if [ "$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')" -ge "84" ]; then
             echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $BASH_ENV
           fi
 
@@ -256,6 +256,34 @@ jobs:
       CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
+  test-php-8.5-d11-legacy:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3 # Lowest Drupal version that supports PHP 8.5.
+    <<: *job-test
+
+  test-php-8.5-d11-stable:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11.3
+    <<: *job-test
+
+  test-php-8.5-d11-canary:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+      - *selenium_image
+    environment:
+      DRUPAL_VERSION: 11@beta
+      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
+    <<: *job-test
+
   deploy:
     <<: *container_config
 
@@ -338,6 +366,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-php-8.5-d11-legacy:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-stable:
+          filters:
+            tags:
+              only: /.*/
+      - test-php-8.5-d11-canary:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test-php-8.2-d10-legacy
@@ -355,6 +395,9 @@ workflows:
             - test-php-8.4-d11-legacy
             - test-php-8.4-d11-stable
             - test-php-8.4-d11-canary
+            - test-php-8.5-d11-legacy
+            - test-php-8.5-d11-stable
+            - test-php-8.5-d11-canary
           filters:
             tags:
               only: /.*/

--- a/README.dist.md
+++ b/README.dist.md
@@ -19,6 +19,7 @@
 ![PHP 8.2](https://img.shields.io/badge/PHP-8.2-777BB4.svg)
 ![PHP 8.3](https://img.shields.io/badge/PHP-8.3-777BB4.svg)
 ![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4.svg)
+![PHP 8.5](https://img.shields.io/badge/PHP-8.5-777BB4.svg)
 ![Drupal 10](https://img.shields.io/badge/Drupal-10-009CDE.svg)
 ![Drupal 11](https://img.shields.io/badge/Drupal-11-006AA9.svg)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 ![PHP 8.2](https://img.shields.io/badge/PHP-8.2-777BB4.svg)
 ![PHP 8.3](https://img.shields.io/badge/PHP-8.3-777BB4.svg)
 ![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4.svg)
+![PHP 8.5](https://img.shields.io/badge/PHP-8.5-777BB4.svg)
 ![Drupal 10](https://img.shields.io/badge/Drupal-10-009CDE.svg)
 ![Drupal 11](https://img.shields.io/badge/Drupal-11-006AA9.svg)
 </div>
@@ -48,7 +49,7 @@ and push the code to [Drupal.org](https://drupal.org).
 ## Features
 
 - Turnkey CI configuration:
-  - PHP version matrix: `8.2`, `8.3`, `8.4`.
+  - PHP version matrix: `8.2`, `8.3`, `8.4`, `8.5`.
   - Drupal version matrix: `stable`, `canary` and `legacy`.
   - CI providers: [GitHub Actions](.github/workflows/test.yml)
     and [CircleCI](.circleci/config.yml)


### PR DESCRIPTION
Closes #369

## Summary

- Adds PHP 8.5 to the CI test matrix for Drupal 11 (legacy, stable, canary tiers) in both GitHub Actions and CircleCI.
- PHP 8.5 is Drupal 11-only: Drupal 10 does not support PHP 8.5 per core requirements, so no D10 entries are added.
- Widens the `SYMFONY_DEPRECATIONS_HELPER` guard from an exact PHP 8.4 match to a `>= 8.4` numeric comparison, so PHP 8.5 (and future minor versions) automatically inherit the workaround.
- Bumps the lint job in GitHub Actions from PHP 8.4 to PHP 8.5.
- Adds a PHP 8.5 shields.io badge to both `README.md` and `README.dist.md` and updates the documented PHP version matrix.
- Regenerates the `.scaffold/tests` snapshot fixtures so `InitTest` passes against the updated workflow files and the new `README.md` badge row.
- Adds `.scaffold/CLAUDE.md` documenting how to regenerate snapshots, update SVG demo assets, and run the scaffold test suite (including the `p0`-`p4` group sharding used by CI).

## Changes

**`.github/workflows/test.yml`**
- Lint job PHP version bumped from 8.4 to 8.5.
- Three new matrix entries added: `test-php-8.5-d11-legacy`, `test-php-8.5-d11-stable`, `test-php-8.5-d11-canary` (legacy/stable use Drupal `11.3` as the minimum D11 release that supports PHP 8.5; canary uses `11@beta`).
- `SYMFONY_DEPRECATIONS_HELPER` guard changed from `== "84"` to `-ge "84"`.

**`.circleci/config.yml`**
- Three new jobs mirroring the GHA matrix, using `cimg/php:8.5-browsers` pinned by SHA digest.
- All three jobs added to `workflows.commit.jobs` and to `deploy.requires`.
- `SYMFONY_DEPRECATIONS_HELPER` guard widened to `-ge "84"`.

**`README.md` and `README.dist.md`**
- New `![PHP 8.5]` shields.io badge added alongside the existing 8.2/8.3/8.4 badges.
- `README.md` features list updated to mention `8.5` in the documented PHP version matrix.

**`.scaffold/tests/fixtures/`**
- Snapshot fixtures for `InitTest` regenerated to match the updated workflow files and the new README badge: the baseline GHA workflow, the baseline README, and all four CircleCI variant configs (six fixture files updated in total).

**`.scaffold/CLAUDE.md`** (new)
- Documents scaffold maintenance commands: snapshot regeneration via `composer --working-dir=.scaffold/tests update-snapshots`, SVG asset updates via `composer --working-dir=.scaffold/tests update-assets`, and the PHPUnit test groups (`p0`-`p4`) used by CI sharding.

## Before / After

CI matrix shape before and after this change (each cell shows which Drupal major versions are tested):

```
PHP version | D10 (before) | D11 (before) | D10 (after) | D11 (after)
------------|--------------|--------------|-------------|------------
8.2         | legacy       | legacy       | legacy      | legacy
8.2         | stable       | stable       | stable      | stable
8.2         | canary       | canary       | canary      | canary
8.3         | legacy       | legacy       | legacy      | legacy
8.3         | stable       | stable       | stable      | stable
8.3         | canary       | canary       | canary      | canary
8.4         | legacy       | legacy       | legacy      | legacy
8.4         | stable       | stable       | stable      | stable
8.4         | canary       | canary       | canary      | canary
8.5         | -            | -            | -           | legacy  [NEW]
8.5         | -            | -            | -           | stable  [NEW]
8.5         | -            | -            | -           | canary  [NEW]
```

D10 gets no PHP 8.5 entries because Drupal 10 does not support PHP 8.5.
