### PR TITLE
[#380] Fixed 'test-js' failure when no JS test files exist by adding '--passWithNoTests' to scaffolded 'package.json'.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/package.json
+++ b/.scaffold/tests/fixtures/init/_baseline/package.json
@@ -11,7 +11,7 @@
     "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
     "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",
     "lint-fix": "npm run lint-fix-js && npm run lint-fix-css",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "build": "echo Would run build"
   },
   "engines": {

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -151,6 +151,13 @@ final class AhoyTest extends DevtoolsTestCase {
 
     $this->processRun('ahoy', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
+
+    // Projects without any JS tests (CSS-only modules, modules without custom
+    // JS) must still see `test-js` succeed.
+    unlink(self::$sut . '/js/your_extension.test.js');
+
+    $this->processRun('ahoy', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
   }
 
   protected function runUnitTests(): void {

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -150,6 +150,13 @@ final class MakeTest extends DevtoolsTestCase {
 
     $this->processRun('make', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
+
+    // Projects without any JS tests (CSS-only modules, modules without custom
+    // JS) must still see `test-js` succeed.
+    unlink(self::$sut . '/js/your_extension.test.js');
+
+    $this->processRun('make', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
   }
 
   protected function runUnitTests(): void {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
     "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",
     "lint-fix": "npm run lint-fix-js && npm run lint-fix-css",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "build": "echo Would run build"
   },
   "engines": {


### PR DESCRIPTION
Closes #380

## Summary

The scaffolded `package.json` shipped `"test": "jest"` without `--passWithNoTests`. Consumer projects with no `*.test.js` files - CSS-only modules, or modules without custom JavaScript - failed `ahoy test-js` / `make test-js` with `No tests found, exiting with code 1`. The fix adds `--passWithNoTests` to bring Jest's behaviour in line with the already-consistent ESLint (`--no-error-on-unmatched-pattern`) and Stylelint (`--allow-empty-input`) scripts.

A second issue affects consumer projects that adopted PHPCS 4.x (shipped via `drupal/coder:^9`): the legacy `@codingStandardsIgnoreStart` / `@codingStandardsIgnoreEnd` inline suppressions are no longer recognised and must be replaced with `phpcs:disable` / `phpcs:enable`. The scaffold itself does not use the legacy form, so no code change is needed here. This note exists so consumers see it in release notes and can migrate their own code - particularly `*.api.php` hook documentation files, which commonly rely on these suppressions.

## Changes

**`package.json` and `.scaffold/tests/fixtures/init/_baseline/package.json`**

- Changed the `test` script from `jest` to `jest --passWithNoTests` in both the template root and the matching baseline fixture snapshot so the two stay in sync.

**`.scaffold/tests/src/Functional/AhoyTest.php` and `MakeTest.php`**

- Extended `runJsTests()` in both test classes: after the existing assertion that `test-js` fails when the test file contains a deliberate error, the test now removes `js/your_extension.test.js` entirely and asserts that `ahoy test-js` / `make test-js` still succeeds (exit 0) - covering the no-JS-tests scenario.

## Before / After

```
Before                                     After
─────────────────────────────────────      ─────────────────────────────────────
"test": "jest"                             "test": "jest --passWithNoTests"

ahoy test-js (no *.test.js files)         ahoy test-js (no *.test.js files)
  → exit 1  "No tests found"                → exit 0  "No tests found"

make test-js (no *.test.js files)         make test-js (no *.test.js files)
  → exit 1  "No tests found"                → exit 0  "No tests found"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Closes `#380`.

Updates the scaffolded `package.json` test script from `"jest"` to `"jest --passWithNoTests"` to ensure the `ahoy test-js` / `make test-js` command succeeds (exit 0) even when consumer projects have no `*.test.js` files. Previously, Jest would fail with exit code 1 when no tests were found, causing CI failures. This aligns Jest's behavior with existing ESLint/Stylelint scripts that accept empty patterns/inputs.

## Changes

- **package.json**: Updated test script to `"jest --passWithNoTests"`
- **.scaffold/tests/fixtures/init/_baseline/package.json**: Updated baseline fixture to match template changes
- **.scaffold/tests/src/Functional/AhoyTest.php**: Extended `runJsTests()` to verify that `ahoy test-js` succeeds when no JS test files exist, simulating projects without JS tests
- **.scaffold/tests/src/Functional/MakeTest.php**: Extended `runJsTests()` to verify that `make test-js` succeeds when no JS test files exist

## Notes

The PR also documents a secondary issue regarding PHPCS 4.x (via drupal/coder:^9) which no longer recognizes legacy inline suppressions `@codingStandardsIgnoreStart` / `@codingStandardsIgnoreEnd`. These must be replaced with `phpcs:disable` / `phpcs:enable`. While the scaffold itself does not use the legacy form, consumers are advised to migrate their code, particularly in `*.api.php` files containing hook documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlexSkrypnyk/drupal_extension_scaffold/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->