### PR TITLE
[#389] Added Jest coverage collection and Codecov upload of the Jest report.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,7 +69,9 @@
       },
       "rules": {
         "no-eval": "off",
-        "max-nested-callbacks": ["warn", 5]
+        "max-nested-callbacks": ["warn", 5],
+        "global-require": "off",
+        "import/extensions": "off"
       }
     }
   ],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.name }}
-          path: ./.logs/coverage/phpunit/.coverage-html
+          path: ./.logs/coverage
           include-hidden-files: true
           if-no-files-found: error
 
@@ -242,7 +242,7 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml
+          files: ./.logs/coverage/phpunit/cobertura.xml,./.logs/coverage/jest/cobertura.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,21 +238,11 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-      - name: Upload PHP coverage report to Codecov
+      - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload JS coverage report to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
-        if: ${{ env.CODECOV_TOKEN != '' && hashFiles('.logs/coverage/jest/cobertura.xml') != '' }}
-        with:
-          files: ./.logs/coverage/jest/cobertura.xml
+          directory: ./.logs/coverage
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,11 +238,21 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-      - name: Upload coverage report to Codecov
+      - name: Upload PHP coverage report to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml,./.logs/coverage/jest/cobertura.xml
+          files: ./.logs/coverage/phpunit/cobertura.xml
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload JS coverage report to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        if: ${{ env.CODECOV_TOKEN != '' && hashFiles('.logs/coverage/jest/cobertura.xml') != '' }}
+        with:
+          files: ./.logs/coverage/jest/cobertura.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/.scaffold/tests/fixtures/init/_baseline/.eslintrc.json
+++ b/.scaffold/tests/fixtures/init/_baseline/.eslintrc.json
@@ -69,7 +69,9 @@
       },
       "rules": {
         "no-eval": "off",
-        "max-nested-callbacks": ["warn", 5]
+        "max-nested-callbacks": ["warn", 5],
+        "global-require": "off",
+        "import/extensions": "off"
       }
     }
   ],

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/upload-artifact@__HASH__ # __VERSION__
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.name }}
-          path: ./.logs/coverage/phpunit/.coverage-html
+          path: ./.logs/coverage
           include-hidden-files: true
           if-no-files-found: error
 
@@ -242,7 +242,7 @@ jobs:
         uses: codecov/codecov-action@__HASH__ # __VERSION__
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml
+          files: ./.logs/coverage/phpunit/cobertura.xml,./.logs/coverage/jest/cobertura.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -238,11 +238,21 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-      - name: Upload coverage report to Codecov
+      - name: Upload PHP coverage report to Codecov
         uses: codecov/codecov-action@__HASH__ # __VERSION__
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml,./.logs/coverage/jest/cobertura.xml
+          files: ./.logs/coverage/phpunit/cobertura.xml
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload JS coverage report to Codecov
+        uses: codecov/codecov-action@__HASH__ # __VERSION__
+        if: ${{ env.CODECOV_TOKEN != '' && hashFiles('.logs/coverage/jest/cobertura.xml') != '' }}
+        with:
+          files: ./.logs/coverage/jest/cobertura.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -238,21 +238,11 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-      - name: Upload PHP coverage report to Codecov
+      - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@__HASH__ # __VERSION__
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload JS coverage report to Codecov
-        uses: codecov/codecov-action@__HASH__ # __VERSION__
-        if: ${{ env.CODECOV_TOKEN != '' && hashFiles('.logs/coverage/jest/cobertura.xml') != '' }}
-        with:
-          files: ./.logs/coverage/jest/cobertura.xml
+          directory: ./.logs/coverage
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/.scaffold/tests/fixtures/init/_baseline/jest.config.js
+++ b/.scaffold/tests/fixtures/init/_baseline/jest.config.js
@@ -19,8 +19,21 @@ dirs.forEach((dir) => {
 });
 
 module.exports = {
+  // V8 tracks files outside rootDir only when rootDir contains them, so
+  // anchor at the project root rather than the build directory.
+  rootDir: path.resolve(__dirname, '..'),
   testEnvironment: 'jsdom',
   roots,
   testMatch: ['**/*.test.js'],
   testPathIgnorePatterns: ['/node_modules/', '/vendor/'],
+  collectCoverage: true,
+  coverageProvider: 'v8',
+  coveragePathIgnorePatterns: ['/node_modules/', '/vendor/', '\\.test\\.js$'],
+  coverageDirectory: path.resolve(__dirname, '../.logs/coverage/jest'),
+  coverageReporters: [
+    'text',
+    ['html', { subdir: '.coverage-html' }],
+    ['cobertura', { file: 'cobertura.xml' }],
+  ],
+  modulePaths: [path.resolve(__dirname, 'node_modules')],
 };

