### PR TITLE
[#380] Added '--passWithNoTests' flag to template jest test command.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/package.json
+++ b/.scaffold/tests/fixtures/init/_baseline/package.json
@@ -11,7 +11,7 @@
     "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
     "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",
     "lint-fix": "npm run lint-fix-js && npm run lint-fix-css",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "build": "echo Would run build"
   },
   "engines": {

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -151,6 +151,13 @@ final class AhoyTest extends DevtoolsTestCase {
 
     $this->processRun('ahoy', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
+
+    // Projects without any JS tests (CSS-only modules, modules without custom
+    // JS) must still see `test-js` succeed.
+    unlink(self::$sut . '/js/your_extension.test.js');
+
+    $this->processRun('ahoy', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
   }
 
   protected function runUnitTests(): void {

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -150,6 +150,13 @@ final class MakeTest extends DevtoolsTestCase {
 
     $this->processRun('make', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessFailed();
+
+    // Projects without any JS tests (CSS-only modules, modules without custom
+    // JS) must still see `test-js` succeed.
+    unlink(self::$sut . '/js/your_extension.test.js');
+
+    $this->processRun('make', ['test-js'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
   }
 
   protected function runUnitTests(): void {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
     "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",
     "lint-fix": "npm run lint-fix-js && npm run lint-fix-css",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "build": "echo Would run build"
   },
   "engines": {


### PR DESCRIPTION
Closes #380

## Summary

Running `test-js` via `ahoy test-js` or `make test-js` would fail with a Jest "no tests found" error on projects that have no JavaScript test files (e.g. CSS-only modules or modules with no custom JS). The fix adds `--passWithNoTests` to the `test` script in both the root `package.json` template and the baseline fixture used by the functional test suite, so Jest exits cleanly when no test files are present. Functional test coverage is extended in both `AhoyTest` and `MakeTest` to assert this behaviour explicitly.

## Changes

- **`package.json`** (root template): added `--passWithNoTests` to the `jest` invocation in the `test` script.
- **`.scaffold/tests/fixtures/init/_baseline/package.json`** (fixture): same change applied to keep the baseline fixture in sync with the template.
- **`.scaffold/tests/src/Functional/AhoyTest.php`**: after the existing assertion that `test-js` fails when the test file contains an intentional failure, the test now removes the JS test file entirely and asserts that `test-js` still succeeds.
- **`.scaffold/tests/src/Functional/MakeTest.php`**: identical extension mirroring the Ahoy variant for the Make workflow.

## Before / After

```
Before
──────
project has no *.test.js files

  ahoy test-js  ──►  jest  ──►  No tests found  ──►  EXIT 1  (FAIL)

After
─────
project has no *.test.js files

  ahoy test-js  ──►  jest --passWithNoTests  ──►  No tests found  ──►  EXIT 0  (PASS)
```
