### PR TITLE
[#365] Added 'ahoy debug' and 'make debug' commands to toggle XDebug step-debugging with fail-fast extension probe.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -28,6 +28,13 @@ commands:
     usage: Stop development environment.
     cmd: ./.devtools/stop
 
+  debug:
+    usage: Enable PHP XDebug step-debugging for the development server.
+    aliases: [xdebug]
+    cmd: |
+      ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
+      (XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
   provision:
     usage: Provision application within assembled codebase.
     cmd: ./.devtools/provision

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -22,6 +22,7 @@ commands:
 
   start:
     usage: Start development environment.
+    aliases: [debug-off, xdebug-off]
     cmd: ./.devtools/start
 
   stop:
@@ -30,7 +31,7 @@ commands:
 
   debug:
     usage: Enable PHP XDebug step-debugging for the development server.
-    aliases: [xdebug]
+    aliases: [debug-on, xdebug, xdebug-on]
     cmd: |
       ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
       (XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))

--- a/.devtools/start
+++ b/.devtools/start
@@ -53,6 +53,15 @@ echo '      💻 START ENVIRONMENT     ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
+if ($xdebug_enabled) {
+  TASK('Verifying that the Xdebug PHP extension is installed.');
+  $php_v = (string) shell_exec('php -v 2>/dev/null');
+  if (stripos($php_v, 'xdebug') === FALSE) {
+    FAIL('XDEBUG=1 is set but the Xdebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
+  }
+  PASS('Xdebug extension is loaded.');
+}
+
 TASK('Stopping previously started services, if any.');
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 

--- a/.devtools/start
+++ b/.devtools/start
@@ -39,6 +39,13 @@ validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
 
+// Enable Xdebug when XdEBUG env var is set. Xdebug extension must be installed
+// and configured on host environment (php -v should show `with Xdebug`).
+// Coverage stays on pcov in test commands because xdebug.mode=debug does
+// not include "coverage", so pcov remains the active coverage driver.
+$xdebug_enabled = getenv_default('XDEBUG', '') !== '';
+$xdebug_flags = $xdebug_enabled ? ' -d xdebug.mode=debug -d xdebug.start_with_request=yes' : '';
+
 // -----------------------------------------------------------------------------
 
 echo '===============================' . PHP_EOL;
@@ -51,7 +58,7 @@ TASK('Stopping previously started services, if any.');
 
 TASK('Starting the PHP webserver.');
 $cwd = (string) getcwd();
-passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
+passthru(sprintf('nohup php%s -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $xdebug_flags, escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
 
 NOTE('Waiting %s seconds for the server to be ready.', (string) $webserver_wait_timeout);
 sleep($webserver_wait_timeout);
@@ -82,8 +89,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Directory : ' . $cwd . '/build/web' . PHP_EOL;
 echo 'URL       : http://' . $webserver_host . ':' . $webserver_port . PHP_EOL;
-echo PHP_EOL;
-echo 'Re-run when you enable or disable XDebug.' . PHP_EOL;
+echo 'XDebug    : ' . ($xdebug_enabled ? 'Enabled' : 'Disabled') . PHP_EOL;
 echo PHP_EOL;
 echo '> Next steps:' . PHP_EOL;
 echo '  .devtools/provision    # Provision the website' . PHP_EOL;

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -21,7 +21,7 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, macos-latest]
-        group: ['p0', 'p1', 'p2', 'p3', 'p4']
+        group: ['p0', 'p1', 'p2', 'p3', 'p4', 'p5']
 
     steps:
       - name: Checkout code
@@ -49,16 +49,18 @@ jobs:
             echo "PKG_CONFIG_PATH=${brew_prefix}/lib/pkgconfig"
           } >> "$GITHUB_ENV"
 
+      # p5 swaps the coverage driver for the real xdebug extension so the
+      # XDebug toggle can be tested end-to-end. All other groups keep pcov.
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: 8.3
           extensions: gd, sqlite, pdo_sqlite
-          coverage: pcov
-          ini-values: pcov.directory=.
+          coverage: ${{ matrix.group == 'p5' && 'xdebug' || 'pcov' }}
+          ini-values: ${{ matrix.group == 'p5' && 'xdebug.mode=off' || 'pcov.directory=.' }}
 
       - name: Install Ahoy
-        if: matrix.group == 'p3'
+        if: matrix.group == 'p3' || matrix.group == 'p5'
         run: |
           os=$(uname -s | tr '[:upper:]' '[:lower:]')
           case "$(uname -m)" in
@@ -97,6 +99,7 @@ jobs:
         working-directory: .scaffold/tests
 
       - name: Run PHP tests with coverage
+        if: matrix.group != 'p5'
         run: composer test-coverage -- --group=${{ matrix.group }}
         working-directory: .scaffold/tests
         env:
@@ -104,7 +107,17 @@ jobs:
           WEBSERVER_HOST: ${{ (matrix.group == 'p3' || matrix.group == 'p4') && '0.0.0.0' || 'localhost' }}
           SCAFFOLD_SKIP_FUNCTIONAL_JAVASCRIPT: ${{ runner.os == 'macOS' && '1' || '0' }}
 
+      # p5 runs without coverage because the runner is configured with xdebug
+      # (not pcov) for the XDebug toggle behaviour test.
+      - name: Run PHP tests
+        if: matrix.group == 'p5'
+        run: composer test -- --group=${{ matrix.group }}
+        working-directory: .scaffold/tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload coverage report as an artifact
+        if: matrix.group != 'p5'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.os }}-${{ matrix.group }}
@@ -113,8 +126,8 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage report to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' && matrix.group != 'p5' }}
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
-        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           directory: .scaffold/tests/.logs
           fail_ci_if_error: true

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -13,7 +13,7 @@ apply to consumer projects produced by running `init.php`.
 
 ## Test groups
 
