### PR TITLE
[#392] Added post-assemble and post-provision script hooks.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
   - &container_config
     working_directory: ~/project
     docker:
-      - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - image: cimg/php:8.2-browsers
 
   - &selenium_image
     image: selenium/standalone-chromium:latest
@@ -127,7 +127,7 @@ jobs:
   test-php-8.2-d10-legacy:
     <<: *container_config
     docker:
-      - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - image: cimg/php:8.2-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
@@ -136,7 +136,7 @@ jobs:
   test-php-8.2-d10-stable:
     <<: *container_config
     docker:
-      - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - image: cimg/php:8.2-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
@@ -145,7 +145,7 @@ jobs:
   test-php-8.2-d10-canary:
     <<: *container_config
     docker:
-      - image: cimg/php:8.2-browsers@sha256:b0bb1f453990cb0ad21073d4db9950fe22890a2b55d6cdf39f66f9f71696d2f2
+      - image: cimg/php:8.2-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
@@ -155,7 +155,7 @@ jobs:
   test-php-8.3-d10-legacy:
     <<: *container_config
     docker:
-      - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - image: cimg/php:8.3-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.2
@@ -164,7 +164,7 @@ jobs:
   test-php-8.3-d10-stable:
     <<: *container_config
     docker:
-      - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - image: cimg/php:8.3-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
@@ -173,7 +173,7 @@ jobs:
   test-php-8.3-d10-canary:
     <<: *container_config
     docker:
-      - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - image: cimg/php:8.3-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
@@ -183,7 +183,7 @@ jobs:
   test-php-8.4-d10-legacy:
     <<: *container_config
     docker:
-      - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - image: cimg/php:8.4-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3 # Lowest Drupal version that supports PHP 8.4.
@@ -192,7 +192,7 @@ jobs:
   test-php-8.4-d10-stable:
     <<: *container_config
     docker:
-      - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - image: cimg/php:8.4-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.3
@@ -201,7 +201,7 @@ jobs:
   test-php-8.4-d10-canary:
     <<: *container_config
     docker:
-      - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - image: cimg/php:8.4-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 10.4@beta
@@ -211,7 +211,7 @@ jobs:
   test-php-8.3-d11-legacy:
     <<: *container_config
     docker:
-      - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - image: cimg/php:8.3-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
@@ -220,7 +220,7 @@ jobs:
   test-php-8.3-d11-stable:
     <<: *container_config
     docker:
-      - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - image: cimg/php:8.3-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
@@ -229,7 +229,7 @@ jobs:
   test-php-8.3-d11-canary:
     <<: *container_config
     docker:
-      - image: cimg/php:8.3-browsers@sha256:b2c996760914c33243cdbdfd786675c2d6bdc54787031d84350f46c8da0a2fc3
+      - image: cimg/php:8.3-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
@@ -239,7 +239,7 @@ jobs:
   test-php-8.4-d11-legacy:
     <<: *container_config
     docker:
-      - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - image: cimg/php:8.4-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0 # Lowest Drupal version that exists.
@@ -248,7 +248,7 @@ jobs:
   test-php-8.4-d11-stable:
     <<: *container_config
     docker:
-      - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - image: cimg/php:8.4-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11.0
@@ -257,7 +257,7 @@ jobs:
   test-php-8.4-d11-canary:
     <<: *container_config
     docker:
-      - image: cimg/php:8.4-browsers@sha256:8796d950218c45bfe5bae08999ff743cf5a72d20262b65fc9bc75de8815f2950
+      - image: cimg/php:8.4-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
@@ -267,7 +267,7 @@ jobs:
   test-php-8.5-d11-legacy:
     <<: *container_config
     docker:
-      - image: cimg/php:8.5-browsers@sha256:9307ddf83e336d92aeb8191f9f676d36147dc5719a331669b02576aa38558e02
+      - image: cimg/php:8.5-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11.3 # Lowest Drupal version that supports PHP 8.5.
@@ -276,7 +276,7 @@ jobs:
   test-php-8.5-d11-stable:
     <<: *container_config
     docker:
-      - image: cimg/php:8.5-browsers@sha256:9307ddf83e336d92aeb8191f9f676d36147dc5719a331669b02576aa38558e02
+      - image: cimg/php:8.5-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11.3
@@ -285,7 +285,7 @@ jobs:
   test-php-8.5-d11-canary:
     <<: *container_config
     docker:
-      - image: cimg/php:8.5-browsers@sha256:9307ddf83e336d92aeb8191f9f676d36147dc5719a331669b02576aa38558e02
+      - image: cimg/php:8.5-browsers
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta

--- a/.devtools/README.md
+++ b/.devtools/README.md
@@ -9,4 +9,8 @@ This directory contains scripts used for development. These can be used locally 
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
+## Custom scripts
+
+`assemble` and `provision` both look for `scripts/<prefix>-*.sh` in the project root and run any matches at the end of the phase. `assemble-*.sh` for post-assemble, `provision-*.sh` for post-provision. Scripts run in lexicographic order, inherit the parent environment, and a non-zero exit aborts the parent. See the "Custom assemble and provision scripts" section in the root `README.md` for the full convention.
+
 See the root `README.md` for higher-level workflow documentation.

--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -270,6 +270,9 @@ if (file_exists($build_dir . '/package-lock.json') && !file_exists('.skip_npm_bu
   PASS('Front-end dependencies processed.');
 }
 
+// Run custom post-assemble scripts from "scripts/assemble-*.sh", if any.
+run_custom_scripts('scripts', 'assemble-');
+
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '    🏗 ASSEMBLE COMPLETE ✅   ' . PHP_EOL;

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -464,6 +464,45 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 }
 
 /**
+ * Run custom shell scripts from a directory matching a filename prefix.
+ *
+ * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,
+ * and executed in order. Each script runs with the current working
+ * directory as the parent process's CWD and inherits the parent's
+ * environment. A non-zero exit from any script aborts the parent.
+ *
+ * The directory and any matching scripts are optional: a missing
+ * directory or an empty match set returns silently. This is the
+ * post-assemble / post-provision extension point.
+ *
+ * @param string $dir
+ *   Directory to scan, relative to the current working directory.
+ * @param string $prefix
+ *   Filename prefix to match (e.g. "assemble-" or "provision-").
+ */
+function run_custom_scripts(string $dir, string $prefix): void {
+  if (!is_dir($dir)) {
+    return;
+  }
+
+  $files = glob($dir . '/' . $prefix . '*.sh') ?: [];
+  if ($files === []) {
+    return;
+  }
+
+  sort($files);
+
+  foreach ($files as $file) {
+    if (!is_file($file)) {
+      continue;
+    }
+    TASK("Running custom script '%s'.", $file);
+    passthru_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
+    PASS("Completed custom script '%s'.", $file);
+  }
+}
+
+/**
  * Run a drush command.
  *
  * @param string $command

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -86,6 +86,9 @@ TASK('Pre-warming caches.');
 @file_get_contents(sprintf('http://%s:%s', $webserver_host, $webserver_port));
 PASS('Caches pre-warmed.');
 
+// Run custom post-provision scripts from "scripts/provision-*.sh", if any.
+run_custom_scripts('scripts', 'provision-');
+
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '   🚀 PROVISION COMPLETE  ✅  ' . PHP_EOL;

--- a/.gitattributes
+++ b/.gitattributes
@@ -31,6 +31,7 @@
 # phpunit.xml        export-ignore
 # rector.php         export-ignore
 # renovate.json      export-ignore
+# scripts            export-ignore
 # tests              export-ignore
 
 # Remove the lines below in your project.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/README.md
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/README.md
@@ -9,4 +9,8 @@ This directory contains scripts used for development. These can be used locally 
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
+## Custom scripts
+
+`assemble` and `provision` both look for `scripts/<prefix>-*.sh` in the project root and run any matches at the end of the phase. `assemble-*.sh` for post-assemble, `provision-*.sh` for post-provision. Scripts run in lexicographic order, inherit the parent environment, and a non-zero exit aborts the parent. See the "Custom assemble and provision scripts" section in the root `README.md` for the full convention.
+
 See the root `README.md` for higher-level workflow documentation.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -270,6 +270,9 @@ if (file_exists($build_dir . '/package-lock.json') && !file_exists('.skip_npm_bu
   PASS('Front-end dependencies processed.');
 }
 
+// Run custom post-assemble scripts from "scripts/assemble-*.sh", if any.
+run_custom_scripts('scripts', 'assemble-');
+
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '    🏗 ASSEMBLE COMPLETE ✅   ' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -464,6 +464,45 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 }
 
 /**
+ * Run custom shell scripts from a directory matching a filename prefix.
+ *
+ * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,
+ * and executed in order. Each script runs with the current working
+ * directory as the parent process's CWD and inherits the parent's
+ * environment. A non-zero exit from any script aborts the parent.
+ *
+ * The directory and any matching scripts are optional: a missing
+ * directory or an empty match set returns silently. This is the
+ * post-assemble / post-provision extension point.
+ *
+ * @param string $dir
+ *   Directory to scan, relative to the current working directory.
+ * @param string $prefix
+ *   Filename prefix to match (e.g. "assemble-" or "provision-").
+ */
+function run_custom_scripts(string $dir, string $prefix): void {
+  if (!is_dir($dir)) {
+    return;
+  }
+
+  $files = glob($dir . '/' . $prefix . '*.sh') ?: [];
+  if ($files === []) {
+    return;
+  }
+
+  sort($files);
+
+  foreach ($files as $file) {
+    if (!is_file($file)) {
+      continue;
+    }
+    TASK("Running custom script '%s'.", $file);
+    passthru_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
+    PASS("Completed custom script '%s'.", $file);
+  }
+}
+
+/**
  * Run a drush command.
  *
  * @param string $command

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -86,6 +86,9 @@ TASK('Pre-warming caches.');
 @file_get_contents(sprintf('http://%s:%s', $webserver_host, $webserver_port));
 PASS('Caches pre-warmed.');
 
+// Run custom post-provision scripts from "scripts/provision-*.sh", if any.
+run_custom_scripts('scripts', 'provision-');
+
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '   🚀 PROVISION COMPLETE  ✅  ' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.gitattributes
+++ b/.scaffold/tests/fixtures/init/_baseline/.gitattributes
@@ -30,5 +30,6 @@ phpunit.d10.xml    export-ignore
 phpunit.xml        export-ignore
 rector.php         export-ignore
 renovate.json      export-ignore
+scripts            export-ignore
 tests              export-ignore
 

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -57,6 +57,7 @@ This is a Force Crystal template for creating contributed modules or themes. The
 - `config/schema/` - Configuration schema definitions
 - `build/` - Assembled Drupal codebase (symlinked extension)
 - `.devtools/` - Build and deployment scripts used by CI
+- `scripts/` - Custom post-assemble (`assemble-*.sh`) and post-provision (`provision-*.sh`) hooks. Run automatically at the end of each phase in lexicographic order; non-zero exit aborts the parent. Excluded from distribution archives via `.gitattributes`
 
 **Template Files (before init):**
 - `force_crystal.*` - Template extension files

--- a/.scaffold/tests/fixtures/init/_baseline/scripts/assemble-example.sh
+++ b/.scaffold/tests/fixtures/init/_baseline/scripts/assemble-example.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# Example post-assemble script.
+#
+# Runs at the end of `.devtools/assemble` (after dependencies are
+# installed and the extension is symlinked into `build/`). The current
+# working directory is the project root. Any non-zero exit aborts the
+# parent assemble run.
+#
+# Drop your own logic in any file matching `scripts/assemble-*.sh` -
+# all matching files run in lexicographic order.
+
+set -eu
+
+echo "[example] post-assemble script ran."

--- a/.scaffold/tests/fixtures/init/_baseline/scripts/provision-example.sh
+++ b/.scaffold/tests/fixtures/init/_baseline/scripts/provision-example.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# Example post-provision script.
+#
+# Runs at the end of `.devtools/provision` (after the site is
+# installed, the extension is enabled, and caches are pre-warmed). The
+# current working directory is the project root. Any non-zero exit
+# aborts the parent provision run.
+#
+# Drop your own logic in any file matching `scripts/provision-*.sh` -
+# all matching files run in lexicographic order.
+
+set -eu
+
+echo "[example] post-provision script ran."

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -44,6 +44,7 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-assemble script ran.');
     $this->assertDirectoryExists(self::$sut . '/build/vendor');
     $this->assertFileExists(self::$sut . '/build/composer.json');
     $this->assertFileExists(self::$sut . '/build/composer.lock');
@@ -64,12 +65,14 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->processRun('ahoy', ['provision'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-provision script ran.');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
 
     // Provision is idempotent.
     $this->processRun('ahoy', ['provision'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-provision script ran.');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
 
     $this->processRun('ahoy', ['drush', 'status'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);

--- a/.scaffold/tests/src/Functional/AssembleTest.php
+++ b/.scaffold/tests/src/Functional/AssembleTest.php
@@ -25,6 +25,7 @@ final class AssembleTest extends DevtoolsTestCase {
 
     $this->assertProcessAnyOutputContains($init_message);
     $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-assemble script ran.');
     $this->assertDirectoryExists(self::$sut . '/build/vendor');
     $this->assertFileExists(self::$sut . '/build/composer.json');
     $this->assertFileExists(self::$sut . '/build/composer.lock');

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -43,6 +43,7 @@ final class MakeTest extends DevtoolsTestCase {
     $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-assemble script ran.');
     $this->assertDirectoryExists(self::$sut . '/build/vendor');
     $this->assertFileExists(self::$sut . '/build/composer.json');
     $this->assertFileExists(self::$sut . '/build/composer.lock');
@@ -63,12 +64,14 @@ final class MakeTest extends DevtoolsTestCase {
     $this->processRun('make', ['provision'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-provision script ran.');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
 
     // Provision is idempotent.
     $this->processRun('make', ['provision'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
     $this->assertProcessAnyOutputContains('PROVISION COMPLETE');
+    $this->assertProcessAnyOutputContains('[example] post-provision script ran.');
     $this->assertProcessAnyOutputNotContains('Do you really want to drop all tables in the database');
 
     $this->processRun('make', ['drush', 'status'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);

--- a/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\run_custom_scripts;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\run_custom_scripts')]
+#[Group('p0')]
+final class HelpersRunCustomScriptsTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testMissingDirectoryIsSilent(): void {
+    run_custom_scripts(self::$tmp . '/nonexistent_' . uniqid(), 'assemble-');
+    $this->expectNotToPerformAssertions();
+  }
+
+  public function testEmptyDirectoryIsSilent(): void {
+    $dir = $this->createScriptsDir();
+    run_custom_scripts($dir, 'assemble-');
+    $this->expectNotToPerformAssertions();
+  }
+
+  public function testDirectoryWithNoPrefixMatchesIsSilent(): void {
+    $dir = $this->createScriptsDir(['unrelated.sh' => 'echo nope', 'README.md' => '']);
+    run_custom_scripts($dir, 'assemble-');
+    $this->expectNotToPerformAssertions();
+  }
+
+  public function testExecutesMatchingScriptsInOrder(): void {
+    $dir = $this->createScriptsDir([
+      'assemble-zeta.sh' => 'echo zeta',
+      'assemble-alpha.sh' => 'echo alpha',
+      'assemble-beta.sh' => 'echo beta',
+    ]);
+
+    $this->mockPassthruMultiple([
+      ['cmd' => escapeshellarg($dir . '/assemble-alpha.sh'), 'result_code' => 0],
+      ['cmd' => escapeshellarg($dir . '/assemble-beta.sh'), 'result_code' => 0],
+      ['cmd' => escapeshellarg($dir . '/assemble-zeta.sh'), 'result_code' => 0],
+    ]);
+
+    ob_start();
+    run_custom_scripts($dir, 'assemble-');
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('assemble-alpha.sh', $output);
+    $this->assertStringContainsString('assemble-beta.sh', $output);
+    $this->assertStringContainsString('assemble-zeta.sh', $output);
+  }
+
+  public function testIgnoresDifferentPrefix(): void {
+    $dir = $this->createScriptsDir([
+      'assemble-run.sh' => 'echo a',
+      'provision-skip.sh' => 'echo p',
+    ]);
+
+    $this->mockPassthru(['cmd' => escapeshellarg($dir . '/assemble-run.sh'), 'result_code' => 0]);
+
+    ob_start();
+    run_custom_scripts($dir, 'assemble-');
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('assemble-run.sh', $output);
+    $this->assertStringNotContainsString('provision-skip.sh', $output);
+  }
+
+  public function testIgnoresNonShellExtension(): void {
+    $dir = $this->createScriptsDir([
+      'assemble-real.sh' => 'echo run',
+      'assemble-readme.md' => '# notes',
+      'assemble-script.txt' => 'echo nope',
+    ]);
+
+    $this->mockPassthru(['cmd' => escapeshellarg($dir . '/assemble-real.sh'), 'result_code' => 0]);
+
+    ob_start();
+    run_custom_scripts($dir, 'assemble-');
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('assemble-real.sh', $output);
+    $this->assertStringNotContainsString('assemble-readme.md', $output);
+    $this->assertStringNotContainsString('assemble-script.txt', $output);
+  }
+
+  public function testNonZeroExitAbortsParent(): void {
+    $dir = $this->createScriptsDir([
+      'provision-first.sh' => 'echo first',
+      'provision-second.sh' => 'echo second',
+    ]);
+
+    $this->mockPassthru(['cmd' => escapeshellarg($dir . '/provision-first.sh'), 'result_code' => 7]);
+    $this->mockQuit(1);
+
+    ob_start();
+    try {
+      run_custom_scripts($dir, 'provision-');
+      $this->fail('Expected QuitErrorException to be thrown.');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertSame(1, $e->getCode());
+    }
+    finally {
+      $output = (string) ob_get_clean();
+      $this->assertStringContainsString('provision-first.sh', $output);
+      $this->assertStringContainsString('Custom script', $output);
+      $this->assertStringContainsString('failed', $output);
+      $this->assertStringNotContainsString('provision-second.sh', $output);
+    }
+  }
+
+  protected function createScriptsDir(array $files = []): string {
+    $dir = self::$tmp . '/scripts_' . uniqid();
+    mkdir($dir, 0755, TRUE);
+    foreach ($files as $name => $contents) {
+      file_put_contents($dir . '/' . $name, $contents);
+    }
+
+    return $dir;
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
@@ -73,6 +73,24 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
     $this->assertStringNotContainsString('provision-skip.sh', $output);
   }
 
+  public function testSkipsDirectoriesMatchingPrefix(): void {
+    $dir = self::$tmp . '/scripts_' . uniqid();
+    mkdir($dir, 0755, TRUE);
+    // A directory whose name matches the glob; run_custom_scripts must
+    // skip it instead of trying to exec it.
+    mkdir($dir . '/assemble-rogue.sh', 0755, TRUE);
+    file_put_contents($dir . '/assemble-real.sh', 'echo real');
+
+    $this->mockPassthru(['cmd' => escapeshellarg($dir . '/assemble-real.sh'), 'result_code' => 0]);
+
+    ob_start();
+    run_custom_scripts($dir, 'assemble-');
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('assemble-real.sh', $output);
+    $this->assertStringNotContainsString('assemble-rogue.sh', $output);
+  }
+
   public function testIgnoresNonShellExtension(): void {
     $dir = $this->createScriptsDir([
       'assemble-real.sh' => 'echo run',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This is a Drupal extension scaffold template for creating contributed modules or
 - `config/schema/` - Configuration schema definitions
 - `build/` - Assembled Drupal codebase (symlinked extension)
 - `.devtools/` - Build and deployment scripts used by CI
+- `scripts/` - Custom post-assemble (`assemble-*.sh`) and post-provision (`provision-*.sh`) hooks. Run automatically at the end of each phase in lexicographic order; non-zero exit aborts the parent. Excluded from distribution archives via `.gitattributes`
 
 **Template Files (before init):**
 - `your_extension.*` - Template extension files

--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ You can browse the contents of the created SQLite database using
 
 A one-time login link will be printed to the console.
 
+### Custom assemble and provision scripts
+
+The `assemble` and `provision` scripts each look for project-local shell scripts in the `scripts/` directory and run them at the end of their respective phase:
+
+- `scripts/assemble-*.sh` runs at the tail of `make assemble` / `ahoy assemble`, after dependencies are installed and the extension is symlinked into `build/`.
+- `scripts/provision-*.sh` runs at the tail of `make provision` / `ahoy provision`, after the site is installed, the extension is enabled, and caches are pre-warmed.
+
+Matching files are executed in lexicographic order. The current working directory is the project root, and each script inherits the parent process environment. A non-zero exit from any script aborts the parent run.
+
+The directory is `export-ignore`d via `.gitattributes`, so anything under `scripts/` is excluded from distribution archives published to Drupal.org.
+
+Two example scripts ship with the scaffold (`scripts/assemble-example.sh`, `scripts/provision-example.sh`). Delete them, replace them, or use them as a starting point.
+
 ### Step-debugging with XDebug
 
 PHP step-debugging is supported via [XDebug](https://xdebug.org/docs/install). Install the XDebug PHP extension on your host (`php -v` should mention `with Xdebug`), then toggle it on the development server:

--- a/init.php
+++ b/init.php
@@ -348,6 +348,7 @@ function process_internal(string $extension_name, string $extension_machine_name
   uncomment_line('.gitattributes', 'phpunit.xml');
   uncomment_line('.gitattributes', 'rector.php');
   uncomment_line('.gitattributes', 'renovate.json');
+  uncomment_line('.gitattributes', 'scripts');
   uncomment_line('.gitattributes', 'tests');
   remove_string_content('# Remove the lines below in your project.');
   remove_string_content('.github/FUNDING.yml export-ignore');

--- a/scripts/assemble-example.sh
+++ b/scripts/assemble-example.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# Example post-assemble script.
+#
+# Runs at the end of `.devtools/assemble` (after dependencies are
+# installed and the extension is symlinked into `build/`). The current
+# working directory is the project root. Any non-zero exit aborts the
+# parent assemble run.
+#
+# Drop your own logic in any file matching `scripts/assemble-*.sh` -
+# all matching files run in lexicographic order.
+
+set -eu
+
+echo "[example] post-assemble script ran."

--- a/scripts/provision-example.sh
+++ b/scripts/provision-example.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# Example post-provision script.
+#
+# Runs at the end of `.devtools/provision` (after the site is
+# installed, the extension is enabled, and caches are pre-warmed). The
+# current working directory is the project root. Any non-zero exit
+# aborts the parent provision run.
+#
+# Drop your own logic in any file matching `scripts/provision-*.sh` -
+# all matching files run in lexicographic order.
+
+set -eu
+
+echo "[example] post-provision script ran."


### PR DESCRIPTION
Closes #392

## Summary

Adds two project-local extension points to the scaffold so consumers can inject custom logic at the end of the assemble and provision phases without modifying the shared `.devtools/` scripts. `assemble` now calls `run_custom_scripts('scripts', 'assemble-')` and `provision` calls `run_custom_scripts('scripts', 'provision-')` immediately before their completion banners. Scripts run in lexicographic order, inherit the parent process environment, and a non-zero exit aborts the parent. The `scripts/` directory is `export-ignore`d in `.gitattributes` so consumer hook scripts are excluded from distribution archives published to Drupal.org.

## Changes

**Hook implementation**
- `.devtools/helpers.php` - new `run_custom_scripts(string $dir, string $prefix): void` function: silently skips a missing directory or empty match set, globs `<dir>/<prefix>*.sh` in lexicographic order, and delegates each file to `passthru_or_fail()` so a non-zero exit triggers the existing abort path
- `.devtools/assemble` - calls `run_custom_scripts('scripts', 'assemble-')` before the ASSEMBLE COMPLETE banner
- `.devtools/provision` - calls `run_custom_scripts('scripts', 'provision-')` before the PROVISION COMPLETE banner

**Examples**
- `scripts/assemble-example.sh` - executable example hook that prints `[example] post-assemble script ran.`
- `scripts/provision-example.sh` - executable example hook that prints `[example] post-provision script ran.`
- `.gitattributes` - adds `# scripts  export-ignore` in the "uncomment in your project" block
- `init.php` - calls `uncomment_line('.gitattributes', 'scripts')` so consumer `init.php` activates the export-ignore entry

**Tests**
- `.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php` - 7 unit tests (group `p0`): missing directory is silent, empty directory is silent, no-prefix-match is silent, lexicographic ordering, prefix isolation (provision scripts not run for assemble prefix), `.sh` extension filtering, non-zero exit triggers `QuitErrorException`
- `.scaffold/tests/src/Functional/AssembleTest.php` - asserts `[example] post-assemble script ran.` in assemble output
- `.scaffold/tests/src/Functional/MakeTest.php` - asserts example markers in both `make assemble` and `make provision` output (including idempotent re-provision)
- `.scaffold/tests/src/Functional/AhoyTest.php` - same assertions for `ahoy assemble` and `ahoy provision`

**Documentation**
- `README.md` - new "Custom assemble and provision scripts" section covering the glob pattern, ordering, CWD, env inheritance, non-zero abort, and `.gitattributes` exclusion
- `.devtools/README.md` - brief "Custom scripts" reference pointing to the root README
- `AGENTS.md` - `scripts/` entry added to the Key Directories table

**Snapshot fixtures**
- `.scaffold/tests/fixtures/init/_baseline/` - all modified source files regenerated into the baseline snapshot so `InitTest` keeps passing: `helpers.php`, `assemble`, `provision`, `.gitattributes`, `AGENTS.md`, `.devtools/README.md`, plus new `scripts/assemble-example.sh` and `scripts/provision-example.sh`

## Before / After

```
Before
──────

make assemble / ahoy assemble
  [composer install, npm, symlink, ...]
  └── ASSEMBLE COMPLETE ✅

make provision / ahoy provision
  [site-install, enable extension, cache pre-warm]
  └── PROVISION COMPLETE ✅


After
─────

make assemble / ahoy assemble
  [composer install, npm, symlink, ...]
  ├── run_custom_scripts('scripts', 'assemble-')
  │     ├── scripts/assemble-example.sh  ← runs if present
  │     └── scripts/assemble-custom.sh  ← runs if present (lex order)
  └── ASSEMBLE COMPLETE ✅

make provision / ahoy provision
  [site-install, enable extension, cache pre-warm]
  ├── run_custom_scripts('scripts', 'provision-')
  │     ├── scripts/provision-example.sh  ← runs if present
  │     └── scripts/provision-custom.sh  ← runs if present (lex order)
  └── PROVISION COMPLETE ✅
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements post-assemble and post-provision script hooks, enabling project-local customization without modifying shared `.devtools/` scripts.

## Implementation

**New helper function**: Added `run_custom_scripts(string $dir, string $prefix): void` in `.devtools/helpers.php` that:
- Silently skips missing directories or empty match sets
- Globs `<dir>/<prefix>*.sh` files in lexicographic order
- Executes each script via `passthru_or_fail()`, aborting on non-zero exit

**Integration points**:
- `.devtools/assemble` calls `run_custom_scripts('scripts', 'assemble-')` before completion banner
- `.devtools/provision` calls `run_custom_scripts('scripts', 'provision-')` before completion banner

**Distribution control**: 
- `.gitattributes` updated to exclude `scripts/` from distribution archives
- `init.php` uncomments the `scripts` entry during scaffold initialization

## Example hooks

Added executable example scripts demonstrating behavior:
- `scripts/assemble-example.sh` (post-assemble)
- `scripts/provision-example.sh` (post-provision)

Both enable strict error handling and print status messages.

## Documentation

- New "Custom assemble and provision scripts" section in `README.md` detailing execution semantics
- Brief reference in `.devtools/README.md` 
- `scripts/` directory listed in `AGENTS.md`

## Testing

**Unit tests** (7 cases in `HelpersRunCustomScriptsTest`): Cover missing/empty directories, prefix filtering, execution order, non-shell file handling, and abort-on-error behavior.

**Functional tests**: Updated `AhoyTest`, `AssembleTest`, and `MakeTest` to verify example script output appears in workflow results and idempotent re-provision.

**Test fixtures**: Updated baseline fixture files to reflect new helper function and script detection logic.

## Behavior

Scripts execute in lexicographic order, inherit parent environment, run with CWD at project root, and any non-zero exit aborts the workflow. The `scripts/` directory is excluded from Drupal.org distribution archives.

Closes `#392`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->