### PR TITLE
[#366] Added macOS to scaffold devtools CI matrix.

### DIFF
--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -60,9 +60,15 @@ jobs:
       - name: Install Ahoy
         if: matrix.group == 'p3'
         run: |
-          os=$(uname -s | tr '[:upper:]' '[:lower:]') && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac)
-          sudo wget -q https://github.com/ahoy-cli/ahoy/releases/download/v2.1.1/ahoy-bin-"${os}-${architecture}" -O /usr/local/bin/ahoy
-          sudo chown "$USER" /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
+          os=$(uname -s | tr '[:upper:]' '[:lower:]')
+          case "$(uname -m)" in
+            x86_64|amd64) architecture=amd64 ;;
+            aarch64|arm64|armv8) architecture=arm64 ;;
+            *) architecture=amd64 ;;
+          esac
+          sudo wget -q "https://github.com/ahoy-cli/ahoy/releases/download/v2.1.1/ahoy-bin-${os}-${architecture}" -O /usr/local/bin/ahoy
+          sudo chown "$USER" /usr/local/bin/ahoy
+          chmod +x /usr/local/bin/ahoy
 
       - name: Start Chromium (Linux only)
         if: runner.os == 'Linux' && (matrix.group == 'p3' || matrix.group == 'p4')

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -14,26 +14,21 @@ on:
 
 jobs:
   scaffold-test-devtools:
-    runs-on: ubuntu-latest
-
-    services:
-      chrome:
-        image: selenium/standalone-chromium:latest@sha256:8c5a8629c96104c0d73df94c6437af9ab9059c4e16aa32e35b330b7d77defe0b
-        ports:
-          - 4444:4444
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
 
       matrix:
+        os: [ubuntu-latest, macos-latest]
         group: ['p0', 'p1', 'p2', 'p3', 'p4']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Upgrade sqlite3
-        if: matrix.group != 'p0'
+      - name: Upgrade sqlite3 (Linux)
+        if: matrix.group != 'p0' && runner.os == 'Linux'
         run: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
           tar -xzf /tmp/sqlite.tar.gz -C /tmp
@@ -41,6 +36,18 @@ jobs:
           ./configure CFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1" --prefix=/usr/local
           make && sudo make install
           sudo ldconfig
+
+      - name: Upgrade sqlite3 (macOS)
+        if: matrix.group != 'p0' && runner.os == 'macOS'
+        run: |
+          brew install sqlite3
+          brew_prefix=$(brew --prefix sqlite3)
+          echo "${brew_prefix}/bin" >> "$GITHUB_PATH"
+          {
+            echo "LDFLAGS=-L${brew_prefix}/lib"
+            echo "CPPFLAGS=-I${brew_prefix}/include"
+            echo "PKG_CONFIG_PATH=${brew_prefix}/lib/pkgconfig"
+          } >> "$GITHUB_ENV"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
@@ -56,6 +63,13 @@ jobs:
           os=$(uname -s | tr '[:upper:]' '[:lower:]') && architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac)
           sudo wget -q https://github.com/ahoy-cli/ahoy/releases/download/v2.1.1/ahoy-bin-"${os}-${architecture}" -O /usr/local/bin/ahoy
           sudo chown "$USER" /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
+
+      - name: Start Chromium (Linux only)
+        if: runner.os == 'Linux' && (matrix.group == 'p3' || matrix.group == 'p4')
+        run: |
+          docker run -d --name chromium -p 4444:4444 selenium/standalone-chromium:latest@sha256:8c5a8629c96104c0d73df94c6437af9ab9059c4e16aa32e35b330b7d77defe0b
+          for _ in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
+          curl -s http://localhost:4444/status | grep -q '"ready": true' || { echo 'ERROR: Chromium failed to become ready after 30 seconds.'; exit 1; }
 
       - name: Install PHP test dependencies
         run: composer install --no-interaction