-PHPUnit tests are tagged with `#[Group('p0'..'p4')]` so CI can shard them across parallel jobs:
+PHPUnit tests are tagged with `#[Group('p0'..'p5')]` so CI can shard them across parallel jobs:
 
 - `p0` - Unit tests in `src/Unit/` (no I/O bound dependencies).
 - `p1` - `InitTest` (snapshot comparison of `init.php` output).
@@ -35,7 +35,7 @@ All commands run from `.scaffold/tests/`. Install dependencies once with `compos
 | Lint (phpcs, phpstan, rector) | `composer --working-dir=.scaffold/tests lint`                                            |
 | Lint autofix                  | `composer --working-dir=.scaffold/tests lint-fix`                                        |
 
-`p2`-`p4` exercise the full build pipeline and need Selenium plus a Drupal-friendly PHP setup; they are the same jobs the GitHub Actions matrix runs (`.github/workflows/scaffold-test.yml`).
+`p2`-`p5` exercise the full build pipeline and need a Drupal-friendly PHP setup; `p3` additionally needs Selenium. These are the same jobs the GitHub Actions matrix runs (`.github/workflows/scaffold-test.yml`).
 
 ## Regenerating snapshot fixtures
 
@@ -78,4 +78,4 @@ Set `SCRIPT_QUIET=1` to suppress verbose progress messages. To record a single a
 
 ## CI
 
-`.github/workflows/scaffold-test.yml` runs the suite across the `p0`-`p4` groups and validates `composer.json` (validate + normalize) plus the PHP lint step in `p0`. A second job (`scaffold-test-actions`) lints the workflow YAML with `yamllint` and `actionlint`.
+`.github/workflows/scaffold-test.yml` runs the suite across the `p0`-`p5` groups and validates `composer.json` (validate + normalize) plus the PHP lint step in `p0`. A second job (`scaffold-test-actions`) lints the workflow YAML with `yamllint` and `actionlint`.

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -20,6 +20,7 @@ PHPUnit tests are tagged with `#[Group('p0'..'p4')]` so CI can shard them across
 - `p2` - `AssembleTest` (Drupal codebase assembly).
 - `p3` - `AhoyTest`, `AutoPortDiscoveryTest` (Ahoy command wrapper).
 - `p4` - `MakeTest` (Makefile command wrapper).