--- a/.scaffold/tests/fixtures/init/_baseline/js/force_crystal.test.js
+++ b/.scaffold/tests/fixtures/init/_baseline/js/force_crystal.test.js
@@ -3,16 +3,15 @@
  * Tests for Force Crystal behaviors.
  */
 
-const fs = require('fs');
-const path = require('path');
-
 describe('Drupal.behaviors.yourExtension', () => {
   beforeEach(() => {
     global.Drupal = { behaviors: {} };
 
-    const filePath = path.resolve(__dirname, 'force_crystal.js');
-    const code = fs.readFileSync(filePath, 'utf8');
-    eval(code);
+    // Re-execute the IIFE in an isolated module registry so each test
+    // re-registers the behavior against the fresh global.Drupal.
+    jest.isolateModules(() => {
+      require('./force_crystal.js');
+    });
   });
 
   afterEach(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,8 +19,21 @@ dirs.forEach((dir) => {
 });
 
 module.exports = {
+  // V8 tracks files outside rootDir only when rootDir contains them, so
+  // anchor at the project root rather than the build directory.
+  rootDir: path.resolve(__dirname, '..'),
   testEnvironment: 'jsdom',
   roots,
   testMatch: ['**/*.test.js'],
   testPathIgnorePatterns: ['/node_modules/', '/vendor/'],
+  collectCoverage: true,
+  coverageProvider: 'v8',
+  coveragePathIgnorePatterns: ['/node_modules/', '/vendor/', '\\.test\\.js$'],
+  coverageDirectory: path.resolve(__dirname, '../.logs/coverage/jest'),
+  coverageReporters: [
+    'text',
+    ['html', { subdir: '.coverage-html' }],
+    ['cobertura', { file: 'cobertura.xml' }],
+  ],
+  modulePaths: [path.resolve(__dirname, 'node_modules')],
 };

--- a/js/your_extension.test.js
+++ b/js/your_extension.test.js
@@ -3,16 +3,15 @@
  * Tests for Your Extension behaviors.
  */
 
-const fs = require('fs');
-const path = require('path');
-
 describe('Drupal.behaviors.yourExtension', () => {
   beforeEach(() => {
     global.Drupal = { behaviors: {} };
 
-    const filePath = path.resolve(__dirname, 'your_extension.js');
-    const code = fs.readFileSync(filePath, 'utf8');
-    eval(code);
+    // Re-execute the IIFE in an isolated module registry so each test
+    // re-registers the behavior against the fresh global.Drupal.
+    jest.isolateModules(() => {
+      require('./your_extension.js');
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
Closes #389

## Summary

Scaffolded consumers now ship with full Jest coverage tracking out of the box. `jest.config.js` gains V8 coverage collection writing Cobertura and HTML reports to `.logs/coverage/jest/`, mirroring the PHPUnit layout. The example `*.test.js` switches from `eval()`-driven loading to `jest.isolateModules() + require()` so V8 actually attributes coverage to `your_extension.js` (verified locally: 100% lines, 100% branches, 100% functions). The GitHub Actions workflow bundles both report trees into the coverage artifact and points `codecov-action@v6` at the parent `./.logs/coverage` directory so it auto-discovers whichever standard coverage files are present and merges them into a single Codecov project view.

## Changes

**`jest.config.js`**
- Added `rootDir: path.resolve(__dirname, '..')` - V8 can only track source files that fall under `rootDir`, and the extension source lives at the project root (one level above `build/`), so anchoring there is required for accurate coverage.
- Added `collectCoverage: true` and `coverageProvider: 'v8'` - the Babel provider reports 0% through symlinks; V8 resolves them correctly.
- Added `coverageDirectory: path.resolve(__dirname, '../.logs/coverage/jest')` to mirror the PHPUnit layout at `.logs/coverage/phpunit/`.
- Added `coverageReporters` producing `text` (console summary), `html` (browsable report under `.coverage-html/`), and `cobertura` (machine-readable `cobertura.xml` for Codecov).
- Added `coveragePathIgnorePatterns` to exclude `node_modules`, `vendor`, and test files themselves.
- Added `modulePaths: [path.resolve(__dirname, 'node_modules')]` so module resolution still finds `build/node_modules` after `rootDir` moves up one level.

**`js/your_extension.test.js`**
- Replaced the `fs.readFileSync()` + `eval()` source-loading pattern with `jest.isolateModules()` wrapping a `require('./your_extension.js')`. V8 native coverage cannot attribute coverage to `eval()`'d code (it has no file URL), but it can track a properly required module. The IIFE in `your_extension.js` still captures `Drupal` from the global set up in `beforeEach`, so the test semantics are preserved.
- `jest.isolateModules()` is required (not plain cache invalidation) because Jest maintains its own module registry separate from Node's `require.cache`; only `isolateModules` reliably re-executes the IIFE between tests so each one re-registers the behavior against a fresh `global.Drupal`.

**`.eslintrc.json`**
- Extended the existing `*.test.js` override to also disable `global-require` and `import/extensions`. The new test pattern places `require()` inside the `jest.isolateModules()` callback (not at the top of the file) and references the source by its `.js` filename - both are correct here but flagged by the airbnb-base rules in non-test code.

**`.github/workflows/test.yml`**
- Widened the `Upload coverage report as an artifact` step's `path:` from `./.logs/coverage/phpunit/.coverage-html` to `./.logs/coverage` so both PHPUnit and Jest reports are bundled.
- Changed the `Upload coverage report to Codecov` step from `files: ./.logs/coverage/phpunit/cobertura.xml` to `directory: ./.logs/coverage` so the action auto-discovers whichever coverage files are present. Avoids a missing-file ENOENT when consumers do not run JS tests (the `Run JS tests` step is itself conditional on `hashFiles('build/node_modules/.package-lock.json') != ''`). Matches the pattern this repo's own `scaffold-test.yml` already uses (`directory: .scaffold/tests/.logs`).

**`.scaffold/tests/fixtures/init/_baseline/...`**
- Regenerated `InitTest` snapshot fixtures (jest config, workflow, eslintrc, test) to reflect the source changes above. Auto-generated via `composer --working-dir=.scaffold/tests update-snapshots`; never hand-edited per `.scaffold/CLAUDE.md`.

`package.json` is intentionally untouched - `jest --passWithNoTests` is already in place from earlier work.

## Verification

Ran `ahoy test-js` locally after the test pattern change. Coverage output:

```
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |
 your_extension.js |     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|-------------------
```

`cobertura.xml` reports `lines-valid="25" lines-covered="25"` and `branches-valid="4" branches-covered="4"` for the example source, confirming Codecov has real data to merge with the PHPUnit report.

## Before / After

**Before** - only PHPUnit flows to Codecov; Jest test runs but produces 0% via `eval()`:

```
CI run
 +-- PHPUnit -> .logs/coverage/phpunit/cobertura.xml ----> Codecov (PHP only)
 +-- Jest (eval-loaded) -> 0% (V8 cannot attribute eval'd code to a file)
```

**After** - Codecov auto-discovers both reports under the parent directory; Jest reports real coverage:

```
CI run
 +-- PHPUnit -> .logs/coverage/phpunit/cobertura.xml --\
 +-- Jest (require-loaded) -> .logs/coverage/jest/cobertura.xml --- +--> Codecov: directory walk
     (only when JS tests ran)                                              merged project view
```
