### PR TITLE
[#386] Added 'drevops/phpcs-standard' to PHPCS configuration.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/composer.dev.json
+++ b/.scaffold/tests/fixtures/init/_baseline/composer.dev.json
@@ -3,6 +3,7 @@
         "behat/mink": "__VERSION__",
         "behat/mink-browserkit-driver": "__VERSION__",
         "dealerdirect/phpcodesniffer-composer-installer": "__VERSION__",
+        "drevops/phpcs-standard": "__VERSION__",
         "drupal/coder": "^8 || ^9",
         "drush/drush": "^12 || ^13",
         "jangregor/phpstan-prophecy": "__VERSION__",

--- a/.scaffold/tests/fixtures/init/_baseline/phpcs.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpcs.xml
@@ -7,6 +7,7 @@
 
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>
+    <rule ref="DrevOps"/>
     <rule ref="PHPCompatibility"/>
     <rule ref="Generic.PHP.RequireStrictTypes"/>
 

--- a/.scaffold/tests/fixtures/init/_baseline/rector.php
+++ b/.scaffold/tests/fixtures/init/_baseline/rector.php
@@ -98,14 +98,14 @@ return RectorConfig::configure()
   ])
   // Configure Drupal autoloading.
   ->withAutoloadPaths((function (): array {
-    $drupalFinder = new DrupalFinderComposerRuntime();
-    $drupalRoot = $drupalFinder->getDrupalRoot();
+    $drupal_finder = new DrupalFinderComposerRuntime();
+    $drupal_root = $drupal_finder->getDrupalRoot();
 
     return [
-      $drupalRoot . '/core',
-      $drupalRoot . '/modules',
-      $drupalRoot . '/themes',
-      $drupalRoot . '/profiles',
+      $drupal_root . '/core',
+      $drupal_root . '/modules',
+      $drupal_root . '/themes',
+      $drupal_root . '/profiles',
     ];
   })())
   // Drupal file extensions.

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -3,6 +3,7 @@
         "behat/mink": "^1.11",
         "behat/mink-browserkit-driver": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
+        "drevops/phpcs-standard": "^0.6.2",
         "drupal/coder": "^8 || ^9",
         "drush/drush": "^12 || ^13",
         "jangregor/phpstan-prophecy": "^1.0.2",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,7 @@
 
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>
+    <rule ref="DrevOps"/>
     <rule ref="PHPCompatibility"/>
     <rule ref="Generic.PHP.RequireStrictTypes"/>
 

--- a/rector.php
+++ b/rector.php
@@ -98,14 +98,14 @@ return RectorConfig::configure()
   ])
   // Configure Drupal autoloading.
   ->withAutoloadPaths((function (): array {
-    $drupalFinder = new DrupalFinderComposerRuntime();
-    $drupalRoot = $drupalFinder->getDrupalRoot();
+    $drupal_finder = new DrupalFinderComposerRuntime();
+    $drupal_root = $drupal_finder->getDrupalRoot();
 
     return [
-      $drupalRoot . '/core',
-      $drupalRoot . '/modules',
-      $drupalRoot . '/themes',
-      $drupalRoot . '/profiles',
+      $drupal_root . '/core',
+      $drupal_root . '/modules',
+      $drupal_root . '/themes',
+      $drupal_root . '/profiles',
     ];
   })())
   // Drupal file extensions.


### PR DESCRIPTION
Closes #386

## Summary

Adds [`drevops/phpcs-standard`](https://github.com/drevops/phpcs-standard) as a `require-dev` dependency in `composer.dev.json` and registers its `DrevOps` ruleset in `phpcs.xml` between the existing `DrupalPractice` and `PHPCompatibility` rules. The scaffold's own self-tests already use this standard; this PR surfaces the same standard into the consumer-facing PHPCS configuration so that scaffolded projects benefit from the same enforcement out of the box. The `DrevOps` ruleset enforces `snake_case` for local variables and parameters, which aligns with the project's existing PHP naming convention. The scaffold's own template `rector.php` had two camelCase closure variables that the new rule flagged on first run; those were renamed in-place. Baseline snapshots used by the scaffold's `InitTest` suite are regenerated to reflect all source changes.

## Changes

### Standard wiring

- **`composer.dev.json`** - Added `"drevops/phpcs-standard": "^0.6.2"` to `require-dev`, sorted alphabetically between `dealerdirect/phpcodesniffer-composer-installer` and `drupal/coder`. The version constraint matches the one already used by `.scaffold/tests/composer.json`.
- **`phpcs.xml`** - Added `<rule ref="DrevOps"/>` between the `DrupalPractice` and `PHPCompatibility` rule references.

### Standard compliance

- **`rector.php`** - Renamed `$drupalFinder` → `$drupal_finder` and `$drupalRoot` → `$drupal_root` inside the `withAutoloadPaths` closure. These were the only camelCase local variables in the scaffold's template PHP, surfaced by the new `DrevOps.NamingConventions.LocalVariableNaming.NotSnakeCase` sniff.

### Snapshot regeneration

- **`.scaffold/tests/fixtures/init/_baseline/composer.dev.json`** - Regenerated to include `"drevops/phpcs-standard": "__VERSION__"`.
- **`.scaffold/tests/fixtures/init/_baseline/phpcs.xml`** - Regenerated to include `<rule ref="DrevOps"/>`.
- **`.scaffold/tests/fixtures/init/_baseline/rector.php`** - Regenerated to reflect the snake_case variable rename.

All snapshot fixtures were produced via `composer --working-dir=.scaffold/tests update-snapshots` per the scaffold's HARD RULE (never hand-edit fixtures).

## Before / After

**`phpcs.xml` ruleset (before):**

```xml
<rule ref="Drupal"/>
<rule ref="DrupalPractice"/>
<rule ref="PHPCompatibility"/>
<rule ref="Generic.PHP.RequireStrictTypes"/>
```

**`phpcs.xml` ruleset (after):**

```xml
<rule ref="Drupal"/>
<rule ref="DrupalPractice"/>
<rule ref="DrevOps"/>
<rule ref="PHPCompatibility"/>
<rule ref="Generic.PHP.RequireStrictTypes"/>
```

**`rector.php` closure (before):**

```php
->withAutoloadPaths((function (): array {
  $drupalFinder = new DrupalFinderComposerRuntime();
  $drupalRoot = $drupalFinder->getDrupalRoot();

  return [
    $drupalRoot . '/core',
    $drupalRoot . '/modules',
    $drupalRoot . '/themes',
    $drupalRoot . '/profiles',
  ];
})())
```

**`rector.php` closure (after):**

```php
->withAutoloadPaths((function (): array {
  $drupal_finder = new DrupalFinderComposerRuntime();
  $drupal_root = $drupal_finder->getDrupalRoot();

  return [
    $drupal_root . '/core',
    $drupal_root . '/modules',
    $drupal_root . '/themes',
    $drupal_root . '/profiles',
  ];
})())
```