+- `p5` - `XdebugTest` (XDebug step-debugging toggle). This is the only group whose CI runner installs the xdebug PHP extension via `coverage: xdebug` instead of pcov - the test exercises the real extension end to end, so coverage is not collected for this group.
 
 ## Running the tests
 

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -22,11 +22,19 @@ commands:
 
   start:
     usage: Start development environment.
+    aliases: [debug-off, xdebug-off]
     cmd: ./.devtools/start
 
   stop:
     usage: Stop development environment.
     cmd: ./.devtools/stop
+
+  debug:
+    usage: Enable PHP XDebug step-debugging for the development server.
+    aliases: [debug-on, xdebug, xdebug-on]
+    cmd: |
+      ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
+      (XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
   provision:
     usage: Provision application within assembled codebase.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -53,6 +53,15 @@ echo '      💻 START ENVIRONMENT     ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
+if ($xdebug_enabled) {
+  TASK('Verifying that the Xdebug PHP extension is installed.');
+  $php_v = (string) shell_exec('php -v 2>/dev/null');
+  if (stripos($php_v, 'xdebug') === FALSE) {
+    FAIL('XDEBUG=1 is set but the Xdebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
+  }
+  PASS('Xdebug extension is loaded.');
+}
+
 TASK('Stopping previously started services, if any.');
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -39,6 +39,13 @@ validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
 
+// Enable Xdebug when XdEBUG env var is set. Xdebug extension must be installed
+// and configured on host environment (php -v should show `with Xdebug`).
+// Coverage stays on pcov in test commands because xdebug.mode=debug does
+// not include "coverage", so pcov remains the active coverage driver.
+$xdebug_enabled = getenv_default('XDEBUG', '') !== '';
+$xdebug_flags = $xdebug_enabled ? ' -d xdebug.mode=debug -d xdebug.start_with_request=yes' : '';
+
 // -----------------------------------------------------------------------------
 
 echo '===============================' . PHP_EOL;
@@ -51,7 +58,7 @@ TASK('Stopping previously started services, if any.');
 
 TASK('Starting the PHP webserver.');
 $cwd = (string) getcwd();
-passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
+passthru(sprintf('nohup php%s -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $xdebug_flags, escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
 
 NOTE('Waiting %s seconds for the server to be ready.', (string) $webserver_wait_timeout);
 sleep($webserver_wait_timeout);
@@ -82,8 +89,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Directory : ' . $cwd . '/build/web' . PHP_EOL;
 echo 'URL       : http://' . $webserver_host . ':' . $webserver_port . PHP_EOL;
-echo PHP_EOL;
-echo 'Re-run when you enable or disable XDebug.' . PHP_EOL;
+echo 'XDebug    : ' . ($xdebug_enabled ? 'Enabled' : 'Disabled') . PHP_EOL;
 echo PHP_EOL;
 echo '> Next steps:' . PHP_EOL;
 echo '  .devtools/provision    # Provision the website' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/README.md
+++ b/.scaffold/tests/fixtures/init/_baseline/README.md
@@ -107,6 +107,14 @@ You can browse the contents of the created SQLite database using
 
 A one-time login link will be printed to the console.
 
+### Step-debugging with XDebug
+
+PHP step-debugging is supported via [XDebug](https://xdebug.org/docs/install). Install the XDebug PHP extension on your host (`php -v` should mention `with Xdebug`), then run `make debug` or `ahoy debug` to restart the PHP server with XDebug enabled. Run `make start` or `ahoy start` to disable.
+
+Code coverage stays on [pcov](https://github.com/krakjoe/pcov) because `xdebug.mode=debug` does not include `coverage`.
+
+Install the Xdebug Helper browser extension to start and stop debug sessions: [Chrome](https://chromewebstore.google.com/detail/xdebug-helper-by-jetbrain/aoelhdemabeimdhedkidlnbkfhnhgnhm) / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/xdebug-helper-by-jetbrains/).
+
 ## Coding standards
 
 The `make lint` or `ahoy lint` command checks the codebase using multiple

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
+.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start status stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -12,13 +12,14 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit
+.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
 
 help:
 	@echo "COMMANDS"
 	@echo "========"
 	@echo "build           - Build or rebuild the project."
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
+	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
@@ -46,6 +47,23 @@ start:
 
 stop:
 	./.devtools/stop
+
+# Enable PHP XDebug step-debugging by restarting the PHP server with
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
+# the running server's command line for `xdebug.mode=debug` so no flag file
+# is needed. Run `make start` to disable.
+debug:
+	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
+# Make has no native command aliases - the alias targets declare `debug` as
+# their sole prerequisite, so running e.g. `make xdebug` executes the `debug`
+# recipe via the prerequisite chain.
+debug-on xdebug xdebug-on: debug
+
+# Mirror the ahoy `start` aliases. `make debug-off` runs the `start` recipe
+# via the prerequisite chain, which restarts without XDebug.
+debug-off xdebug-off: start
 
 # Allow running Drush commands with `make drush <command>`
 ifeq (drush,$(firstword $(MAKECMDGOALS)))

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
+.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start status stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -12,13 +12,14 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit
+.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
 
 help:
 	@echo "COMMANDS"
 	@echo "========"
 	@echo "build           - Build or rebuild the project."
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
+	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
@@ -46,6 +47,23 @@ start:
 
 stop:
 	./.devtools/stop
+
+# Enable PHP XDebug step-debugging by restarting the PHP server with
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
+# the running server's command line for `xdebug.mode=debug` so no flag file
+# is needed. Run `make start` to disable.
+debug:
+	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
+# Make has no native command aliases - the alias targets declare `debug` as
+# their sole prerequisite, so running e.g. `make xdebug` executes the `debug`
+# recipe via the prerequisite chain.
+debug-on xdebug xdebug-on: debug
+
+# Mirror the ahoy `start` aliases. `make debug-off` runs the `start` recipe
+# via the prerequisite chain, which restarts without XDebug.
+debug-off xdebug-off: start
 
 # Allow running Drush commands with `make drush <command>`
 ifeq (drush,$(firstword $(MAKECMDGOALS)))

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
+.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start status stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -12,13 +12,14 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit
+.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
 
 help:
 	@echo "COMMANDS"
 	@echo "========"
 	@echo "build           - Build or rebuild the project."
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
+	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
@@ -46,6 +47,23 @@ start:
 
 stop:
 	./.devtools/stop
+
+# Enable PHP XDebug step-debugging by restarting the PHP server with
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
+# the running server's command line for `xdebug.mode=debug` so no flag file
+# is needed. Run `make start` to disable.
+debug:
+	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
+# Make has no native command aliases - the alias targets declare `debug` as
+# their sole prerequisite, so running e.g. `make xdebug` executes the `debug`
+# recipe via the prerequisite chain.
+debug-on xdebug xdebug-on: debug
+
+# Mirror the ahoy `start` aliases. `make debug-off` runs the `start` recipe
+# via the prerequisite chain, which restarts without XDebug.
+debug-off xdebug-off: start
 
 # Allow running Drush commands with `make drush <command>`
 ifeq (drush,$(firstword $(MAKECMDGOALS)))

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
+.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start status stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -12,13 +12,14 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit
+.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
 
 help:
 	@echo "COMMANDS"
 	@echo "========"
 	@echo "build           - Build or rebuild the project."
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
+	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
@@ -46,6 +47,23 @@ start:
 
 stop:
 	./.devtools/stop
+
+# Enable PHP XDebug step-debugging by restarting the PHP server with
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
+# the running server's command line for `xdebug.mode=debug` so no flag file
+# is needed. Run `make start` to disable.
+debug:
+	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
+# Make has no native command aliases - the alias targets declare `debug` as
+# their sole prerequisite, so running e.g. `make xdebug` executes the `debug`
+# recipe via the prerequisite chain.
+debug-on xdebug xdebug-on: debug
+
+# Mirror the ahoy `start` aliases. `make debug-off` runs the `start` recipe
+# via the prerequisite chain, which restarts without XDebug.
+debug-off xdebug-off: start
 
 # Allow running Drush commands with `make drush <command>`
 ifeq (drush,$(firstword $(MAKECMDGOALS)))

--- a/.scaffold/tests/src/Functional/XdebugTest.php
+++ b/.scaffold/tests/src/Functional/XdebugTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for the XDebug step-debugging toggle.
+ *
+ * The CI job for this group installs the xdebug PHP extension via
+ * `coverage: xdebug` with a baseline `xdebug.mode=off`. The `debug` command
+ * overrides via the `-d xdebug.mode=debug` runtime flag, and the running
+ * server is queried through a probe file dropped in the docroot.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p5')]
+final class XdebugTest extends DevtoolsTestCase {
+
+  public function testAhoy(): void {
+    $this->assertToggle('ahoy');
+  }
+
+  public function testMake(): void {
+    $this->assertToggle('make');
+  }
+
+  protected function assertToggle(string $tool): void {
+    self::assertTrue(extension_loaded('xdebug'), 'Xdebug PHP extension must be installed in the runner PHP for this test group.');
+
+    $this->processRun($tool, ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+
+    $this->processRun($tool, ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('XDebug    : Disabled');
+
+    // The Drupal `.ht.router.php` serves any file that physically exists, so
+    // a PHP file dropped in the docroot runs in the same webserver whose
+    // xdebug configuration we are toggling.
+    $probe = self::$sut . '/build/web/_xdebug_check.php';
+    file_put_contents($probe, '<?php echo ini_get("xdebug.mode") ?: "off";');
+
+    $this->assertSame('off', $this->fetchProbe(), 'Baseline: xdebug.mode is off.');
+
+    $this->processRun($tool, ['debug'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('Enabled XDebug');
+    $this->assertSame('debug', $this->fetchProbe(), 'After debug: xdebug.mode is debug.');
+
+    $this->processRun($tool, ['debug'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('XDebug is already enabled');
+    $this->assertSame('debug', $this->fetchProbe(), 'After repeat debug: still debug.');
+
+    $this->processRun($tool, ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('XDebug    : Disabled');
+    $this->assertSame('off', $this->fetchProbe(), 'After start: xdebug.mode is off again.');
+  }
+
+  protected function fetchProbe(): string {
+    $env = file_exists(self::$sut . '/.env') ? parse_ini_file(self::$sut . '/.env') : [];
+    $port = (string) ($env['WEBSERVER_PORT'] ?? '8000');
+    $body = @file_get_contents('http://localhost:' . $port . '/_xdebug_check.php');
+
+    return $body === FALSE ? '' : trim($body);
+  }
+
+}

--- a/.scaffold/tests/src/Functional/XdebugTest.php
+++ b/.scaffold/tests/src/Functional/XdebugTest.php
@@ -29,7 +29,7 @@ final class XdebugTest extends DevtoolsTestCase {
   }
 
   protected function assertToggle(string $tool): void {
-    self::assertTrue(extension_loaded('xdebug'), 'Xdebug PHP extension must be installed in the runner PHP for this test group.');
+    $this->assertTrue(extension_loaded('xdebug'), 'Xdebug PHP extension must be installed in the runner PHP for this test group.');
 
     $this->processRun($tool, ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
+.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start status stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,14 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit
+.PHONY: assemble, build, debug, debug-off, debug-on, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit, xdebug, xdebug-off, xdebug-on
 
 help:
 	@echo "COMMANDS"
 	@echo "========"
 	@echo "build           - Build or rebuild the project."
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
+	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
@@ -46,6 +47,23 @@ start:
 
 stop:
 	./.devtools/stop
+
+# Enable PHP XDebug step-debugging by restarting the PHP server with
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
+# the running server's command line for `xdebug.mode=debug` so no flag file
+# is needed. Run `make start` to disable.
+debug:
+	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
+# Make has no native command aliases - the alias targets declare `debug` as
+# their sole prerequisite, so running e.g. `make xdebug` executes the `debug`
+# recipe via the prerequisite chain.
+debug-on xdebug xdebug-on: debug
+
+# Mirror the ahoy `start` aliases. `make debug-off` runs the `start` recipe
+# via the prerequisite chain, which restarts without XDebug.
+debug-off xdebug-off: start
 
 # Allow running Drush commands with `make drush <command>`
 ifeq (drush,$(firstword $(MAKECMDGOALS)))

--- a/README.dist.md
+++ b/README.dist.md
@@ -107,6 +107,14 @@ You can browse the contents of the created SQLite database using
 
 A one-time login link will be printed to the console.
 
+### Step-debugging with XDebug
+
+PHP step-debugging is supported via [XDebug](https://xdebug.org/docs/install). Install the XDebug PHP extension on your host (`php -v` should mention `with Xdebug`), then run `make debug` or `ahoy debug` to restart the PHP server with XDebug enabled. Run `make start` or `ahoy start` to disable.
+
+Code coverage stays on [pcov](https://github.com/krakjoe/pcov) because `xdebug.mode=debug` does not include `coverage`.
+
+Install the Xdebug Helper browser extension to start and stop debug sessions: [Chrome](https://chromewebstore.google.com/detail/xdebug-helper-by-jetbrain/aoelhdemabeimdhedkidlnbkfhnhgnhm) / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/xdebug-helper-by-jetbrains/).
+
 ## Coding standards
 
 The `make lint` or `ahoy lint` command checks the codebase using multiple

--- a/README.md
+++ b/README.md
@@ -230,6 +230,22 @@ You can browse the contents of the created SQLite database using
 
 A one-time login link will be printed to the console.
 
+### Step-debugging with XDebug
+
+PHP step-debugging is supported via [XDebug](https://xdebug.org/docs/install). Install the XDebug PHP extension on your host (`php -v` should mention `with Xdebug`), then toggle it on the development server:
+
+```bash
+make debug      # restart with XDebug enabled (aliases: debug-on, xdebug, xdebug-on)
+ahoy debug      # same, with ahoy
+
+make start      # restart without XDebug (aliases: debug-off, xdebug-off)
+ahoy start      # same, with ahoy
+```
+
+The `debug` command probes the running PHP server's command line for `xdebug.mode=debug` and skips the restart if XDebug is already enabled. Code coverage stays on [pcov](https://github.com/krakjoe/pcov) because `xdebug.mode=debug` does not include `coverage`.
+
+To start and stop debug sessions from the browser, install the Xdebug Helper extension: [Chrome](https://chromewebstore.google.com/detail/xdebug-helper-by-jetbrain/aoelhdemabeimdhedkidlnbkfhnhgnhm) / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/xdebug-helper-by-jetbrains/).
+
 ## Coding standards
 
 The `make lint` or `ahoy lint` command checks the codebase using multiple


### PR DESCRIPTION
Closes #365

## Summary

Adds `ahoy debug` / `make debug` commands that toggle PHP XDebug step-debugging on the development server without requiring manual edits to `.env` or shell variables. The commands detect whether XDebug is already enabled by probing the running server's command line, then restart the PHP webserver with `-d xdebug.mode=debug -d xdebug.start_with_request=yes` only when needed. Running `ahoy start` / `make start` (via the new `debug-off` / `xdebug-off` aliases) restores a non-XDebug server. `.devtools/start` additionally probes `php -v` when `XDEBUG=1` is set and fails fast with a clear error if the Xdebug extension is not installed on the host. Documentation sections are added to both READMEs, and a new `p5` CI group exercises the full toggle cycle end-to-end using the real Xdebug extension.

## Changes

### Ahoy command

- Added `ahoy debug` command (aliases: `debug-on`, `xdebug`, `xdebug-on`) that probes the running server process and restarts with `XDEBUG=1` when not already enabled.
- Added `debug-off` and `xdebug-off` as aliases on the existing `ahoy start` command.

### Makefile targets

- Added `debug` target with an inline probe-and-restart recipe.
- Added alias targets `debug-on`, `xdebug`, `xdebug-on` (prerequisite chain to `debug`) and `debug-off`, `xdebug-off` (prerequisite chain to `start`).
- Replaced commas with spaces in the `.PHONY` declaration (commas made GNU Make treat every entry as a literal name with a trailing comma, so the real targets were never actually flagged as phony) and added all new targets to it.
- Added `debug` entry to the `help` target output.

### PHP webserver bootstrap

- `.devtools/start` now reads the `XDEBUG` environment variable and conditionally appends `-d xdebug.mode=debug -d xdebug.start_with_request=yes` to the `php -S` launch command.
- When `XDEBUG=1` is set, the script first probes `php -v` for the loaded Xdebug extension and aborts with a clear install-link message if the extension is missing - no destructive kill of the existing server happens in that case.
- Status line in the startup banner changed from a static "Re-run when you enable or disable XDebug." reminder to a dynamic `XDebug    : Enabled / Disabled` indicator.

### Documentation

- Added "Step-debugging with XDebug" sections to both `README.md` and `README.dist.md` covering installation, the toggle commands with their aliases, the coverage note, and links to the Xdebug Helper browser extension for Chrome and Firefox.

### CI / Test coverage

- `.github/workflows/scaffold-test.yml` gains a `p5` group in the test matrix (Ubuntu + macOS).
- The `p5` runner installs the real `xdebug` PHP extension (instead of `pcov`) with a baseline `xdebug.mode=off`, and runs `composer test` (no coverage) rather than `composer test-coverage`.
- Upload-artifact and Codecov steps are skipped for `p5` (no coverage report).
- New `XdebugTest` functional test class (`.scaffold/tests/src/Functional/XdebugTest.php`, `#[Group('p5')]`) exercises the full cycle: assemble → start (disabled) → debug (enabled) → debug again (idempotent) → start (disabled again), using a PHP probe file served by the running webserver that reads `ini_get('xdebug.mode')` from inside the live process.
- `.scaffold/CLAUDE.md` updated to document the `p5` group purpose and to sync the `p0..p4` references to `p0..p5`.

### Snapshot fixtures

- Regenerated `.scaffold/tests/fixtures/init/_baseline/.ahoy.yml`, `.../.devtools/start`, `.../README.md` and the four `*_makefile` / `*_both_wrappers` Makefile fixtures so the `init.php` snapshot test reflects all of the above.

## Before / After

```
Before
──────
Developer wants step-debugging:
  ┌─────────────────────────────────────────────────────┐
  │ 1. Edit .env (or export XDEBUG=1 in shell manually) │
  │ 2. Kill PHP server                                  │
  │ 3. Re-run .devtools/start                           │
  │ 4. No feedback on whether XDebug is actually on     │
  │ 5. No check that the extension is even installed    │
  └─────────────────────────────────────────────────────┘
  Banner: "Re-run when you enable or disable XDebug."
  (static text regardless of actual state)

After
─────
Developer wants step-debugging:
  ┌──────────────────────────────────────────────────────┐
  │  ahoy debug  (or: make debug / ahoy xdebug / ...)    │
  │                                                      │
  │  Probe: grep running server command for              │
  │         xdebug.mode=debug                            │
  │                                                      │
  │  Already enabled?  ──► "XDebug is already enabled."  │
  │  Not enabled?      ──► XDEBUG=1 ./.devtools/start    │
  │                         ├─► php -v has Xdebug?       │
  │                         │   no  ──► FAIL with link   │
  │                         │   yes ──► restart server   │
  │                         └─► "Enabled XDebug."        │
  └──────────────────────────────────────────────────────┘
  Banner: "XDebug    : Enabled"   (dynamic, reflects reality)

  To disable:
  ┌──────────────────────────────────────────────────────┐
  │  ahoy start  (or: make start / ahoy debug-off / ...) │
  │  Banner: "XDebug    : Disabled"                      │
  └──────────────────────────────────────────────────────┘
```
