### PR TITLE
[#403] Resolved relative 'TMPDIR' to absolute in 'ahoy' and 'make' wrappers.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -169,6 +169,9 @@ entrypoint:
   - -c
   - -e
   - |
+    # Resolve a relative TMPDIR to an absolute path so tools that chdir (pushd
+    # build) still find it. No-op when unset or already absolute.
+    if [ -n "${TMPDIR:-}" ]; then case "$TMPDIR" in /*) ;; *) TMPDIR="$PWD/$TMPDIR" ;; esac; mkdir -p "$TMPDIR"; export TMPDIR; fi
     extension="$(basename -s .info.yml -- ./*.info.yml)"
     export BROWSERTEST_OUTPUT_DIRECTORY="${TMPDIR:-/tmp}"
     export SIMPLETEST_BASE_URL=http://${WEBSERVER_HOST:-localhost}:${WEBSERVER_PORT:-8000}

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -51,8 +51,6 @@ composer --working-dir=.scaffold/tests update-snapshots
 
 **HARD RULE - commit source changes before regenerating.** `update-snapshots` stages, commits, and amends the fixture diffs via `git`. Always commit your source changes (`.ahoy.yml`, `Makefile`, `.devtools/`, `init.php`, etc.) as their own commit **first**, then run `update-snapshots` so the regenerated fixtures land in a separate, clean commit on top. Running it with uncommitted source mixes the two changesets and leaves the branch history tangled.
 
-**HARD RULE - use an absolute `TMPDIR`.** The snapshot harness resolves its workspace and `.snapshot-expected-*` comparison dirs from `sys_get_temp_dir()`. If `TMPDIR` is relative (e.g. under Claude Code, where it points at `.artifacts/tmp/...`), those dirs get written **inside** the copied-out fixtures and, because `.artifacts/` is git-ignored, they stay invisible to `git status` while still polluting the filesystem comparison - every dataset then fails to match. Export an absolute `TMPDIR` before regenerating or verifying, e.g. `TMPDIR="$PWD/.artifacts/tmp/snapshots" composer --working-dir=.scaffold/tests update-snapshots`. CI is unaffected because its system temp is already absolute.
-
 This wraps `vendor/bin/update-snapshots` from `alexskrypnyk/snapshot`. It:
 
 1. Runs the baseline dataset first and commits any baseline diff as its own commit.

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -49,6 +49,10 @@ When source files change (workflows, `.devtools/`, `init.php`, Claude settings, 
 composer --working-dir=.scaffold/tests update-snapshots
 ```
 
+**HARD RULE - commit source changes before regenerating.** `update-snapshots` stages, commits, and amends the fixture diffs via `git`. Always commit your source changes (`.ahoy.yml`, `Makefile`, `.devtools/`, `init.php`, etc.) as their own commit **first**, then run `update-snapshots` so the regenerated fixtures land in a separate, clean commit on top. Running it with uncommitted source mixes the two changesets and leaves the branch history tangled.
+
+**HARD RULE - use an absolute `TMPDIR`.** The snapshot harness resolves its workspace and `.snapshot-expected-*` comparison dirs from `sys_get_temp_dir()`. If `TMPDIR` is relative (e.g. under Claude Code, where it points at `.artifacts/tmp/...`), those dirs get written **inside** the copied-out fixtures and, because `.artifacts/` is git-ignored, they stay invisible to `git status` while still polluting the filesystem comparison - every dataset then fails to match. Export an absolute `TMPDIR` before regenerating or verifying, e.g. `TMPDIR="$PWD/.artifacts/tmp/snapshots" composer --working-dir=.scaffold/tests update-snapshots`. CI is unaffected because its system temp is already absolute.
+
 This wraps `vendor/bin/update-snapshots` from `alexskrypnyk/snapshot`. It:
 
 1. Runs the baseline dataset first and commits any baseline diff as its own commit.

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -169,6 +169,9 @@ entrypoint:
   - -c
   - -e
   - |
+    # Resolve a relative TMPDIR to an absolute path so tools that chdir (pushd
+    # build) still find it. No-op when unset or already absolute.
+    if [ -n "${TMPDIR:-}" ]; then case "$TMPDIR" in /*) ;; *) TMPDIR="$PWD/$TMPDIR" ;; esac; mkdir -p "$TMPDIR"; export TMPDIR; fi
     extension="$(basename -s .info.yml -- ./*.info.yml)"
     export BROWSERTEST_OUTPUT_DIRECTORY="${TMPDIR:-/tmp}"
     export SIMPLETEST_BASE_URL=http://${WEBSERVER_HOST:-localhost}:${WEBSERVER_PORT:-8000}

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -5,6 +5,12 @@ SHELL=/bin/bash
 -include .env
 export
 
+# Resolve a relative TMPDIR to an absolute path so build/-dir tools (which
+# chdir into build) can still find it. No-op when unset or already absolute.
+ifdef TMPDIR
+export TMPDIR := $(abspath $(TMPDIR))
+endif
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -5,6 +5,12 @@ SHELL=/bin/bash
 -include .env
 export
 
+# Resolve a relative TMPDIR to an absolute path so build/-dir tools (which
+# chdir into build) can still find it. No-op when unset or already absolute.
+ifdef TMPDIR
+export TMPDIR := $(abspath $(TMPDIR))
+endif
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -5,6 +5,12 @@ SHELL=/bin/bash
 -include .env
 export
 
+# Resolve a relative TMPDIR to an absolute path so build/-dir tools (which
+# chdir into build) can still find it. No-op when unset or already absolute.
+ifdef TMPDIR
+export TMPDIR := $(abspath $(TMPDIR))
+endif
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -5,6 +5,12 @@ SHELL=/bin/bash
 -include .env
 export
 
+# Resolve a relative TMPDIR to an absolute path so build/-dir tools (which
+# chdir into build) can still find it. No-op when unset or already absolute.
+ifdef TMPDIR
+export TMPDIR := $(abspath $(TMPDIR))
+endif
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -119,6 +119,17 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
+    // A relative TMPDIR must not break tools that run from the build/ directory.
+    // The lint and test wrappers chdir into build/ before invoking PHP tools, so
+    // a relative sys_get_temp_dir() resolves against build/ and tempnam() fails
+    // with "Path must not be empty". The wrapper must resolve TMPDIR to an
+    // absolute path first, so linting still passes when TMPDIR is relative.
+    if (!is_dir(self::$sut . '/.logs/relative-tmp')) {
+      mkdir(self::$sut . '/.logs/relative-tmp', 0777, TRUE);
+    }
+    $this->processRun('ahoy', ['lint'], [], ['TMPDIR' => '.logs/relative-tmp'], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+
     // PHP: introduce a PHPCS violation.
     File::append(self::$sut . '/your_extension.module', '$a=123;echo $a;' . PHP_EOL);
 

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -119,11 +119,11 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
-    // A relative TMPDIR must not break tools that run from the build/ directory.
-    // The lint and test wrappers chdir into build/ before invoking PHP tools, so
-    // a relative sys_get_temp_dir() resolves against build/ and tempnam() fails
-    // with "Path must not be empty". The wrapper must resolve TMPDIR to an
-    // absolute path first, so linting still passes when TMPDIR is relative.
+    // A relative TMPDIR must not break tools that run from build/. The
+    // lint and test wrappers chdir into build/ before running PHP tools,
+    // so a relative sys_get_temp_dir() resolves against build/ and
+    // tempnam() fails. The wrapper resolves TMPDIR to an absolute path
+    // first, so linting still passes when TMPDIR is relative.
     if (!is_dir(self::$sut . '/.logs/relative-tmp')) {
       mkdir(self::$sut . '/.logs/relative-tmp', 0777, TRUE);
     }

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -118,6 +118,17 @@ final class MakeTest extends DevtoolsTestCase {
     $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
+    // A relative TMPDIR must not break tools that run from the build/ directory.
+    // The lint and test wrappers chdir into build/ before invoking PHP tools, so
+    // a relative sys_get_temp_dir() resolves against build/ and tempnam() fails
+    // with "Path must not be empty". The wrapper must resolve TMPDIR to an
+    // absolute path first, so linting still passes when TMPDIR is relative.
+    if (!is_dir(self::$sut . '/.logs/relative-tmp')) {
+      mkdir(self::$sut . '/.logs/relative-tmp', 0777, TRUE);
+    }
+    $this->processRun('make', ['lint'], [], ['TMPDIR' => '.logs/relative-tmp'], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+
     // PHP: introduce a PHPCS violation.
     File::append(self::$sut . '/your_extension.module', '$a=123;echo $a;' . PHP_EOL);
 

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -118,11 +118,11 @@ final class MakeTest extends DevtoolsTestCase {
     $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
     $this->assertProcessSuccessful();
 
-    // A relative TMPDIR must not break tools that run from the build/ directory.
-    // The lint and test wrappers chdir into build/ before invoking PHP tools, so
-    // a relative sys_get_temp_dir() resolves against build/ and tempnam() fails
-    // with "Path must not be empty". The wrapper must resolve TMPDIR to an
-    // absolute path first, so linting still passes when TMPDIR is relative.
+    // A relative TMPDIR must not break tools that run from build/. The
+    // lint and test wrappers chdir into build/ before running PHP tools,
+    // so a relative sys_get_temp_dir() resolves against build/ and
+    // tempnam() fails. The wrapper resolves TMPDIR to an absolute path
+    // first, so linting still passes when TMPDIR is relative.
     if (!is_dir(self::$sut . '/.logs/relative-tmp')) {
       mkdir(self::$sut . '/.logs/relative-tmp', 0777, TRUE);
     }

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ SHELL=/bin/bash
 -include .env
 export
 
+# Resolve a relative TMPDIR to an absolute path so build/-dir tools (which
+# chdir into build) can still find it. No-op when unset or already absolute.
+ifdef TMPDIR
+export TMPDIR := $(abspath $(TMPDIR))
+endif
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 


### PR DESCRIPTION
Closes #403

## Summary

Both the `ahoy` entrypoint and `Makefile` recipes `chdir` into `build/` before running PHP tools (PHPCS, PHPStan, PHPUnit). When `TMPDIR` is set to a relative path, `sys_get_temp_dir()` resolves it against `build/` and `tempnam()` subsequently fails with "Path must not be empty", crashing the entire lint/test pipeline. This fix resolves `TMPDIR` to an absolute path once, at the very top of each wrapper, before any directory change occurs. The resolution is a no-op when `TMPDIR` is unset or already absolute, so CI and normal local use are unaffected.

## Changes

**`.ahoy.yml` - shell-level resolution at entrypoint start**
- Added a `case` pattern at the top of the entrypoint `|-` block: if `TMPDIR` is set and does not start with `/`, it is prefixed with `$PWD` and the resulting directory is created with `mkdir -p` before any `pushd build/` can happen.

**`Makefile` - make-level resolution near the top**
- Added an `ifdef TMPDIR` / `export TMPDIR := $(abspath $(TMPDIR))` block immediately after the `.env` include so every recipe that calls into `build/` inherits the absolute value.

**Snapshot fixtures updated**
- All four `Makefile` fixtures under `.scaffold/tests/fixtures/init/` (`circleci_both_wrappers`, `circleci_makefile`, `gha_both_wrappers`, `gha_makefile`) and the baseline `_baseline/.ahoy.yml` regenerated to include the new blocks.

**Regression tests added**
- `AhoyTest.php` and `MakeTest.php` each assert that `lint` still passes when `TMPDIR=.logs/relative-tmp` (a relative path) is injected into the process environment, directly exercising the fix.

**`.scaffold/CLAUDE.md` - workflow note added**
- Documents the rule to commit source changes before running `update-snapshots` so regenerated fixtures land in a separate, clean commit.

## Before / After

```
BEFORE
──────────────────────────────────────────────────────────
  env: TMPDIR=.logs/relative-tmp (relative)
        │
        ▼
  ahoy / make wrapper starts
        │
        ▼
  pushd build/   ← cwd changes to build/
        │
        ▼
  PHP tools call sys_get_temp_dir()
  → returns ".logs/relative-tmp"   (still relative)
        │
        ▼
  tempnam(".logs/relative-tmp", …)
  → FAILS: "Path must not be empty"
        │
        ▼
  ✗ lint / test pipeline crashes

AFTER
──────────────────────────────────────────────────────────
  env: TMPDIR=.logs/relative-tmp (relative)
        │
        ▼
  ahoy / make wrapper starts
        │
        ▼
  Resolve TMPDIR to absolute path
  TMPDIR="$PWD/.logs/relative-tmp"   (shell)
  TMPDIR := $(abspath $(TMPDIR))     (make)
  mkdir -p "$TMPDIR"
        │
        ▼
  pushd build/   ← cwd changes to build/
        │
        ▼
  PHP tools call sys_get_temp_dir()
  → returns "/abs/path/.logs/relative-tmp"
        │
        ▼
  tempnam("/abs/path/.logs/relative-tmp", …)
  → succeeds
        │
        ▼
  ✓ lint / test pipeline passes
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR resolves a crash that occurs when `TMPDIR` is set to a relative path in build environments. The issue arises because the ahoy entrypoint and Makefile recipes change directories into `build/` before running PHP tools. When `TMPDIR` is relative, PHP's `sys_get_temp_dir()` resolves it relative to the new working directory (`build/`), producing a non-existent path and causing `tempnam()` to fail with "Path must not be empty". This crash affects PHPCS, PHPStan, and PHPUnit.

## Changes

**Core fixes:**
- **.ahoy.yml**: Added shell logic to detect when `TMPDIR` is set and relative. If so, it prefixes `TMPDIR` with `$PWD`, creates the directory with `mkdir -p`, and exports the resolved absolute path before subsequent operations and the main command execution.
- **Makefile**: Added a conditional `ifdef TMPDIR` block that exports `TMPDIR` as an absolute path using `$(abspath $(TMPDIR))` immediately after environment loading, ensuring all downstream recipes inherit the corrected value.

**Test fixtures updated:**
- `.scaffold/tests/fixtures/init/_baseline/.ahoy.yml`: Updated to include the new TMPDIR resolution logic.
- `.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile`
- `.scaffold/tests/fixtures/init/circleci_makefile/Makefile`
- `.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile`
- `.scaffold/tests/fixtures/init/gha_makefile/Makefile`

All four Makefile fixtures now include the conditional `ifdef TMPDIR` block.

**Test coverage:**
- **AhoyTest.php**: Updated `runLint()` to test the ahoy wrapper with `TMPDIR` set to a relative path (`.logs/relative-tmp`), ensuring the wrapper handles this scenario successfully.
- **MakeTest.php**: Updated `runLint()` to test the Makefile wrapper with `TMPDIR` set to a relative path, verifying lint passes before running additional positive/negative lint checks.

**Documentation:**
- **.scaffold/CLAUDE.md**: Added a "HARD RULE" clarifying that all source changes must be committed before running `update-snapshots`, ensuring regenerated snapshot fixture diffs land in a separate commit.

## Impact

- **Backward compatible**: Changes are no-ops when `TMPDIR` is unset or already absolute.
- **CI-safe**: Environment variable behavior in CI systems is unaffected.
- **Tooling**: Ensures PHP tools and `.devtools/` scripts inherit the corrected `TMPDIR` value.

## Related

Closes `#403`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->