### PR TITLE
[#376] Skipped already-installed suggested dependencies in 'assemble' to avoid interactive Composer prompt.

### DIFF
--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -168,8 +168,13 @@ PASS('Dependencies installed.');
 // them in extension's composer.json.
 TASK("Installing suggested dependencies from extension's composer.json.");
 $composer_data = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+$build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
 if (isset($composer_data['suggest']) && is_array($composer_data['suggest'])) {
   foreach (array_keys($composer_data['suggest']) as $suggest) {
+    if (isset($build_json['require'][$suggest]) || isset($build_json['require-dev'][$suggest])) {
+      NOTE('Skipping %s (already in require or require-dev).', $suggest);
+      continue;
+    }
     passthru_or_fail(sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest)));
   }
 }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -168,8 +168,13 @@ PASS('Dependencies installed.');
 // them in extension's composer.json.
 TASK("Installing suggested dependencies from extension's composer.json.");
 $composer_data = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+$build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
 if (isset($composer_data['suggest']) && is_array($composer_data['suggest'])) {
   foreach (array_keys($composer_data['suggest']) as $suggest) {
+    if (isset($build_json['require'][$suggest]) || isset($build_json['require-dev'][$suggest])) {
+      NOTE('Skipping %s (already in require or require-dev).', $suggest);
+      continue;
+    }
     passthru_or_fail(sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest)));
   }
 }

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -249,9 +249,14 @@ final class AssembleTest extends UnitTestCase {
     // 7. Suggested dependencies. Entries already present in the extension's
     // require / require-dev are skipped (no composer require call).
     foreach (array_keys($config['suggestions']) as $suggest) {
-      if (isset($config['extension_require'][$suggest]) || isset($config['extension_require_dev'][$suggest])) {
+      if (isset($config['extension_require'][$suggest])) {
         continue;
       }
+
+      if (isset($config['extension_require_dev'][$suggest])) {
+        continue;
+      }
+
       $passthru_responses[] = ['cmd' => sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest))];
     }
 

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -48,6 +48,8 @@ final class AssembleTest extends UnitTestCase {
       'has_patches' => FALSE,
       'github_token' => '',
       'suggestions' => [],
+      'extension_require' => [],
+      'extension_require_dev' => [],
       'has_deprecations_disabled' => FALSE,
       'has_package_lock' => FALSE,
       'has_skip_npm_build' => FALSE,
@@ -63,18 +65,25 @@ final class AssembleTest extends UnitTestCase {
 
     // Build composer.json content.
     $composer_json = ['name' => 'drupal/' . $config['extension_name']];
+    if ($config['extension_require'] !== []) {
+      $composer_json['require'] = $config['extension_require'];
+    }
+    if ($config['extension_require_dev'] !== []) {
+      $composer_json['require-dev'] = $config['extension_require_dev'];
+    }
     if ($config['suggestions'] !== []) {
       $composer_json['suggest'] = $config['suggestions'];
     }
     $composer_json_str = json_encode($composer_json, JSON_THROW_ON_ERROR);
 
-    // Build/composer.json content (scaffold).
+    // Build/composer.json content (scaffold, with extension require/require-dev
+    // merged in to mirror the real assemble flow).
     $build_composer_json = json_encode([
       'repositories' => [
         ['type' => 'composer', 'url' => 'https://packages.drupal.org/8'],
       ],
-      'require' => ['drupal/core-recommended' => '^11', 'drupal/core-composer-scaffold' => '^11'],
-      'require-dev' => ['drupal/core-dev' => '^11'],
+      'require' => array_merge(['drupal/core-recommended' => '^11', 'drupal/core-composer-scaffold' => '^11'], $config['extension_require']),
+      'require-dev' => array_merge(['drupal/core-dev' => '^11'], $config['extension_require_dev']),
       'minimum-stability' => 'stable',
       'prefer-stable' => TRUE,
     ], JSON_THROW_ON_ERROR);
@@ -237,8 +246,12 @@ final class AssembleTest extends UnitTestCase {
     // 6. composer install.
     $passthru_responses[] = ['cmd' => 'composer --working-dir=build install'];
 
-    // 7. Suggested dependencies.
+    // 7. Suggested dependencies. Entries already present in the extension's
+    // require / require-dev are skipped (no composer require call).
     foreach (array_keys($config['suggestions']) as $suggest) {
+      if (isset($config['extension_require'][$suggest]) || isset($config['extension_require_dev'][$suggest])) {
+        continue;
+      }
       $passthru_responses[] = ['cmd' => sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest))];
     }
 
@@ -332,6 +345,18 @@ final class AssembleTest extends UnitTestCase {
       $this->assertStringContainsString('Processing front-end dependencies', $output);
       $this->assertStringContainsString('Front-end dependencies processed', $output);
     }
+
+    // Suggested packages already present in require / require-dev must be
+    // skipped - composer require on an existing package prompts interactively
+    // and would hang the build.
+    $extension_require = $config['extension_require'] ?? [];
+    $extension_require_dev = $config['extension_require_dev'] ?? [];
+    foreach (array_keys($config['suggestions'] ?? []) as $suggest) {
+      if (isset($extension_require[$suggest]) || isset($extension_require_dev[$suggest])) {
+        $this->assertStringContainsString(sprintf('Skipping %s (already in require or require-dev)', $suggest), $output);
+      }
+    }
+    $this->assertStringContainsString('Suggested dependencies installed', $output);
   }
 
   public static function dataProviderAssembleSuccess(): \Iterator {
@@ -380,6 +405,52 @@ final class AssembleTest extends UnitTestCase {
       'config' => [
         'extension_type' => 'module',
         'github_token' => '',
+        'suggestions' => ['drupal/token' => 'Token support', 'drupal/pathauto' => 'Pathauto'],
+        'has_build_dir' => FALSE,
+        'has_patches' => FALSE,
+        'has_package_lock' => FALSE,
+        'has_skip_npm_build' => FALSE,
+        'tool_files' => ['phpcs.xml', 'phpunit.xml'],
+      ],
+    ];
+    // 'drupal/token' is BOTH a dev dependency AND a suggestion. Without the
+    // skip, composer require would prompt to move it from require-dev to
+    // require and hang the build.
+    yield 'suggested dependency overlaps with require-dev' => [
+      'env' => [],
+      'config' => [
+        'extension_type' => 'module',
+        'github_token' => '',
+        'extension_require_dev' => ['drupal/token' => '^1.17'],
+        'suggestions' => ['drupal/token' => 'Token support', 'drupal/pathauto' => 'Pathauto'],
+        'has_build_dir' => FALSE,
+        'has_patches' => FALSE,
+        'has_package_lock' => FALSE,
+        'has_skip_npm_build' => FALSE,
+        'tool_files' => ['phpcs.xml', 'phpunit.xml'],
+      ],
+    ];
+    yield 'suggested dependency overlaps with require' => [
+      'env' => [],
+      'config' => [
+        'extension_type' => 'module',
+        'github_token' => '',
+        'extension_require' => ['drupal/pathauto' => '^1.13'],
+        'suggestions' => ['drupal/token' => 'Token support', 'drupal/pathauto' => 'Pathauto'],
+        'has_build_dir' => FALSE,
+        'has_patches' => FALSE,
+        'has_package_lock' => FALSE,
+        'has_skip_npm_build' => FALSE,
+        'tool_files' => ['phpcs.xml', 'phpunit.xml'],
+      ],
+    ];
+    yield 'all suggested dependencies overlap and are skipped' => [
+      'env' => [],
+      'config' => [
+        'extension_type' => 'module',
+        'github_token' => '',
+        'extension_require' => ['drupal/pathauto' => '^1.13'],
+        'extension_require_dev' => ['drupal/token' => '^1.17'],
         'suggestions' => ['drupal/token' => 'Token support', 'drupal/pathauto' => 'Pathauto'],
         'has_build_dir' => FALSE,
         'has_patches' => FALSE,


### PR DESCRIPTION
Closes #376

## Summary

`.devtools/assemble` was calling `composer require` for every entry in the extension's `suggest` section, but by that point the extension's `require` and `require-dev` had already been merged into `build/composer.json` and `composer install` had run. Requiring an already-installed package caused Composer to prompt interactively ("Do you want to move this requirement?") and hang the CI build. The fix reads `build/composer.json` once before the suggest loop and skips any package already present in `require` or `require-dev`, logging a `NOTE: Skipping <pkg> (already in require or require-dev).` message for each skipped entry.

## Changes

**`.devtools/assemble`**
- Loads `build/composer.json` before the suggest loop.
- Skips any suggested package whose key is already in `require` or `require-dev` of the assembled manifest.
- Emits a `NOTE` message for each skipped package.

**`.scaffold/tests/src/Unit/AssembleTest.php`**
- `setupAssembleMocks` accepts `extension_require` / `extension_require_dev` config keys, mirrors them into both the extension and build composer.json fixtures, and excludes overlapping packages from the expected `passthru` call sequence.
- `testAssembleSuccess` asserts a `Skipping <pkg>` output line for each overlapping suggestion.
- Three new data-provider cases: `suggested dependency overlaps with require-dev`, `suggested dependency overlaps with require`, `all suggested dependencies overlap and are skipped`.
- The existing `with suggested dependencies` case is retained as the no-overlap baseline.

## Before / After

```
BEFORE
──────
assemble script
  └─ foreach suggest entry
       └─ composer require <pkg>        ← runs even when <pkg> is already in
                                           require / require-dev; Composer
                                           prompts interactively → build hangs

AFTER
─────
assemble script
  └─ load build/composer.json once
  └─ foreach suggest entry
       ├─ if key in require OR require-dev
       │    └─ NOTE: Skipping <pkg> ...  ← no composer call; build continues
       └─ else
            └─ composer require <pkg>    ← only truly new packages
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the `.devtools/assemble` script to prevent interactive Composer prompts when installing suggested dependencies that are already present in the assembled build. The script now reads `build/composer.json` before processing suggestions and skips any suggested package that already exists in the build's `require` or `require-dev` sections, logging a note instead of attempting to re-install it.

## Changes

**`.devtools/assemble`**
- Loads the generated `build/composer.json` into a variable before iterating over suggested dependencies
- Checks each suggested package against the build's existing `require` and `require-dev` sections
- Skips running `composer require` for packages already present, logging "NOTE: Skipping <pkg> (already in require or require-dev)"
- Preserves existing behavior for suggestions not present in the build

**`.scaffold/tests/fixtures/init/_baseline/.devtools/assemble`**
- Baseline fixture updated with the same conditional installation logic

**`.scaffold/tests/src/Unit/AssembleTest.php`**
- Updated `setupAssembleMocks` to include `extension_require` and `extension_require_dev` parameters
- Modified mock setup to mirror extension requirements into the build's `composer.json`
- Updated passthru call sequences to exclude overlapping packages from `composer require` commands
- Added assertions to verify "Skipping" messages are emitted for overlapping dependencies
- Added three new test data-provider scenarios covering overlaps with `require-dev`, `require`, and all suggestions overlapping
- Retained existing non-overlap test case

## Impact

Prevents Composer's interactive prompt (which occurs when requiring an already-installed package) from being triggered in the assemble script, eliminating CI hangs in headless/non-interactive environments while maintaining backward compatibility.

## Related issues

Addresses `#376`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlexSkrypnyk/drupal_extension_scaffold/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->