### PR TITLE
[#393] Added 'info' command, dual-mode field probes, and shared webserver resolution helpers.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -15,7 +15,6 @@ commands:
       ahoy assemble
       ahoy start
       ahoy provision
-      ahoy info
 
   assemble:
     usage: Assemble a codebase using project code and all required dependencies.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -38,8 +38,8 @@ commands:
     usage: Enable PHP XDebug step-debugging for the development server.
     aliases: [debug-on, xdebug, xdebug-on]
     cmd: |
-      ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
-      (XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+      [ "$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
+      (XDEBUG=1 ./.devtools/start && sleep 1 && [ "$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
   provision:
     usage: Provision application within assembled codebase.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -15,6 +15,7 @@ commands:
       ahoy assemble
       ahoy start
       ahoy provision
+      ahoy info
 
   assemble:
     usage: Assemble a codebase using project code and all required dependencies.
@@ -28,6 +29,10 @@ commands:
   stop:
     usage: Stop development environment.
     cmd: ./.devtools/stop
+
+  info:
+    usage: Print a read-only summary of the current environment.
+    cmd: ./.devtools/info
 
   debug:
     usage: Enable PHP XDebug step-debugging for the development server.

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -185,6 +185,44 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
 }
 
 /**
+ * Resolve an environment value from env, then dotenv, then default.
+ *
+ * Mirrors the precedence chain used by the start, stop, provision, and
+ * info scripts: shell environment first, then a matching key in the
+ * dotenv file, then the supplied default. Returns the resolved value
+ * together with a source label identifying which leg of the chain
+ * produced it.
+ *
+ * @param string $name
+ *   Variable name to resolve.
+ * @param string $default
+ *   Value to return when neither env nor the dotenv file provides a
+ *   non-empty value. May be an empty string when callers want to
+ *   detect that case and apply their own fallback (for example,
+ *   start's auto-discovery branch).
+ * @param string $dotenv_file
+ *   Path to the dotenv file to consult.
+ *
+ * @return array{0: string, 1: string}
+ *   Tuple of [value, source] where source is 'env' when the value came
+ *   from the shell environment, the dotenv file path when the value
+ *   came from that file, or 'default' when neither produced a value.
+ */
+function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
+  $env = getenv($name);
+  if ($env !== FALSE && is_string($env) && $env !== '') {
+    return [$env, 'env'];
+  }
+
+  $dotenv = dotenv_read($dotenv_file);
+  if (isset($dotenv[$name]) && $dotenv[$name] !== '') {
+    return [$dotenv[$name], $dotenv_file];
+  }
+
+  return [$default, 'default'];
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -223,6 +223,58 @@ function resolve_env_value(string $name, string $default, string $dotenv_file = 
 }
 
 /**
+ * Resolve the webserver host and port with source tracking.
+ *
+ * Wraps resolve_env_value() for both 'WEBSERVER_HOST' and
+ * 'WEBSERVER_PORT'. Optionally auto-discovers a free port when neither
+ * env nor the dotenv file provides one, persisting the discovered port
+ * back to the dotenv file. Optionally validates that the resolved port
+ * is a valid TCP port number.
+ *
+ * @param bool $auto_discover
+ *   When TRUE and the port resolves from neither env nor dotenv,
+ *   discover a free port via find_free_port() and persist it via
+ *   dotenv_write_var(). The reported port source then becomes the
+ *   dotenv file path because that is where the value now lives.
+ * @param bool $validate_port
+ *   When TRUE, call validate_port_or_fail() on the resolved port and
+ *   abort if it is not a valid TCP port. The info script disables
+ *   this so a malformed value can be surfaced in the output rather
+ *   than crashing the read-only summary.
+ * @param string $dotenv_file
+ *   Path to the dotenv file to read and (optionally) write.
+ *
+ * @return array{host: string, host_source: string, port: string, port_source: string}
+ *   The resolved host and port together with the source label for
+ *   each: 'env' when the value came from the shell environment, the
+ *   dotenv file path when it came from that file, or 'default' when
+ *   the supplied default was used.
+ */
+function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
+  [$host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
+
+  $default_port = $auto_discover ? '' : '8000';
+  [$port, $port_source] = resolve_env_value('WEBSERVER_PORT', $default_port, $dotenv_file);
+
+  if ($auto_discover && $port_source === 'default') {
+    $port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $port, $dotenv_file);
+    $port_source = $dotenv_file;
+  }
+
+  if ($validate_port) {
+    validate_port_or_fail($port, 'WEBSERVER_PORT');
+  }
+
+  return [
+    'host' => $host,
+    'host_source' => $host_source,
+    'port' => $port,
+    'port_source' => $port_source,
+  ];
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -210,7 +210,7 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
  */
 function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
   $env = getenv($name);
-  if ($env !== FALSE && is_string($env) && $env !== '') {
+  if ($env !== FALSE && $env !== '') {
     return [$env, 'env'];
   }
 

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -275,6 +275,23 @@ function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TR
 }
 
 /**
+ * Detect the XDebug state of the dev server listening on the given port.
+ *
+ * Inspects the running PHP process's command line for the
+ * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
+ * server is listening, and '-' when no server is bound to the port.
+ */
+function xdebug_state(string $port): string {
+  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '') {
+    return '-';
+  }
+
+  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.

--- a/.devtools/info
+++ b/.devtools/info
@@ -1,0 +1,134 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @file
+ * Print a read-only summary of the current development environment.
+ *
+ * Resolves PHP, Drupal, Composer, Drush, Node, and npm versions; the
+ * webserver host and port along with where each value was sourced from
+ * (shell env vs '.env' vs default); the running server's XDebug state;
+ * the build directory; the SQLite database path; and the active Drupal
+ * install profile.
+ *
+ * Any value that cannot be resolved prints '-' rather than failing.
+ */
+
+declare(strict_types=1);
+
+namespace DrupalExtensionScaffold\DevTools;
+
+require_once __DIR__ . '/helpers.php';
+
+// -----------------------------------------------------------------------------
+// Resolution.
+// -----------------------------------------------------------------------------
+
+[$webserver_host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost');
+[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '8000');
+
+$drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
+
+$php_version = info_php_version();
+$php_path = command_path('php');
+$composer_version = info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i');
+$node_version = info_tool_version('node --version 2>/dev/null', '/v?(.+)/');
+$npm_version = info_tool_version('npm --version 2>/dev/null', '/(.+)/');
+
+$drush_bin = 'build/vendor/bin/drush';
+$has_drush = is_file($drush_bin);
+$drush_version = $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-';
+$drupal_version = $has_drush ? info_drupal_version($drush_bin) : '-';
+
+$xdebug_state = info_xdebug_state($webserver_port);
+
+$cwd = (string) getcwd();
+$build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
+
+$info_files = glob('*.info.yml');
+$extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
+$db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
+
+// -----------------------------------------------------------------------------
+// Output.
+// -----------------------------------------------------------------------------
+
+echo PHP_EOL;
+echo '===============================' . PHP_EOL;
+echo '       ENVIRONMENT INFO        ' . PHP_EOL;
+echo '===============================' . PHP_EOL;
+echo PHP_EOL;
+printf("Drupal version:     %s%s", $drupal_version, PHP_EOL);
+printf("PHP version:        %s%s%s", $php_version, $php_path !== FALSE && $php_version !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
+printf("Composer:           %s%s", $composer_version, PHP_EOL);
+printf("Drush:              %s%s", $drush_version, PHP_EOL);
+printf("Node / npm:         %s / %s%s", $node_version, $npm_version, PHP_EOL);
+echo PHP_EOL;
+printf("Webserver host:     %s (%s)%s", $webserver_host, $host_source, PHP_EOL);
+printf("Webserver port:     %s (%s)%s", $webserver_port, $port_source, PHP_EOL);
+printf("Site URL:           http://%s:%s%s", $webserver_host, $webserver_port, PHP_EOL);
+printf("XDebug:             %s%s", $xdebug_state, PHP_EOL);
+echo PHP_EOL;
+printf("Build dir:          %s%s", $build_dir, PHP_EOL);
+printf("Database:           %s%s", $db_file, PHP_EOL);
+printf("Drupal profile:     %s%s", $drupal_profile, PHP_EOL);
+echo PHP_EOL;
+
+// -----------------------------------------------------------------------------
+// Local helpers.
+// -----------------------------------------------------------------------------
+
+/**
+ * Get the host PHP version, or '-' if it cannot be parsed.
+ */
+function info_php_version(): string {
+  $out = (string) @shell_exec('php -v 2>/dev/null');
+  if ($out === '' || !preg_match('/^PHP\s+(\S+)/m', $out, $matches)) {
+    return '-';
+  }
+
+  return $matches[1];
+}
+
+/**
+ * Run a version probe and extract the first capture group.
+ *
+ * Returns '-' if the command produces no output or the pattern does
+ * not match.
+ */
+function info_tool_version(string $cmd, string $pattern): string {
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '' || !preg_match($pattern, $out, $matches)) {
+    return '-';
+  }
+
+  return trim($matches[1]);
+}
+
+/**
+ * Get the installed Drupal version via drush, or '-' if unavailable.
+ */
+function info_drupal_version(string $drush_bin): string {
+  $cmd = escapeshellarg($drush_bin) . ' -r ' . escapeshellarg(getcwd() . '/build/web') . ' status --field=drupal-version 2>/dev/null';
+  $out = trim((string) @shell_exec($cmd));
+
+  return $out === '' ? '-' : $out;
+}
+
+/**
+ * Detect the XDebug state of the dev server listening on the given port.
+ *
+ * Uses the same lsof + ps probe as the 'debug' wrapper command:
+ * inspects the running PHP process's command line for the
+ * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
+ * server is listening, and '-' when no server is bound to the port.
+ */
+function info_xdebug_state(string $port): string {
+  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '') {
+    return '-';
+  }
+
+  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
+}

--- a/.devtools/info
+++ b/.devtools/info
@@ -24,8 +24,13 @@ require_once __DIR__ . '/helpers.php';
 // Resolution.
 // -----------------------------------------------------------------------------
 
-[$webserver_host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost');
-[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '8000');
+// validate_port: FALSE so a malformed '.env' entry surfaces in the
+// output instead of crashing the read-only summary.
+$webserver = resolve_webserver(validate_port: FALSE);
+$webserver_host = $webserver['host'];
+$host_source = $webserver['host_source'];
+$webserver_port = $webserver['port'];
+$port_source = $webserver['port_source'];
 
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
 

--- a/.devtools/info
+++ b/.devtools/info
@@ -12,6 +12,14 @@
  * install profile.
  *
  * Any value that cannot be resolved prints '-' rather than failing.
+ *
+ * Two output modes:
+ * - No arguments: print the formatted full summary.
+ * - 'info <field>': print only that field's value on stdout, exit 0.
+ *   Unknown field name prints '-' and exits 1.
+ *
+ * Field-mode keeps expensive subprocess probes lazy: only the requested
+ * field's resolver runs.
  */
 
 declare(strict_types=1);
@@ -21,11 +29,9 @@ namespace DrupalExtensionScaffold\DevTools;
 require_once __DIR__ . '/helpers.php';
 
 // -----------------------------------------------------------------------------
-// Resolution.
+// Cheap resolutions (env + filesystem). Always run.
 // -----------------------------------------------------------------------------
 
-// validate_port: FALSE so a malformed '.env' entry surfaces in the
-// output instead of crashing the read-only summary.
 $webserver = resolve_webserver(validate_port: FALSE);
 $webserver_host = $webserver['host'];
 $host_source = $webserver['host_source'];
@@ -34,19 +40,6 @@ $port_source = $webserver['port_source'];
 
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
 
-$php_version = info_php_version();
-$php_path = command_path('php');
-$composer_version = info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i');
-$node_version = info_tool_version('node --version 2>/dev/null', '/v?(.+)/');
-$npm_version = info_tool_version('npm --version 2>/dev/null', '/(.+)/');
-
-$drush_bin = 'build/vendor/bin/drush';
-$has_drush = is_file($drush_bin);
-$drush_version = $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-';
-$drupal_version = $has_drush ? info_drupal_version($drush_bin) : '-';
-
-$xdebug_state = info_xdebug_state($webserver_port);
-
 $cwd = (string) getcwd();
 $build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
 
@@ -54,29 +47,71 @@ $info_files = glob('*.info.yml');
 $extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
 $db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
 
+$drush_bin = 'build/vendor/bin/drush';
+$has_drush = is_file($drush_bin);
+
+$site_url = sprintf('http://%s:%s', $webserver_host, $webserver_port);
+
 // -----------------------------------------------------------------------------
-// Output.
+// Field resolvers. Each closure is invoked only when its field is requested.
 // -----------------------------------------------------------------------------
+
+$fields = [
+  'drupal-version' => fn(): string => $has_drush ? info_drupal_version($drush_bin) : '-',
+  'php-version' => fn(): string => info_php_version(),
+  'composer' => fn(): string => info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i'),
+  'drush' => fn(): string => $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-',
+  'node' => fn(): string => info_tool_version('node --version 2>/dev/null', '/v?(.+)/'),
+  'npm' => fn(): string => info_tool_version('npm --version 2>/dev/null', '/(.+)/'),
+  'webserver-host' => fn(): string => $webserver_host,
+  'webserver-port' => fn(): string => $webserver_port,
+  'site-url' => fn(): string => $site_url,
+  'xdebug' => fn(): string => xdebug_state($webserver_port),
+  'build-dir' => fn(): string => $build_dir,
+  'database' => fn(): string => $db_file,
+  'drupal-profile' => fn(): string => $drupal_profile,
+];
+
+// -----------------------------------------------------------------------------
+// Field-mode dispatch.
+// -----------------------------------------------------------------------------
+
+$field = isset($argv[1]) && !str_starts_with((string) $argv[1], '-') ? (string) $argv[1] : NULL;
+if ($field !== NULL) {
+  if (isset($fields[$field])) {
+    echo $fields[$field]() . PHP_EOL;
+    quit(0);
+  }
+  echo '-' . PHP_EOL;
+  quit(1);
+}
+
+// -----------------------------------------------------------------------------
+// Full summary. Resolves every field then formats.
+// -----------------------------------------------------------------------------
+
+$values = array_map(fn(callable $cb): string => $cb(), $fields);
+$php_path = command_path('php');
 
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '       ENVIRONMENT INFO        ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
-printf("Drupal version:     %s%s", $drupal_version, PHP_EOL);
-printf("PHP version:        %s%s%s", $php_version, $php_path !== FALSE && $php_version !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
-printf("Composer:           %s%s", $composer_version, PHP_EOL);
-printf("Drush:              %s%s", $drush_version, PHP_EOL);
-printf("Node / npm:         %s / %s%s", $node_version, $npm_version, PHP_EOL);
+printf("Drupal version:     %s%s", $values['drupal-version'], PHP_EOL);
+printf("PHP version:        %s%s%s", $values['php-version'], $php_path !== FALSE && $values['php-version'] !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
+printf("Composer:           %s%s", $values['composer'], PHP_EOL);
+printf("Drush:              %s%s", $values['drush'], PHP_EOL);
+printf("Node / npm:         %s / %s%s", $values['node'], $values['npm'], PHP_EOL);
 echo PHP_EOL;
-printf("Webserver host:     %s (%s)%s", $webserver_host, $host_source, PHP_EOL);
-printf("Webserver port:     %s (%s)%s", $webserver_port, $port_source, PHP_EOL);
-printf("Site URL:           http://%s:%s%s", $webserver_host, $webserver_port, PHP_EOL);
-printf("XDebug:             %s%s", $xdebug_state, PHP_EOL);
+printf("Webserver host:     %s (%s)%s", $values['webserver-host'], $host_source, PHP_EOL);
+printf("Webserver port:     %s (%s)%s", $values['webserver-port'], $port_source, PHP_EOL);
+printf("Site URL:           %s%s", $values['site-url'], PHP_EOL);
+printf("XDebug:             %s%s", $values['xdebug'], PHP_EOL);
 echo PHP_EOL;
-printf("Build dir:          %s%s", $build_dir, PHP_EOL);
-printf("Database:           %s%s", $db_file, PHP_EOL);
-printf("Drupal profile:     %s%s", $drupal_profile, PHP_EOL);
+printf("Build dir:          %s%s", $values['build-dir'], PHP_EOL);
+printf("Database:           %s%s", $values['database'], PHP_EOL);
+printf("Drupal profile:     %s%s", $values['drupal-profile'], PHP_EOL);
 echo PHP_EOL;
 
 // -----------------------------------------------------------------------------
@@ -118,22 +153,4 @@ function info_drupal_version(string $drush_bin): string {
   $out = trim((string) @shell_exec($cmd));
 
   return $out === '' ? '-' : $out;
-}
-
-/**
- * Detect the XDebug state of the dev server listening on the given port.
- *
- * Uses the same lsof + ps probe as the 'debug' wrapper command:
- * inspects the running PHP process's command line for the
- * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
- * server is listening, and '-' when no server is bound to the port.
- */
-function info_xdebug_state(string $port): string {
-  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
-  $out = trim((string) @shell_exec($cmd));
-  if ($out === '') {
-    return '-';
-  }
-
-  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
 }

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -20,15 +20,11 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver hostname.
-[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
-
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
-[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver host and port resolved via the env -> '.env' -> default
+// chain.
+$webserver = resolve_webserver();
+$webserver_host = $webserver['host'];
+$webserver_port = $webserver['port'];
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -21,17 +21,13 @@ require_once __DIR__ . '/helpers.php';
 // -----------------------------------------------------------------------------
 
 // Webserver hostname.
-$webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
+[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
 
 // Webserver port. Resolution precedence:
 // 1. WEBSERVER_PORT env var, if set.
 // 2. WEBSERVER_PORT entry in .env, if present.
 // 3. Default '8000'.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
-}
+[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
 validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Drupal profile to use when installing the site.

--- a/.devtools/start
+++ b/.devtools/start
@@ -16,19 +16,13 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver hostname.
-[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
-
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Auto-discovery via find_free_port(), persisted to .env.
-[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '');
-if ($port_source === 'default') {
-  $webserver_port = (string) find_free_port();
-  dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-}
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver host and port. The helper resolves both via the
+// env -> '.env' -> default chain. With auto_discover: TRUE, a free
+// port is allocated and persisted to '.env' when neither env nor
+// '.env' provides one.
+$webserver = resolve_webserver(auto_discover: TRUE);
+$webserver_host = $webserver['host'];
+$webserver_port = $webserver['port'];
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');

--- a/.devtools/start
+++ b/.devtools/start
@@ -17,22 +17,16 @@ require_once __DIR__ . '/helpers.php';
 // -----------------------------------------------------------------------------
 
 // Webserver hostname.
-$webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
+[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
 
 // Webserver port. Resolution precedence:
 // 1. WEBSERVER_PORT env var, if set.
 // 2. WEBSERVER_PORT entry in .env, if present.
 // 3. Auto-discovery via find_free_port(), persisted to .env.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
-    $webserver_port = $dotenv['WEBSERVER_PORT'];
-  }
-  else {
-    $webserver_port = (string) find_free_port();
-    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-  }
+[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '');
+if ($port_source === 'default') {
+  $webserver_port = (string) find_free_port();
+  dotenv_write_var('WEBSERVER_PORT', $webserver_port);
 }
 validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -20,11 +20,7 @@ require_once __DIR__ . '/helpers.php';
 // 1. WEBSERVER_PORT env var, if set.
 // 2. WEBSERVER_PORT entry in .env, if present.
 // 3. Default '8000'.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
-}
+[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
 validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // -----------------------------------------------------------------------------

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -16,12 +16,8 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
-[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver port resolved via the env -> '.env' -> default chain.
+$webserver_port = resolve_webserver()['port'];
 
 // -----------------------------------------------------------------------------
 

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -15,7 +15,6 @@ commands:
       ahoy assemble
       ahoy start
       ahoy provision
-      ahoy info
 
   assemble:
     usage: Assemble a codebase using project code and all required dependencies.

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -38,8 +38,8 @@ commands:
     usage: Enable PHP XDebug step-debugging for the development server.
     aliases: [debug-on, xdebug, xdebug-on]
     cmd: |
-      ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
-      (XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+      [ "$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
+      (XDEBUG=1 ./.devtools/start && sleep 1 && [ "$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
   provision:
     usage: Provision application within assembled codebase.

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -15,6 +15,7 @@ commands:
       ahoy assemble
       ahoy start
       ahoy provision
+      ahoy info
 
   assemble:
     usage: Assemble a codebase using project code and all required dependencies.
@@ -28,6 +29,10 @@ commands:
   stop:
     usage: Stop development environment.
     cmd: ./.devtools/stop
+
+  info:
+    usage: Print a read-only summary of the current environment.
+    cmd: ./.devtools/info
 
   debug:
     usage: Enable PHP XDebug step-debugging for the development server.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -185,6 +185,44 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
 }
 
 /**
+ * Resolve an environment value from env, then dotenv, then default.
+ *
+ * Mirrors the precedence chain used by the start, stop, provision, and
+ * info scripts: shell environment first, then a matching key in the
+ * dotenv file, then the supplied default. Returns the resolved value
+ * together with a source label identifying which leg of the chain
+ * produced it.
+ *
+ * @param string $name
+ *   Variable name to resolve.
+ * @param string $default
+ *   Value to return when neither env nor the dotenv file provides a
+ *   non-empty value. May be an empty string when callers want to
+ *   detect that case and apply their own fallback (for example,
+ *   start's auto-discovery branch).
+ * @param string $dotenv_file
+ *   Path to the dotenv file to consult.
+ *
+ * @return array{0: string, 1: string}
+ *   Tuple of [value, source] where source is 'env' when the value came
+ *   from the shell environment, the dotenv file path when the value
+ *   came from that file, or 'default' when neither produced a value.
+ */
+function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
+  $env = getenv($name);
+  if ($env !== FALSE && is_string($env) && $env !== '') {
+    return [$env, 'env'];
+  }
+
+  $dotenv = dotenv_read($dotenv_file);
+  if (isset($dotenv[$name]) && $dotenv[$name] !== '') {
+    return [$dotenv[$name], $dotenv_file];
+  }
+
+  return [$default, 'default'];
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -223,6 +223,58 @@ function resolve_env_value(string $name, string $default, string $dotenv_file = 
 }
 
 /**
+ * Resolve the webserver host and port with source tracking.
+ *
+ * Wraps resolve_env_value() for both 'WEBSERVER_HOST' and
+ * 'WEBSERVER_PORT'. Optionally auto-discovers a free port when neither
+ * env nor the dotenv file provides one, persisting the discovered port
+ * back to the dotenv file. Optionally validates that the resolved port
+ * is a valid TCP port number.
+ *
+ * @param bool $auto_discover
+ *   When TRUE and the port resolves from neither env nor dotenv,
+ *   discover a free port via find_free_port() and persist it via
+ *   dotenv_write_var(). The reported port source then becomes the
+ *   dotenv file path because that is where the value now lives.
+ * @param bool $validate_port
+ *   When TRUE, call validate_port_or_fail() on the resolved port and
+ *   abort if it is not a valid TCP port. The info script disables
+ *   this so a malformed value can be surfaced in the output rather
+ *   than crashing the read-only summary.
+ * @param string $dotenv_file
+ *   Path to the dotenv file to read and (optionally) write.
+ *
+ * @return array{host: string, host_source: string, port: string, port_source: string}
+ *   The resolved host and port together with the source label for
+ *   each: 'env' when the value came from the shell environment, the
+ *   dotenv file path when it came from that file, or 'default' when
+ *   the supplied default was used.
+ */
+function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
+  [$host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
+
+  $default_port = $auto_discover ? '' : '8000';
+  [$port, $port_source] = resolve_env_value('WEBSERVER_PORT', $default_port, $dotenv_file);
+
+  if ($auto_discover && $port_source === 'default') {
+    $port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $port, $dotenv_file);
+    $port_source = $dotenv_file;
+  }
+
+  if ($validate_port) {
+    validate_port_or_fail($port, 'WEBSERVER_PORT');
+  }
+
+  return [
+    'host' => $host,
+    'host_source' => $host_source,
+    'port' => $port,
+    'port_source' => $port_source,
+  ];
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -210,7 +210,7 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
  */
 function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
   $env = getenv($name);
-  if ($env !== FALSE && is_string($env) && $env !== '') {
+  if ($env !== FALSE && $env !== '') {
     return [$env, 'env'];
   }
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -275,6 +275,23 @@ function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TR
 }
 
 /**
+ * Detect the XDebug state of the dev server listening on the given port.
+ *
+ * Inspects the running PHP process's command line for the
+ * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
+ * server is listening, and '-' when no server is bound to the port.
+ */
+function xdebug_state(string $port): string {
+  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '') {
+    return '-';
+  }
+
+  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/info
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/info
@@ -1,0 +1,134 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @file
+ * Print a read-only summary of the current development environment.
+ *
+ * Resolves PHP, Drupal, Composer, Drush, Node, and npm versions; the
+ * webserver host and port along with where each value was sourced from
+ * (shell env vs '.env' vs default); the running server's XDebug state;
+ * the build directory; the SQLite database path; and the active Drupal
+ * install profile.
+ *
+ * Any value that cannot be resolved prints '-' rather than failing.
+ */
+
+declare(strict_types=1);
+
+namespace DrupalExtensionScaffold\DevTools;
+
+require_once __DIR__ . '/helpers.php';
+
+// -----------------------------------------------------------------------------
+// Resolution.
+// -----------------------------------------------------------------------------
+
+[$webserver_host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost');
+[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '8000');
+
+$drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
+
+$php_version = info_php_version();
+$php_path = command_path('php');
+$composer_version = info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i');
+$node_version = info_tool_version('node --version 2>/dev/null', '/v?(.+)/');
+$npm_version = info_tool_version('npm --version 2>/dev/null', '/(.+)/');
+
+$drush_bin = 'build/vendor/bin/drush';
+$has_drush = is_file($drush_bin);
+$drush_version = $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-';
+$drupal_version = $has_drush ? info_drupal_version($drush_bin) : '-';
+
+$xdebug_state = info_xdebug_state($webserver_port);
+
+$cwd = (string) getcwd();
+$build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
+
+$info_files = glob('*.info.yml');
+$extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
+$db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
+
+// -----------------------------------------------------------------------------
+// Output.
+// -----------------------------------------------------------------------------
+
+echo PHP_EOL;
+echo '===============================' . PHP_EOL;
+echo '       ENVIRONMENT INFO        ' . PHP_EOL;
+echo '===============================' . PHP_EOL;
+echo PHP_EOL;
+printf("Drupal version:     %s%s", $drupal_version, PHP_EOL);
+printf("PHP version:        %s%s%s", $php_version, $php_path !== FALSE && $php_version !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
+printf("Composer:           %s%s", $composer_version, PHP_EOL);
+printf("Drush:              %s%s", $drush_version, PHP_EOL);
+printf("Node / npm:         %s / %s%s", $node_version, $npm_version, PHP_EOL);
+echo PHP_EOL;
+printf("Webserver host:     %s (%s)%s", $webserver_host, $host_source, PHP_EOL);
+printf("Webserver port:     %s (%s)%s", $webserver_port, $port_source, PHP_EOL);
+printf("Site URL:           http://%s:%s%s", $webserver_host, $webserver_port, PHP_EOL);
+printf("XDebug:             %s%s", $xdebug_state, PHP_EOL);
+echo PHP_EOL;
+printf("Build dir:          %s%s", $build_dir, PHP_EOL);
+printf("Database:           %s%s", $db_file, PHP_EOL);
+printf("Drupal profile:     %s%s", $drupal_profile, PHP_EOL);
+echo PHP_EOL;
+
+// -----------------------------------------------------------------------------
+// Local helpers.
+// -----------------------------------------------------------------------------
+
+/**
+ * Get the host PHP version, or '-' if it cannot be parsed.
+ */
+function info_php_version(): string {
+  $out = (string) @shell_exec('php -v 2>/dev/null');
+  if ($out === '' || !preg_match('/^PHP\s+(\S+)/m', $out, $matches)) {
+    return '-';
+  }
+
+  return $matches[1];
+}
+
+/**
+ * Run a version probe and extract the first capture group.
+ *
+ * Returns '-' if the command produces no output or the pattern does
+ * not match.
+ */
+function info_tool_version(string $cmd, string $pattern): string {
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '' || !preg_match($pattern, $out, $matches)) {
+    return '-';
+  }
+
+  return trim($matches[1]);
+}
+
+/**
+ * Get the installed Drupal version via drush, or '-' if unavailable.
+ */
+function info_drupal_version(string $drush_bin): string {
+  $cmd = escapeshellarg($drush_bin) . ' -r ' . escapeshellarg(getcwd() . '/build/web') . ' status --field=drupal-version 2>/dev/null';
+  $out = trim((string) @shell_exec($cmd));
+
+  return $out === '' ? '-' : $out;
+}
+
+/**
+ * Detect the XDebug state of the dev server listening on the given port.
+ *
+ * Uses the same lsof + ps probe as the 'debug' wrapper command:
+ * inspects the running PHP process's command line for the
+ * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
+ * server is listening, and '-' when no server is bound to the port.
+ */
+function info_xdebug_state(string $port): string {
+  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '') {
+    return '-';
+  }
+
+  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
+}

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/info
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/info
@@ -24,8 +24,13 @@ require_once __DIR__ . '/helpers.php';
 // Resolution.
 // -----------------------------------------------------------------------------
 
-[$webserver_host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost');
-[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '8000');
+// validate_port: FALSE so a malformed '.env' entry surfaces in the
+// output instead of crashing the read-only summary.
+$webserver = resolve_webserver(validate_port: FALSE);
+$webserver_host = $webserver['host'];
+$host_source = $webserver['host_source'];
+$webserver_port = $webserver['port'];
+$port_source = $webserver['port_source'];
 
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/info
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/info
@@ -12,6 +12,14 @@
  * install profile.
  *
  * Any value that cannot be resolved prints '-' rather than failing.
+ *
+ * Two output modes:
+ * - No arguments: print the formatted full summary.
+ * - 'info <field>': print only that field's value on stdout, exit 0.
+ *   Unknown field name prints '-' and exits 1.
+ *
+ * Field-mode keeps expensive subprocess probes lazy: only the requested
+ * field's resolver runs.
  */
 
 declare(strict_types=1);
@@ -21,11 +29,9 @@ namespace DrupalExtensionScaffold\DevTools;
 require_once __DIR__ . '/helpers.php';
 
 // -----------------------------------------------------------------------------
-// Resolution.
+// Cheap resolutions (env + filesystem). Always run.
 // -----------------------------------------------------------------------------
 
-// validate_port: FALSE so a malformed '.env' entry surfaces in the
-// output instead of crashing the read-only summary.
 $webserver = resolve_webserver(validate_port: FALSE);
 $webserver_host = $webserver['host'];
 $host_source = $webserver['host_source'];
@@ -34,19 +40,6 @@ $port_source = $webserver['port_source'];
 
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
 
-$php_version = info_php_version();
-$php_path = command_path('php');
-$composer_version = info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i');
-$node_version = info_tool_version('node --version 2>/dev/null', '/v?(.+)/');
-$npm_version = info_tool_version('npm --version 2>/dev/null', '/(.+)/');
-
-$drush_bin = 'build/vendor/bin/drush';
-$has_drush = is_file($drush_bin);
-$drush_version = $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-';
-$drupal_version = $has_drush ? info_drupal_version($drush_bin) : '-';
-
-$xdebug_state = info_xdebug_state($webserver_port);
-
 $cwd = (string) getcwd();
 $build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
 
@@ -54,29 +47,71 @@ $info_files = glob('*.info.yml');
 $extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
 $db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
 
+$drush_bin = 'build/vendor/bin/drush';
+$has_drush = is_file($drush_bin);
+
+$site_url = sprintf('http://%s:%s', $webserver_host, $webserver_port);
+
 // -----------------------------------------------------------------------------
-// Output.
+// Field resolvers. Each closure is invoked only when its field is requested.
 // -----------------------------------------------------------------------------
+
+$fields = [
+  'drupal-version' => fn(): string => $has_drush ? info_drupal_version($drush_bin) : '-',
+  'php-version' => fn(): string => info_php_version(),
+  'composer' => fn(): string => info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i'),
+  'drush' => fn(): string => $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-',
+  'node' => fn(): string => info_tool_version('node --version 2>/dev/null', '/v?(.+)/'),
+  'npm' => fn(): string => info_tool_version('npm --version 2>/dev/null', '/(.+)/'),
+  'webserver-host' => fn(): string => $webserver_host,
+  'webserver-port' => fn(): string => $webserver_port,
+  'site-url' => fn(): string => $site_url,
+  'xdebug' => fn(): string => xdebug_state($webserver_port),
+  'build-dir' => fn(): string => $build_dir,
+  'database' => fn(): string => $db_file,
+  'drupal-profile' => fn(): string => $drupal_profile,
+];
+
+// -----------------------------------------------------------------------------
+// Field-mode dispatch.
+// -----------------------------------------------------------------------------
+
+$field = isset($argv[1]) && !str_starts_with((string) $argv[1], '-') ? (string) $argv[1] : NULL;
+if ($field !== NULL) {
+  if (isset($fields[$field])) {
+    echo $fields[$field]() . PHP_EOL;
+    quit(0);
+  }
+  echo '-' . PHP_EOL;
+  quit(1);
+}
+
+// -----------------------------------------------------------------------------
+// Full summary. Resolves every field then formats.
+// -----------------------------------------------------------------------------
+
+$values = array_map(fn(callable $cb): string => $cb(), $fields);
+$php_path = command_path('php');
 
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '       ENVIRONMENT INFO        ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
-printf("Drupal version:     %s%s", $drupal_version, PHP_EOL);
-printf("PHP version:        %s%s%s", $php_version, $php_path !== FALSE && $php_version !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
-printf("Composer:           %s%s", $composer_version, PHP_EOL);
-printf("Drush:              %s%s", $drush_version, PHP_EOL);
-printf("Node / npm:         %s / %s%s", $node_version, $npm_version, PHP_EOL);
+printf("Drupal version:     %s%s", $values['drupal-version'], PHP_EOL);
+printf("PHP version:        %s%s%s", $values['php-version'], $php_path !== FALSE && $values['php-version'] !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
+printf("Composer:           %s%s", $values['composer'], PHP_EOL);
+printf("Drush:              %s%s", $values['drush'], PHP_EOL);
+printf("Node / npm:         %s / %s%s", $values['node'], $values['npm'], PHP_EOL);
 echo PHP_EOL;
-printf("Webserver host:     %s (%s)%s", $webserver_host, $host_source, PHP_EOL);
-printf("Webserver port:     %s (%s)%s", $webserver_port, $port_source, PHP_EOL);
-printf("Site URL:           http://%s:%s%s", $webserver_host, $webserver_port, PHP_EOL);
-printf("XDebug:             %s%s", $xdebug_state, PHP_EOL);
+printf("Webserver host:     %s (%s)%s", $values['webserver-host'], $host_source, PHP_EOL);
+printf("Webserver port:     %s (%s)%s", $values['webserver-port'], $port_source, PHP_EOL);
+printf("Site URL:           %s%s", $values['site-url'], PHP_EOL);
+printf("XDebug:             %s%s", $values['xdebug'], PHP_EOL);
 echo PHP_EOL;
-printf("Build dir:          %s%s", $build_dir, PHP_EOL);
-printf("Database:           %s%s", $db_file, PHP_EOL);
-printf("Drupal profile:     %s%s", $drupal_profile, PHP_EOL);
+printf("Build dir:          %s%s", $values['build-dir'], PHP_EOL);
+printf("Database:           %s%s", $values['database'], PHP_EOL);
+printf("Drupal profile:     %s%s", $values['drupal-profile'], PHP_EOL);
 echo PHP_EOL;
 
 // -----------------------------------------------------------------------------
@@ -118,22 +153,4 @@ function info_drupal_version(string $drush_bin): string {
   $out = trim((string) @shell_exec($cmd));
 
   return $out === '' ? '-' : $out;
-}
-
-/**
- * Detect the XDebug state of the dev server listening on the given port.
- *
- * Uses the same lsof + ps probe as the 'debug' wrapper command:
- * inspects the running PHP process's command line for the
- * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
- * server is listening, and '-' when no server is bound to the port.
- */
-function info_xdebug_state(string $port): string {
-  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
-  $out = trim((string) @shell_exec($cmd));
-  if ($out === '') {
-    return '-';
-  }
-
-  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
 }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -20,15 +20,11 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver hostname.
-[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
-
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
-[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver host and port resolved via the env -> '.env' -> default
+// chain.
+$webserver = resolve_webserver();
+$webserver_host = $webserver['host'];
+$webserver_port = $webserver['port'];
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -21,17 +21,13 @@ require_once __DIR__ . '/helpers.php';
 // -----------------------------------------------------------------------------
 
 // Webserver hostname.
-$webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
+[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
 
 // Webserver port. Resolution precedence:
 // 1. WEBSERVER_PORT env var, if set.
 // 2. WEBSERVER_PORT entry in .env, if present.
 // 3. Default '8000'.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
-}
+[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
 validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Drupal profile to use when installing the site.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -16,19 +16,13 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver hostname.
-[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
-
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Auto-discovery via find_free_port(), persisted to .env.
-[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '');
-if ($port_source === 'default') {
-  $webserver_port = (string) find_free_port();
-  dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-}
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver host and port. The helper resolves both via the
+// env -> '.env' -> default chain. With auto_discover: TRUE, a free
+// port is allocated and persisted to '.env' when neither env nor
+// '.env' provides one.
+$webserver = resolve_webserver(auto_discover: TRUE);
+$webserver_host = $webserver['host'];
+$webserver_port = $webserver['port'];
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -17,22 +17,16 @@ require_once __DIR__ . '/helpers.php';
 // -----------------------------------------------------------------------------
 
 // Webserver hostname.
-$webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
+[$webserver_host] = resolve_env_value('WEBSERVER_HOST', 'localhost');
 
 // Webserver port. Resolution precedence:
 // 1. WEBSERVER_PORT env var, if set.
 // 2. WEBSERVER_PORT entry in .env, if present.
 // 3. Auto-discovery via find_free_port(), persisted to .env.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
-    $webserver_port = $dotenv['WEBSERVER_PORT'];
-  }
-  else {
-    $webserver_port = (string) find_free_port();
-    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-  }
+[$webserver_port, $port_source] = resolve_env_value('WEBSERVER_PORT', '');
+if ($port_source === 'default') {
+  $webserver_port = (string) find_free_port();
+  dotenv_write_var('WEBSERVER_PORT', $webserver_port);
 }
 validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -20,11 +20,7 @@ require_once __DIR__ . '/helpers.php';
 // 1. WEBSERVER_PORT env var, if set.
 // 2. WEBSERVER_PORT entry in .env, if present.
 // 3. Default '8000'.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
-}
+[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
 validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // -----------------------------------------------------------------------------

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -16,12 +16,8 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
-[$webserver_port] = resolve_env_value('WEBSERVER_PORT', '8000');
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver port resolved via the env -> '.env' -> default chain.
+$webserver_port = resolve_webserver()['port'];
 
 // -----------------------------------------------------------------------------
 

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -45,6 +45,10 @@ This is a Force Crystal template for creating contributed modules or themes. The
 - `make drush <command>` - Run Drush commands
 - `make login` / `ahoy login` - Get one-time login link
 
+### Diagnostics
+
+- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. Runs automatically at the end of `make build` / `ahoy build`.
+
 ## Project Structure
 
 **Key Directories:**

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -47,7 +47,7 @@ This is a Force Crystal template for creating contributed modules or themes. The
 
 ### Diagnostics
 
-- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. Runs automatically at the end of `make build` / `ahoy build`.
+- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile.
 
 ## Project Structure
 

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -53,12 +53,12 @@ info:
 	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
-# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
-# the running server's command line for `xdebug.mode=debug` so no flag file
-# is needed. Run `make start` to disable.
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. State is
+# probed by `info xdebug`, which inspects the running server's command
+# line. Run `make start` to disable.
 debug:
-	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
-		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+	@[ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && [ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
 # Make has no native command aliases - the alias targets declare `debug` as
 # their sole prerequisite, so running e.g. `make xdebug` executes the `debug`

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on help info lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"
@@ -21,6 +21,7 @@ help:
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
 	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
+	@echo "info            - Print a read-only summary of the current environment."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
 	@echo "login           - Run Drush login command."
@@ -37,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build: stop assemble start provision info
 
 assemble:
 	./.devtools/assemble
@@ -47,6 +48,9 @@ start:
 
 stop:
 	./.devtools/stop
+
+info:
+	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
 # `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision info
+build: stop assemble start provision
 
 assemble:
 	./.devtools/assemble

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -53,12 +53,12 @@ info:
 	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
-# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
-# the running server's command line for `xdebug.mode=debug` so no flag file
-# is needed. Run `make start` to disable.
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. State is
+# probed by `info xdebug`, which inspects the running server's command
+# line. Run `make start` to disable.
 debug:
-	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
-		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+	@[ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && [ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
 # Make has no native command aliases - the alias targets declare `debug` as
 # their sole prerequisite, so running e.g. `make xdebug` executes the `debug`

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on help info lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"
@@ -21,6 +21,7 @@ help:
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
 	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
+	@echo "info            - Print a read-only summary of the current environment."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
 	@echo "login           - Run Drush login command."
@@ -37,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build: stop assemble start provision info
 
 assemble:
 	./.devtools/assemble
@@ -47,6 +48,9 @@ start:
 
 stop:
 	./.devtools/stop
+
+info:
+	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
 # `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision info
+build: stop assemble start provision
 
 assemble:
 	./.devtools/assemble

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -53,12 +53,12 @@ info:
 	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
-# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
-# the running server's command line for `xdebug.mode=debug` so no flag file
-# is needed. Run `make start` to disable.
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. State is
+# probed by `info xdebug`, which inspects the running server's command
+# line. Run `make start` to disable.
 debug:
-	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
-		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+	@[ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && [ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
 # Make has no native command aliases - the alias targets declare `debug` as
 # their sole prerequisite, so running e.g. `make xdebug` executes the `debug`

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on help info lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"
@@ -21,6 +21,7 @@ help:
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
 	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
+	@echo "info            - Print a read-only summary of the current environment."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
 	@echo "login           - Run Drush login command."
@@ -37,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build: stop assemble start provision info
 
 assemble:
 	./.devtools/assemble
@@ -47,6 +48,9 @@ start:
 
 stop:
 	./.devtools/stop
+
+info:
+	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
 # `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision info
+build: stop assemble start provision
 
 assemble:
 	./.devtools/assemble

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -53,12 +53,12 @@ info:
 	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
-# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
-# the running server's command line for `xdebug.mode=debug` so no flag file
-# is needed. Run `make start` to disable.
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. State is
+# probed by `info xdebug`, which inspects the running server's command
+# line. Run `make start` to disable.
 debug:
-	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
-		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+	@[ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && [ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
 # Make has no native command aliases - the alias targets declare `debug` as
 # their sole prerequisite, so running e.g. `make xdebug` executes the `debug`

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on help info lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"
@@ -21,6 +21,7 @@ help:
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
 	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
+	@echo "info            - Print a read-only summary of the current environment."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
 	@echo "login           - Run Drush login command."
@@ -37,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build: stop assemble start provision info
 
 assemble:
 	./.devtools/assemble
@@ -47,6 +48,9 @@ start:
 
 stop:
 	./.devtools/stop
+
+info:
+	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
 # `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision info
+build: stop assemble start provision
 
 assemble:
 	./.devtools/assemble

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -81,6 +81,13 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('user/reset/1/');
 
+    $this->processRun('ahoy', ['info'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT INFO');
+    $this->assertProcessAnyOutputContains('Drupal version:');
+    $this->assertProcessAnyOutputContains('Webserver port:');
+    $this->assertProcessAnyOutputContains('Site URL:           http://');
+
     $this->runLint();
 
     // `ahoy test` runs every PHPUnit suite in the consumer project, including

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -80,6 +80,13 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('user/reset/1/');
 
+    $this->processRun('make', ['info'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ENVIRONMENT INFO');
+    $this->assertProcessAnyOutputContains('Drupal version:');
+    $this->assertProcessAnyOutputContains('Webserver port:');
+    $this->assertProcessAnyOutputContains('Site URL:           http://');
+
     $this->runLint();
 
     // `make test` runs every PHPUnit suite in the consumer project, including

--- a/.scaffold/tests/src/Unit/HelpersResolveEnvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersResolveEnvTest.php
@@ -26,7 +26,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
   }
 
   protected function tearDown(): void {
-    static::envReset();
+    self::envReset();
     parent::tearDown();
   }
 
@@ -90,7 +90,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     $this->assertSame('default', $source);
   }
 
-  #[DataProvider('dataProviderDotenvFilePaths')]
+  #[DataProvider('dataProviderDotenvFilePathSurfacedAsSource')]
   public function testDotenvFilePathSurfacedAsSource(string $relative_name): void {
     $file = self::$tmp . '/' . $relative_name;
     file_put_contents($file, "FOO=value\n");
@@ -101,7 +101,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     $this->assertSame($file, $source);
   }
 
-  public static function dataProviderDotenvFilePaths(): \Iterator {
+  public static function dataProviderDotenvFilePathSurfacedAsSource(): \Iterator {
     yield 'standard name' => ['relative_name' => '.env'];
     yield 'environment-specific name' => ['relative_name' => '.env.local'];
   }

--- a/.scaffold/tests/src/Unit/HelpersResolveEnvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersResolveEnvTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\resolve_env_value;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for the resolve_env_value() helper.
+ *
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[CoversFunction('DrupalExtensionScaffold\DevTools\resolve_env_value')]
+#[Group('p0')]
+final class HelpersResolveEnvTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  protected function tearDown(): void {
+    static::envReset();
+    parent::tearDown();
+  }
+
+  public function testEnvWinsOverDotenv(): void {
+    $file = self::$tmp . '/resolve_env_' . uniqid();
+    file_put_contents($file, "FOO=from_dotenv\n");
+    $this->envSet('FOO', 'from_env');
+
+    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+
+    $this->assertSame('from_env', $value);
+    $this->assertSame('env', $source);
+  }
+
+  public function testDotenvUsedWhenEnvUnset(): void {
+    $file = self::$tmp . '/resolve_env_' . uniqid();
+    file_put_contents($file, "FOO=from_dotenv\n");
+
+    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+
+    $this->assertSame('from_dotenv', $value);
+    $this->assertSame($file, $source);
+  }
+
+  public function testDotenvSkippedWhenValueIsEmpty(): void {
+    $file = self::$tmp . '/resolve_env_' . uniqid();
+    file_put_contents($file, "FOO=\n");
+
+    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+
+    $this->assertSame('fallback', $value);
+    $this->assertSame('default', $source);
+  }
+
+  public function testEnvSkippedWhenValueIsEmpty(): void {
+    $file = self::$tmp . '/resolve_env_' . uniqid();
+    file_put_contents($file, "FOO=from_dotenv\n");
+    $this->envSet('FOO', '');
+
+    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+
+    $this->assertSame('from_dotenv', $value);
+    $this->assertSame($file, $source);
+  }
+
+  public function testDefaultReturnedWhenNeitherSourceHasValue(): void {
+    $file = self::$tmp . '/resolve_env_' . uniqid();
+
+    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+
+    $this->assertSame('fallback', $value);
+    $this->assertSame('default', $source);
+  }
+
+  public function testDefaultMayBeEmptyString(): void {
+    $file = self::$tmp . '/resolve_env_' . uniqid();
+
+    [$value, $source] = resolve_env_value('FOO', '', $file);
+
+    $this->assertSame('', $value);
+    $this->assertSame('default', $source);
+  }
+
+  #[DataProvider('dataProviderDotenvFilePaths')]
+  public function testDotenvFilePathSurfacedAsSource(string $relative_name): void {
+    $file = self::$tmp . '/' . $relative_name;
+    file_put_contents($file, "FOO=value\n");
+
+    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+
+    $this->assertSame('value', $value);
+    $this->assertSame($file, $source);
+  }
+
+  public static function dataProviderDotenvFilePaths(): \Iterator {
+    yield 'standard name' => ['relative_name' => '.env'];
+    yield 'environment-specific name' => ['relative_name' => '.env.local'];
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersResolveWebserverTest.php
+++ b/.scaffold/tests/src/Unit/HelpersResolveWebserverTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\resolve_webserver;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for the resolve_webserver() helper.
+ *
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[CoversFunction('DrupalExtensionScaffold\DevTools\resolve_webserver')]
+#[RunTestsInSeparateProcesses]
+#[Group('p0')]
+final class HelpersResolveWebserverTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+
+    // CI workflows preload WEBSERVER_HOST. Strip it so each test
+    // starts from a known baseline.
+    self::envUnset('WEBSERVER_HOST');
+    self::envUnset('WEBSERVER_PORT');
+  }
+
+  protected function tearDown(): void {
+    self::envReset();
+    parent::tearDown();
+  }
+
+  public function testDefaultsWhenNothingProvided(): void {
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+
+    $resolved = resolve_webserver();
+
+    $this->assertSame('localhost', $resolved['host']);
+    $this->assertSame('default', $resolved['host_source']);
+    $this->assertSame('8000', $resolved['port']);
+    $this->assertSame('default', $resolved['port_source']);
+  }
+
+  public function testEnvOverridesDotenvAndDefault(): void {
+    self::envSet('WEBSERVER_HOST', '0.0.0.0');
+    self::envSet('WEBSERVER_PORT', '9001');
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => TRUE);
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBSERVER_HOST=ignored\nWEBSERVER_PORT=1234\n");
+
+    $resolved = resolve_webserver();
+
+    $this->assertSame('0.0.0.0', $resolved['host']);
+    $this->assertSame('env', $resolved['host_source']);
+    $this->assertSame('9001', $resolved['port']);
+    $this->assertSame('env', $resolved['port_source']);
+  }
+
+  public function testDotenvUsedWhenEnvUnset(): void {
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $f): bool => $f === '.env');
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBSERVER_HOST=internal\nWEBSERVER_PORT=8123\n");
+
+    $resolved = resolve_webserver();
+
+    $this->assertSame('internal', $resolved['host']);
+    $this->assertSame('.env', $resolved['host_source']);
+    $this->assertSame('8123', $resolved['port']);
+    $this->assertSame('.env', $resolved['port_source']);
+  }
+
+  public function testAutoDiscoveryWritesPortAndUpdatesSource(): void {
+    // No env, no dotenv - auto-discovery kicks in.
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+    $this->registerMock('stream_socket_client', 'DrupalExtensionScaffold\\DevTools', fn(): false => FALSE);
+
+    $persisted = NULL;
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function (string $f, string $body) use (&$persisted): int {
+      if (preg_match('/WEBSERVER_PORT=(\d+)/', $body, $m)) {
+        $persisted = $m[1];
+      }
+
+      return strlen($body);
+    });
+
+    $resolved = resolve_webserver(auto_discover: TRUE);
+
+    $this->assertSame('localhost', $resolved['host']);
+    $this->assertSame('default', $resolved['host_source']);
+    $this->assertSame('8000', $resolved['port']);
+    $this->assertSame('.env', $resolved['port_source'], 'Auto-discovered port reports the dotenv file as its source after the write.');
+    $this->assertSame('8000', $persisted, 'find_free_port() result was persisted to .env.');
+  }
+
+  public function testAutoDiscoverySkippedWhenDotenvHasPort(): void {
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $f): bool => $f === '.env');
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBSERVER_PORT=8123\n");
+
+    $write_called = FALSE;
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function () use (&$write_called): int {
+      $write_called = TRUE;
+
+      return 0;
+    });
+    $probe_called = FALSE;
+    $this->registerMock('stream_socket_client', 'DrupalExtensionScaffold\\DevTools', function () use (&$probe_called): false {
+      $probe_called = TRUE;
+
+      return FALSE;
+    });
+
+    $resolved = resolve_webserver(auto_discover: TRUE);
+
+    $this->assertSame('8123', $resolved['port']);
+    $this->assertSame('.env', $resolved['port_source']);
+    $this->assertFalse($write_called, 'No write should occur when .env already supplies the port.');
+    $this->assertFalse($probe_called, 'find_free_port() should not run when .env already supplies the port.');
+  }
+
+  public function testValidationFailsOnMalformedPort(): void {
+    self::envSet('WEBSERVER_PORT', 'not-a-port');
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+
+    $this->mockQuit(1);
+
+    ob_start();
+    try {
+      resolve_webserver();
+      $this->fail('Expected resolve_webserver() to abort via FAIL().');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertSame(1, $e->getCode());
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+      $this->assertStringContainsString('Invalid WEBSERVER_PORT "not-a-port"', $output);
+    }
+  }
+
+  public function testValidationSkippedWhenDisabled(): void {
+    self::envSet('WEBSERVER_PORT', 'not-a-port');
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+
+    $resolved = resolve_webserver(validate_port: FALSE);
+
+    $this->assertSame('not-a-port', $resolved['port'], 'With validation disabled, the malformed value is surfaced verbatim.');
+    $this->assertSame('env', $resolved['port_source']);
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersXdebugStateTest.php
+++ b/.scaffold/tests/src/Unit/HelpersXdebugStateTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\xdebug_state;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for the xdebug_state() helper.
+ *
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[CoversFunction('DrupalExtensionScaffold\DevTools\xdebug_state')]
+#[RunTestsInSeparateProcesses]
+#[Group('p0')]
+final class HelpersXdebugStateTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderXdebugState')]
+  public function testXdebugState(string $ps_output, string $expected): void {
+    $captured_cmd = NULL;
+    $this->registerMock('shell_exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd) use (&$captured_cmd, $ps_output): string {
+      $captured_cmd = $cmd;
+
+      return $ps_output;
+    });
+
+    $this->assertSame($expected, xdebug_state('8000'));
+    $this->assertNotNull($captured_cmd);
+    $this->assertStringContainsString("lsof -ti:'8000'", $captured_cmd);
+  }
+
+  public static function dataProviderXdebugState(): \Iterator {
+    yield 'no server listening' => [
+      'ps_output' => '',
+      'expected' => '-',
+    ];
+    yield 'server running without xdebug' => [
+      'ps_output' => "php -S localhost:8000\n",
+      'expected' => 'disabled',
+    ];
+    yield 'server running with xdebug' => [
+      'ps_output' => "php -d xdebug.mode=debug -d xdebug.start_with_request=yes -S localhost:8000\n",
+      'expected' => 'enabled',
+    ];
+    yield 'output is whitespace only' => [
+      'ps_output' => "   \n",
+      'expected' => '-',
+    ];
+  }
+
+  public function testPortIsShellEscaped(): void {
+    $captured_cmd = NULL;
+    $this->registerMock('shell_exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd) use (&$captured_cmd): string {
+      $captured_cmd = $cmd;
+
+      return '';
+    });
+
+    xdebug_state('8000; rm -rf /');
+
+    $this->assertNotNull($captured_cmd);
+    $this->assertStringContainsString("'8000; rm -rf /'", $captured_cmd, 'Port is wrapped in escapeshellarg quotes.');
+    $this->assertStringNotContainsString('; rm -rf /;', $captured_cmd, 'Embedded command substitution must not break out of the quotes.');
+  }
+
+}

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitSuccessException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -266,6 +268,162 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('Drupal version:     -', $output);
   }
 
+  #[DataProvider('dataProviderFieldModeKnownFields')]
+  public function testFieldModeKnownFields(string $field, array $shell_exec_map, array $files, string $expected): void {
+    $this->configureInfoMocks(
+      shell_exec_map: $shell_exec_map,
+      files: $files,
+      info_files: ['your_extension.info.yml'],
+      cwd: '/test/project',
+    );
+
+    $output = $this->runInfoField($field, 0);
+
+    $this->assertSame($expected . PHP_EOL, $output);
+  }
+
+  public static function dataProviderFieldModeKnownFields(): \Iterator {
+    yield 'xdebug enabled' => [
+      'field' => 'xdebug',
+      'shell_exec_map' => ['lsof -ti' => "php -d xdebug.mode=debug -S localhost:8000\n", '*' => ''],
+      'files' => [],
+      'expected' => 'enabled',
+    ];
+    yield 'xdebug disabled' => [
+      'field' => 'xdebug',
+      'shell_exec_map' => ['lsof -ti' => "php -S localhost:8000\n", '*' => ''],
+      'files' => [],
+      'expected' => 'disabled',
+    ];
+    yield 'xdebug no server' => [
+      'field' => 'xdebug',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => '-',
+    ];
+    yield 'webserver-port default' => [
+      'field' => 'webserver-port',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => '8000',
+    ];
+    yield 'webserver-host default' => [
+      'field' => 'webserver-host',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => 'localhost',
+    ];
+    yield 'site-url' => [
+      'field' => 'site-url',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => 'http://localhost:8000',
+    ];
+    yield 'drupal-profile default' => [
+      'field' => 'drupal-profile',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => 'standard',
+    ];
+    yield 'build-dir present' => [
+      'field' => 'build-dir',
+      'shell_exec_map' => ['*' => ''],
+      'files' => ['/test/project/build' => TRUE],
+      'expected' => '/test/project/build',
+    ];
+    yield 'build-dir absent' => [
+      'field' => 'build-dir',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => '-',
+    ];
+    yield 'database' => [
+      'field' => 'database',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => '/tmp/site_your_extension.sqlite',
+    ];
+    yield 'php-version' => [
+      'field' => 'php-version',
+      'shell_exec_map' => ['php -v' => "PHP 8.3.14 (cli)\n", '*' => ''],
+      'files' => [],
+      'expected' => '8.3.14',
+    ];
+    yield 'composer' => [
+      'field' => 'composer',
+      'shell_exec_map' => ['composer --version' => "Composer version 2.7.7\n", '*' => ''],
+      'files' => [],
+      'expected' => '2.7.7',
+    ];
+    yield 'node' => [
+      'field' => 'node',
+      'shell_exec_map' => ['node --version' => "v20.18.0\n", '*' => ''],
+      'files' => [],
+      'expected' => '20.18.0',
+    ];
+    yield 'npm' => [
+      'field' => 'npm',
+      'shell_exec_map' => ['npm --version' => "10.8.2\n", '*' => ''],
+      'files' => [],
+      'expected' => '10.8.2',
+    ];
+    yield 'drush version (binary present)' => [
+      'field' => 'drush',
+      'shell_exec_map' => ['--version' => "Drush Commandline Tool 13.3.0\n", '*' => ''],
+      'files' => ['build/vendor/bin/drush' => TRUE],
+      'expected' => '13.3.0',
+    ];
+    yield 'drush version (binary absent)' => [
+      'field' => 'drush',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => '-',
+    ];
+    yield 'drupal-version via drush' => [
+      'field' => 'drupal-version',
+      'shell_exec_map' => ['status --field=drupal-version' => "11.3.11\n", '*' => ''],
+      'files' => ['build/vendor/bin/drush' => TRUE],
+      'expected' => '11.3.11',
+    ];
+    yield 'drupal-version no drush' => [
+      'field' => 'drupal-version',
+      'shell_exec_map' => ['*' => ''],
+      'files' => [],
+      'expected' => '-',
+    ];
+  }
+
+  public function testFieldModeUnknownFieldPrintsDashAndExits1(): void {
+    $this->configureInfoMocks(
+      shell_exec_map: ['*' => ''],
+      files: [],
+      info_files: [],
+      cwd: '/test/project',
+    );
+
+    $output = $this->runInfoField('not-a-field', 1);
+
+    $this->assertSame('-' . PHP_EOL, $output);
+  }
+
+  public function testFieldModeBypassedForFlagLikeArg(): void {
+    // phpunit may pass its own argv (e.g. '--no-coverage') through to the
+    // included script. Args starting with '-' must NOT trigger field mode.
+    $this->configureInfoMocks(
+      shell_exec_map: ['*' => ''],
+      files: [],
+      info_files: [],
+      cwd: '/test/project',
+    );
+
+    $argv = ['info', '--no-coverage'];
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/info';
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('ENVIRONMENT INFO', $output);
+  }
+
   /**
    * Run the info script and capture its output.
    */
@@ -274,6 +432,31 @@ final class InfoTest extends UnitTestCase {
     require dirname(__DIR__, 4) . '/.devtools/info';
 
     return (string) ob_get_clean();
+  }
+
+  /**
+   * Run the info script in field mode and capture its output.
+   */
+  protected function runInfoField(string $field, int $expected_exit_code): string {
+    $this->mockQuit($expected_exit_code);
+
+    // Set $argv in this method's scope so the included info script,
+    // which inherits the calling scope, sees the field argument.
+    $argv = ['info', $field];
+
+    ob_start();
+    try {
+      require dirname(__DIR__, 4) . '/.devtools/info';
+      $this->fail('Expected info to call quit() in field mode.');
+    }
+    catch (QuitSuccessException | QuitErrorException $e) {
+      $this->assertSame($expected_exit_code, $e->getCode());
+    }
+    finally {
+      $output = (string) ob_get_clean();
+    }
+
+    return $output;
   }
 
 }

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for the info devtools script.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[RunTestsInSeparateProcesses]
+#[Group('p0')]
+final class InfoTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  /**
+   * Set up the standard mocks for an info run.
+   *
+   * @param array<string, string> $shell_exec_map
+   *   Map of substring → full command output. The first key whose
+   *   substring appears in the requested command wins. A literal
+   *   '*' key acts as a catch-all default.
+   * @param array<string, bool> $files
+   *   Map of file path → existence; used for file_exists, is_file,
+   *   and is_dir lookups.
+   * @param string[] $info_files
+   *   Files returned from glob('*.info.yml').
+   * @param string $cwd
+   *   Value to return from getcwd().
+   * @param array<string, string> $file_contents
+   *   Map of file path → contents, used by file_get_contents.
+   * @param string|false $command_php_path
+   *   Path returned by command_path('php'); FALSE means not found.
+   */
+  protected function configureInfoMocks(
+    array $shell_exec_map,
+    array $files = [],
+    array $info_files = [],
+    string $cwd = '/test/project',
+    array $file_contents = [],
+    string|false $command_php_path = '/usr/bin/php',
+  ): void {
+    $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
+
+    $this->registerMock('shell_exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd) use ($shell_exec_map): string {
+      foreach ($shell_exec_map as $needle => $output) {
+        if ($needle !== '*' && str_contains($cmd, $needle)) {
+          return $output;
+        }
+      }
+
+      return $shell_exec_map['*'] ?? '';
+    });
+
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $path): bool => $files[$path] ?? FALSE);
+    $this->registerMock('is_file', 'DrupalExtensionScaffold\\DevTools', fn(string $path): bool => $files[$path] ?? FALSE);
+    $this->registerMock('is_dir', 'DrupalExtensionScaffold\\DevTools', fn(string $path): bool => $files[$path] ?? FALSE);
+    $this->registerMock('glob', 'DrupalExtensionScaffold\\DevTools', fn(): array => $info_files);
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(string $file): string => $file_contents[$file] ?? '');
+
+    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, mixed &$output = NULL, mixed &$code = NULL) use ($command_php_path): bool {
+      $output ??= [];
+      if ($command_php_path !== FALSE && str_contains($cmd, 'command -v php')) {
+        $output[] = $command_php_path;
+        $code = 0;
+
+        return TRUE;
+      }
+      $code = 1;
+
+      return FALSE;
+    });
+  }
+
+  public function testFullyPopulatedEnvironment(): void {
+    $this->envSet('WEBSERVER_HOST', 'example.com');
+    $this->envSet('WEBSERVER_PORT', '9001');
+    $this->envSet('DRUPAL_PROFILE', 'minimal');
+
+    $cwd = '/test/project';
+    $drush_bin = 'build/vendor/bin/drush';
+
+    $this->configureInfoMocks(
+      shell_exec_map: [
+        'php -v' => "PHP 8.3.14 (cli) (built: ...)\n",
+        'composer --version' => "Composer version 2.7.7 2024-06-10 22:11:12\n",
+        'node --version' => "v20.18.0\n",
+        'npm --version' => "10.8.2\n",
+        '--version' => "Drush Commandline Tool 13.3.0\n",
+        'status --field=drupal-version' => "11.3.11\n",
+        'lsof -ti' => "php -S example.com:9001\n",
+      ],
+      files: [
+        $drush_bin => TRUE,
+        $cwd . '/build' => TRUE,
+      ],
+      info_files: ['your_extension.info.yml'],
+      cwd: $cwd,
+    );
+
+    $output = $this->runInfo();
+
+    $this->assertStringContainsString('Drupal version:     11.3.11', $output);
+    $this->assertStringContainsString('PHP version:        8.3.14 (/usr/bin/php)', $output);
+    $this->assertStringContainsString('Composer:           2.7.7', $output);
+    $this->assertStringContainsString('Drush:              13.3.0', $output);
+    $this->assertStringContainsString('Node / npm:         20.18.0 / 10.8.2', $output);
+    $this->assertStringContainsString('Webserver host:     example.com (env)', $output);
+    $this->assertStringContainsString('Webserver port:     9001 (env)', $output);
+    $this->assertStringContainsString('Site URL:           http://example.com:9001', $output);
+    $this->assertStringContainsString('XDebug:             disabled', $output);
+    $this->assertStringContainsString('Build dir:          /test/project/build', $output);
+    $this->assertStringContainsString('Database:           /tmp/site_your_extension.sqlite', $output);
+    $this->assertStringContainsString('Drupal profile:     minimal', $output);
+    $this->assertStringContainsString('ENVIRONMENT INFO', $output);
+  }
+
+  public function testReadsPortFromDotenvWithFileSource(): void {
+    $cwd = '/test/project';
+
+    $this->configureInfoMocks(
+      shell_exec_map: [
+        'php -v' => "PHP 8.3.14\n",
+        'composer --version' => '',
+        'node --version' => '',
+        'npm --version' => '',
+        'lsof -ti' => '',
+      ],
+      files: ['.env' => TRUE],
+      info_files: [],
+      cwd: $cwd,
+      file_contents: ['.env' => "WEBSERVER_PORT=8123\n"],
+    );
+
+    $output = $this->runInfo();
+
+    $this->assertStringContainsString('Webserver host:     localhost (default)', $output);
+    $this->assertStringContainsString('Webserver port:     8123 (.env)', $output);
+    $this->assertStringContainsString('Site URL:           http://localhost:8123', $output);
+  }
+
+  public function testFallsBackToDefaultsWhenNothingResolves(): void {
+    $cwd = '/test/project';
+
+    $this->configureInfoMocks(
+      shell_exec_map: ['*' => ''],
+      files: [],
+      info_files: [],
+      cwd: $cwd,
+      command_php_path: FALSE,
+    );
+
+    $output = $this->runInfo();
+
+    $this->assertStringContainsString('Drupal version:     -', $output);
+    $this->assertStringContainsString('PHP version:        -', $output);
+    $this->assertStringContainsString('Composer:           -', $output);
+    $this->assertStringContainsString('Drush:              -', $output);
+    $this->assertStringContainsString('Node / npm:         - / -', $output);
+    $this->assertStringContainsString('Webserver host:     localhost (default)', $output);
+    $this->assertStringContainsString('Webserver port:     8000 (default)', $output);
+    $this->assertStringContainsString('Site URL:           http://localhost:8000', $output);
+    $this->assertStringContainsString('XDebug:             -', $output);
+    $this->assertStringContainsString('Build dir:          -', $output);
+    $this->assertStringContainsString('Database:           -', $output);
+    $this->assertStringContainsString('Drupal profile:     standard', $output);
+  }
+
+  public function testDrushAbsentSuppressesPhpPathSuffixOnlyWhenPhpAlsoMissing(): void {
+    // PHP is detectable but command_path('php') returns FALSE - the path
+    // suffix is omitted.
+    $cwd = '/test/project';
+
+    $this->configureInfoMocks(
+      shell_exec_map: [
+        'php -v' => "PHP 8.3.14\n",
+        '*' => '',
+      ],
+      files: [],
+      info_files: [],
+      cwd: $cwd,
+      command_php_path: FALSE,
+    );
+
+    $output = $this->runInfo();
+
+    $this->assertStringContainsString("PHP version:        8.3.14\n", $output);
+    $this->assertStringNotContainsString('PHP version:        8.3.14 (', $output);
+  }
+
+  #[DataProvider('dataProviderXdebugState')]
+  public function testXdebugStateDetection(string $ps_output, string $expected_state): void {
+    $cwd = '/test/project';
+
+    $this->configureInfoMocks(
+      shell_exec_map: [
+        'lsof -ti' => $ps_output,
+        '*' => '',
+      ],
+      files: [],
+      info_files: [],
+      cwd: $cwd,
+    );
+
+    $output = $this->runInfo();
+
+    $this->assertStringContainsString('XDebug:             ' . $expected_state, $output);
+  }
+
+  public static function dataProviderXdebugState(): \Iterator {
+    yield 'no server listening' => ['ps_output' => '', 'expected_state' => '-'];
+    yield 'server running without xdebug' => [
+      'ps_output' => "php -S localhost:8000\n",
+      'expected_state' => 'disabled',
+    ];
+    yield 'server running with xdebug' => [
+      'ps_output' => "php -d xdebug.mode=debug -d xdebug.start_with_request=yes -S localhost:8000\n",
+      'expected_state' => 'enabled',
+    ];
+  }
+
+  public function testDrushDrupalVersionFallbackWhenStatusReturnsNothing(): void {
+    // Drush binary exists but `drush status --field=drupal-version` returns
+    // empty (e.g. before site install). Drush version is still reported.
+    $cwd = '/test/project';
+    $drush_bin = 'build/vendor/bin/drush';
+
+    $this->configureInfoMocks(
+      shell_exec_map: [
+        '--version' => "Drush Commandline Tool 13.3.0\n",
+        'status --field=drupal-version' => '',
+        '*' => '',
+      ],
+      files: [
+        $drush_bin => TRUE,
+      ],
+      info_files: [],
+      cwd: $cwd,
+    );
+
+    $output = $this->runInfo();
+
+    $this->assertStringContainsString('Drush:              13.3.0', $output);
+    $this->assertStringContainsString('Drupal version:     -', $output);
+  }
+
+  /**
+   * Run the info script and capture its output.
+   */
+  protected function runInfo(): string {
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/info';
+
+    return (string) ob_get_clean();
+  }
+
+}

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -21,6 +21,18 @@ final class InfoTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+
+    // CI workflows pre-populate WEBSERVER_HOST and friends in the job
+    // environment. Strip them so each test starts from a known state and
+    // sees only the values it sets explicitly via envSet().
+    self::envUnset('WEBSERVER_HOST');
+    self::envUnset('WEBSERVER_PORT');
+    self::envUnset('DRUPAL_PROFILE');
+  }
+
+  protected function tearDown(): void {
+    self::envReset();
+    parent::tearDown();
   }
 
   /**

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -68,7 +68,7 @@ final class InfoTest extends UnitTestCase {
     $this->registerMock('glob', 'DrupalExtensionScaffold\\DevTools', fn(): array => $info_files);
     $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(string $file): string => $file_contents[$file] ?? '');
 
-    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, mixed &$output = NULL, mixed &$code = NULL) use ($command_php_path): bool {
+    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL) use ($command_php_path): bool {
       $output ??= [];
       if ($command_php_path !== FALSE && str_contains($cmd, 'command -v php')) {
         $output[] = $command_php_path;
@@ -198,7 +198,7 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringNotContainsString('PHP version:        8.3.14 (', $output);
   }
 
-  #[DataProvider('dataProviderXdebugState')]
+  #[DataProvider('dataProviderXdebugStateDetection')]
   public function testXdebugStateDetection(string $ps_output, string $expected_state): void {
     $cwd = '/test/project';
 
@@ -217,7 +217,7 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('XDebug:             ' . $expected_state, $output);
   }
 
-  public static function dataProviderXdebugState(): \Iterator {
+  public static function dataProviderXdebugStateDetection(): \Iterator {
     yield 'no server listening' => ['ps_output' => '', 'expected_state' => '-'];
     yield 'server running without xdebug' => [
       'ps_output' => "php -S localhost:8000\n",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ This is a Drupal extension scaffold template for creating contributed modules or
 - `make drush <command>` - Run Drush commands
 - `make login` / `ahoy login` - Get one-time login link
 
+### Diagnostics
+
+- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. Runs automatically at the end of `make build` / `ahoy build`.
+
 ## Project Structure
 
 **Key Directories:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ This is a Drupal extension scaffold template for creating contributed modules or
 
 ### Diagnostics
 
-- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. Runs automatically at the end of `make build` / `ahoy build`.
+- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile.
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ info:
 	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
-# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects
-# the running server's command line for `xdebug.mode=debug` so no flag file
-# is needed. Run `make start` to disable.
+# `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. State is
+# probed by `info xdebug`, which inspects the running server's command
+# line. Run `make start` to disable.
 debug:
-	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
-		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+	@[ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && [ "$$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
 # Make has no native command aliases - the alias targets declare `debug` as
 # their sole prerequisite, so running e.g. `make xdebug` executes the `debug`

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on help info lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"
@@ -21,6 +21,7 @@ help:
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
 	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
+	@echo "info            - Print a read-only summary of the current environment."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
 	@echo "login           - Run Drush login command."
@@ -37,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build: stop assemble start provision info
 
 assemble:
 	./.devtools/assemble
@@ -47,6 +48,9 @@ start:
 
 stop:
 	./.devtools/stop
+
+info:
+	@./.devtools/info
 
 # Enable PHP XDebug step-debugging by restarting the PHP server with
 # `-d xdebug.mode=debug -d xdebug.start_with_request=yes`. The probe inspects

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "selenium-stop              - Stop Selenium container."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision info
+build: stop assemble start provision
 
 assemble:
 	./.devtools/assemble


### PR DESCRIPTION
Closes #393

## Summary

Adds a new `info` command to `Makefile` and `.ahoy.yml` that prints a read-only snapshot of the current development environment: PHP, Drupal, Composer, Drush, and Node/npm versions; webserver host and port annotated with the source they were resolved from (shell env, `.env`, or default); XDebug state; build directory; SQLite database path; and the active Drupal install profile.

The command also has a machine-readable mode: `./.devtools/info <field>` prints only that field's value and exits, with lazy resolution so only the requested probe runs. The wrapper `debug` recipes now ask `./.devtools/info xdebug` rather than carrying their own copy of the `lsof` + `ps` + `grep` probe - the DevTools layer owns the facts; the wrappers just orchestrate.

Along the way, two helpers were extracted from previously-duplicated logic. `resolve_env_value()` handles the `env -> .env -> default` chain with source tracking; `resolve_webserver()` builds on it to resolve both `WEBSERVER_HOST` and `WEBSERVER_PORT` in one call, with optional auto-discovery (write a free port back to `.env` when neither env nor dotenv supplies one) and optional port validation. `start`, `stop`, `provision`, and `info` all route through `resolve_webserver()` and the duplicated resolution blocks are gone.

## Changes

**New `info` command**
- Added `.devtools/info` - PHP CLI script. No args: print the full formatted snapshot. With an arg (`./.devtools/info xdebug`, `./.devtools/info webserver-port`, `./.devtools/info drupal-version`, etc.): print just that field's value and exit 0; unknown field prints `-` and exits 1. Field resolution is lazy via closures, so `./.devtools/info xdebug` runs only the lsof+ps probe and skips the version probes entirely.
- Added `info` target to `Makefile` (declared in `.PHONY`).
- Added `info` command to `.ahoy.yml`.
- Documented in `AGENTS.md`.

**Wrapper `debug` recipes rewritten**
- `Makefile` and `.ahoy.yml` `debug` recipes now call `./.devtools/info xdebug` instead of inlining `ps -o command= -p "$(lsof -ti:PORT | head -1)" | grep -q 'xdebug.mode=debug'`. Same `&&`/`||` chain shape; no more `lsof`, `ps`, `grep`, the magic string, or `WEBSERVER_PORT` reference in the wrappers.

**Shared helpers**
- `resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array` returns `[value, source]` where source is `'env'`, the dotenv file path, or `'default'`.
- `resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array` returns `['host', 'host_source', 'port', 'port_source']`. Encapsulates the chain plus the auto-discovery side effect previously open-coded in `start` and the validation previously open-coded in `start`/`stop`/`provision`.
- `xdebug_state(string $port): string` - the lsof+ps probe lifted out of `info` into `helpers.php` so any caller (and the `info xdebug` dispatch) shares one source of truth.
- `.devtools/start`, `.devtools/stop`, `.devtools/provision`, and `.devtools/info` all use the new helpers. The duplicated env/dotenv/default resolution blocks they used to carry individually are gone.

**Tests**
- `HelpersResolveEnvTest` (8 cases, p0): all resolution legs - env wins over dotenv, dotenv when env unset, both skipped when empty, default returned when neither produces a value, empty-string default allowed, source label honours the dotenv path argument.
- `HelpersResolveWebserverTest` (7 cases, p0, separate processes): full defaults, env overrides everything, dotenv used when env unset, auto-discovery writes the port and updates the source, auto-discovery skipped when dotenv has the port, validation fails on malformed port, validation skippable.
- `HelpersXdebugStateTest` (5 cases, p0, separate processes): no server, disabled, enabled, whitespace-only output, port argument is `escapeshellarg()`-wrapped (no shell-injection via the port).
- `InfoTest` (36 cases, p0, separate processes): full summary with everything populated, dotenv port source, all-default fallback, PHP path suffix omission, three XDebug states, drush present but `status` returning empty, 17 parameterised field-mode invocations covering every field name, unknown-field exits 1 with `-` on stdout, flag-shaped arg (`--no-coverage`) bypasses field mode so phpunit's own argv doesn't trip the dispatch.
- `MakeTest` and `AhoyTest` smoke-assert that `make info` / `ahoy info` exits 0 and emits `ENVIRONMENT INFO`, `Drupal version:`, `Webserver port:`, and `Site URL:` after `provision`.

**Fixtures**
- `.scaffold/tests/fixtures/init/**` regenerated to match the new `Makefile`, `.ahoy.yml`, `.devtools/helpers.php`, `.devtools/info`, `start`, `stop`, `provision`, and `AGENTS.md`.

## Before / After

Two layers consolidate.

**Env resolution.** Previously open-coded in three scripts. Now: every script that needs `WEBSERVER_HOST`/`WEBSERVER_PORT` calls one helper.

```
Before                                    After
─────────────────────────────────────     ────────────────────────────────────────
start, stop, provision (each script):     helpers.php (single source):
┌───────────────────────────────────┐     ┌──────────────────────────────────────┐
│ $port = getenv_default('...', '');│     │ resolve_env_value(name, default)     │
│ if ($port === '') {               │     │   -> [value, source]                 │
│   $dotenv = dotenv_read('.env');  │     │                                      │
│   $port = $dotenv[...] ?: '8000'; │     │ resolve_webserver(                   │
│ }                                 │     │   auto_discover: bool,               │
│ validate_port_or_fail(...);       │     │   validate_port: bool                │
└───────────────────────────────────┘     │ ) -> [host, host_source,             │
   ... duplicated 3x with variants ...    │      port, port_source]              │
                                          └──────────────────────────────────────┘

                                          start:    resolve_webserver(TRUE)
                                          stop:     resolve_webserver()['port']
                                          provision: resolve_webserver()
                                          info:     resolve_webserver(validate_port: FALSE)
```

**XDebug check.** Previously inlined in both wrappers. Now: a DevTools-owned probe, the wrappers ask a question.

```
Before                                    After
─────────────────────────────────────     ────────────────────────────────────────
Makefile / .ahoy.yml (each wrapper):      helpers.php:
┌───────────────────────────────────┐     ┌──────────────────────────────────────┐
│ ps -o command= -p \              │     │ function xdebug_state(port):         │
│   "$(lsof -ti:$PORT | head -1)" \│     │   probes lsof + ps; returns          │
│   | grep -q 'xdebug.mode=debug'  │     │   'enabled' | 'disabled' | '-'       │
└───────────────────────────────────┘     └──────────────────────────────────────┘
   ... duplicated in both wrappers ...

                                          info xdebug                    -> calls helper
                                          Makefile / .ahoy.yml debug:
                                            [ "$(./.devtools/info xdebug)" = "enabled" ] && ...
                                          (no lsof, no ps, no grep, no PORT reference)
```
