### PR TITLE
[#401] Gated npm cache to push events to prevent cache poisoning in the 'lint' job.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ github.event_name == 'push' && 'npm' || '' }}
 
       - name: Install Node.js dependencies
         run: npm ci --ignore-scripts

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@__HASH__ # __VERSION__
         with:
           node-version: __VERSION__
-          cache: npm
+          cache: ${{ github.event_name == 'push' && 'npm' || '' }}
 
       - name: Install Node.js dependencies
         run: npm ci --ignore-scripts

--- a/.scaffold/tests/fixtures/init/keep_script/init.php
+++ b/.scaffold/tests/fixtures/init/keep_script/init.php
@@ -1,1 +1,0 @@
-#igonred


### PR DESCRIPTION
Closes #401

## Summary

The `lint` job's `actions/setup-node` step had `cache: npm` set unconditionally, which zizmor flags as a cache-poisoning risk: `pull_request` runs triggered from forks can read and write the shared npm cache, allowing a malicious actor to poison the cache with a tampered package that a later trusted `push` run would restore and execute. Gating the cache expression to `push` events closes that vector - `pull_request` runs (including from forks) still install dependencies fresh via `npm ci` but neither read from nor write to the shared cache. Every project that consumes this scaffold inherits the fix automatically on its next scaffold update.

## Changes

**Workflow fix (`.github/workflows/test.yml`):** Changed the `cache` input on the `actions/setup-node` step from the unconditional string `npm` to the expression `${{ github.event_name == 'push' && 'npm' || '' }}`. On `push` events the cache behaves exactly as before; on `pull_request` events the cache input resolves to an empty string, disabling cache restore and save for that run.

**Regenerated snapshots (`.scaffold/tests/fixtures/init/`):** The baseline fixture `.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml` was updated to mirror the gated cache line from the source. The stale drift file `.scaffold/tests/fixtures/init/keep_script/init.php` (which contained only a typo'd `#igonred` marker) was removed by the snapshot generator. Both changes were produced by running `composer --working-dir=.scaffold/tests update-snapshots` and must not be hand-edited.

## Before / After

```yaml
# Before
cache: npm

# After
cache: ${{ github.event_name == 'push' && 'npm' || '' }}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Modified the npm cache configuration in the GitHub Actions `lint` workflow to prevent cache poisoning from fork-triggered pull requests.

### .github/workflows/test.yml

Updated the `actions/setup-node` step in the `lint` job to conditionally enable npm caching:
- Changed `cache: npm` to `cache: ${{ github.event_name == 'push' && 'npm' || '' }}`
- The npm cache is now used only on `push` events; `pull_request` runs (including those from forks) have cache disabled

### Test fixtures

Regenerated snapshot files under `.scaffold/tests/fixtures/init/` to reflect the gated cache change:
- Updated `.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml` with the conditional cache configuration
- Removed stale drift file `.scaffold/tests/fixtures/init/keep_script/init.php` that contained a typo'd marker (`#igonred`)

These snapshot changes were produced by running `composer --working-dir=.scaffold/tests update-snapshots`.

## Issue

Closes `#401`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->