@@ -82,11 +96,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEBSERVER_HOST: ${{ (matrix.group == 'p3' || matrix.group == 'p4') && '0.0.0.0' || 'localhost' }}
+          SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT: ${{ runner.os == 'macOS' && '1' || '0' }}
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{github.job}}-code-coverage-report-${{ matrix.group }}
+          name: ${{github.job}}-code-coverage-report-${{ matrix.os }}-${{ matrix.group }}
           path: .scaffold/tests/.logs
           include-hidden-files: true
           if-no-files-found: error

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -180,6 +180,14 @@ final class AhoyTest extends DevtoolsTestCase {
   }
 
   protected function runFunctionalJavascriptTests(): void {
+    // Allow CI environments without Docker (e.g. GitHub Actions macOS runners)
+    // to opt out of the Selenium-backed FunctionalJavascript step.
+    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
+      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping FunctionalJavascript step.' . PHP_EOL);
+
+      return;
+    }
+
     $this->processRun('ahoy', ['test-functional-javascript'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -83,9 +83,7 @@ final class AhoyTest extends DevtoolsTestCase {
 
     $this->runLint();
 
-    $this->processRun('ahoy', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
+    $this->runTests();
 
     $this->runJsTests();
 
@@ -134,6 +132,20 @@ final class AhoyTest extends DevtoolsTestCase {
 
     $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
+  }
+
+  protected function runTests(): void {
+    // `ahoy test` runs every PHPUnit suite in the consumer project, including
+    // FunctionalJavascript. Skip on CI environments without Docker (macOS).
+    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
+      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping `ahoy test` (includes FunctionalJavascript).' . PHP_EOL);
+
+      return;
+    }
+
+    $this->processRun('ahoy', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
   }
 
   protected function runJsTests(): void {

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -83,7 +83,16 @@ final class AhoyTest extends DevtoolsTestCase {
 
     $this->runLint();
 
-    $this->runTests();
+    // `ahoy test` runs every PHPUnit suite in the consumer project, including
+    // FunctionalJavascript. Skip on CI environments without Docker (macOS).
+    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
+      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping `ahoy test` (includes FunctionalJavascript).' . PHP_EOL);
+    }
+    else {
+      $this->processRun('ahoy', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+      $this->assertProcessSuccessful();
+      $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
+    }
 
     $this->runJsTests();
 
@@ -132,20 +141,6 @@ final class AhoyTest extends DevtoolsTestCase {
 
     $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
-  }
-
-  protected function runTests(): void {
-    // `ahoy test` runs every PHPUnit suite in the consumer project, including
-    // FunctionalJavascript. Skip on CI environments without Docker (macOS).
-    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
-      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping `ahoy test` (includes FunctionalJavascript).' . PHP_EOL);
-
-      return;
-    }
-
-    $this->processRun('ahoy', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
   }
 
   protected function runJsTests(): void {

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -82,7 +82,16 @@ final class MakeTest extends DevtoolsTestCase {
 
     $this->runLint();
 
-    $this->runTests();
+    // `make test` runs every PHPUnit suite in the consumer project, including
+    // FunctionalJavascript. Skip on CI environments without Docker (macOS).
+    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
+      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping `make test` (includes FunctionalJavascript).' . PHP_EOL);
+    }
+    else {
+      $this->processRun('make', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+      $this->assertProcessSuccessful();
+      $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
+    }
 
     $this->runJsTests();
 
@@ -131,20 +140,6 @@ final class MakeTest extends DevtoolsTestCase {
 
     $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
-  }
-
-  protected function runTests(): void {
-    // `make test` runs every PHPUnit suite in the consumer project, including
-    // FunctionalJavascript. Skip on CI environments without Docker (macOS).
-    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
-      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping `make test` (includes FunctionalJavascript).' . PHP_EOL);
-
-      return;
-    }
-
-    $this->processRun('make', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
   }
 
   protected function runJsTests(): void {

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -179,6 +179,14 @@ final class MakeTest extends DevtoolsTestCase {
   }
 
   protected function runFunctionalJavascriptTests(): void {
+    // Allow CI environments without Docker (e.g. GitHub Actions macOS runners)
+    // to opt out of the Selenium-backed FunctionalJavascript step.
+    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
+      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping FunctionalJavascript step.' . PHP_EOL);
+
+      return;
+    }
+
     $this->processRun('make', ['test-functional-javascript'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -82,9 +82,7 @@ final class MakeTest extends DevtoolsTestCase {
 
     $this->runLint();
 
-    $this->processRun('make', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
-    $this->assertProcessSuccessful();
-    $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
+    $this->runTests();
 
     $this->runJsTests();
 
@@ -133,6 +131,20 @@ final class MakeTest extends DevtoolsTestCase {
 
     $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
+  }
+
+  protected function runTests(): void {
+    // `make test` runs every PHPUnit suite in the consumer project, including
+    // FunctionalJavascript. Skip on CI environments without Docker (macOS).
+    if (getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1') {
+      fwrite(STDERR, 'SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1: skipping `make test` (includes FunctionalJavascript).' . PHP_EOL);
+
+      return;
+    }
+
+    $this->processRun('make', ['test'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertDirectoryExists(self::$sut . '/build/web/sites/simpletest/browser_output');
   }
 
   protected function runJsTests(): void {


### PR DESCRIPTION
Closes #366

## Summary

Adds `macos-latest` as a second OS dimension to the `scaffold-test-devtools` CI job matrix, doubling the combinations from 5 (1 OS × 5 groups) to 10 (2 OS × 5 groups). Because macOS GitHub Actions runners do not support Docker, the Selenium/Chromium container is moved from a job-level `services:` block to a conditional step that runs only on Linux when the group requires it (p3 or p4). macOS runs receive `SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1` so the test harness skips both the dedicated FunctionalJavascript step and the broader `ahoy test`/`make test` smoke step (which would otherwise try to reach Selenium at `localhost:4444`). The sqlite3 upgrade is split into a Linux step (source build with `SQLITE_ENABLE_COLUMN_METADATA`) and a macOS step (`brew install sqlite3` with build flags exported via `$GITHUB_ENV`). The pre-existing `Install Ahoy` step's inline `case` syntax inside `$(...)` is split across lines so it parses under macOS's bash 3.2. Coverage artifact names are disambiguated by OS so the two runners do not collide on upload.

## Changes

**`.github/workflows/scaffold-test.yml`**

- Replaced `runs-on: ubuntu-latest` with `runs-on: ${{ matrix.os }}` and added `os: [ubuntu-latest, macos-latest]` to the matrix.
- Removed the job-level `services:` block (Docker service containers are unsupported on macOS runners).
- Added a conditional `Start Chromium (Linux only)` step that runs `docker run` only when `runner.os == 'Linux'` and `matrix.group` is `p3` or `p4`, with a 30-second readiness poll before proceeding.
- Split the sqlite3 upgrade into a Linux step (unchanged `wget` + source build) and a macOS step (`brew install sqlite3` with `LDFLAGS`/`CPPFLAGS`/`PKG_CONFIG_PATH` exported via `$GITHUB_ENV`).
- Rewrote the `Install Ahoy` step's `os`/`architecture` detection: split the inline `case $(uname -m) in ... esac` into a multi-line `case` block. The single-line form parses under bash 4+ on Linux but errors on macOS bash 3.2 (`syntax error near unexpected token ';;'`).
- Added `SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT: ${{ runner.os == 'macOS' && '1' || '0' }}` to the test step's `env` block.
- Disambiguated the coverage artifact name from `...-${{ matrix.group }}` to `...-${{ matrix.os }}-${{ matrix.group }}`.

**`.scaffold/tests/src/Functional/AhoyTest.php` and `MakeTest.php`**

- Added an early-return guard at the top of `runFunctionalJavascriptTests()` that checks `getenv('SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT') === '1'` and writes a marker line to STDERR before returning.
- Added the same guard inline around the `ahoy test`/`make test` call in `testWorkflow()`. `ahoy test` and `make test` invoke PHPUnit with no filter and therefore run the FunctionalJavascript suite as well; without Selenium reachable, that step errors with `Could not connect to localhost port 4444`. The guard skips both that command and its `browser_output` directory assertion when the env var is set.
- Default behaviour when the env var is unset or set to any other value is unchanged.

## Before / After

**Before** - 1 OS × 5 groups = 5 matrix jobs, Selenium always pulled as a job-level service:

```
OS              | p0 | p1 | p2 | p3 | p4
ubuntu-latest   |  X |  X |  X |  X |  X     <- Selenium service always on
```

**After** - 2 OS × 5 groups = 10 matrix jobs, Selenium started only where needed:

```
OS              | p0 | p1 | p2 | p3        | p4
ubuntu-latest   |  X |  X |  X |  X + DOCK |  X + DOCK    <- step-level docker run
macos-latest    |  X |  X |  X |  X SKIP   |  X SKIP      <- SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT=1
```

`X` = group runs. `+ DOCK` = Selenium container started in a Linux-only step before the test step. `SKIP` = both `ahoy test`/`make test` and the dedicated `test-functional-javascript` step are skipped via env var; every other workflow step (assemble, start, provision, lint, test-unit, test-kernel, test-functional) still runs.
