### PR TITLE
Moved CSpell to run last in the 'lint' targets.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -56,9 +56,6 @@ commands:
   lint:
     usage: Check coding standards for violations.
     cmd: |
-      ahoy title "Running CSpell"
-      [ -d node_modules ] || npm install --no-audit --no-fund
-      npm run lint-spell
       pushd "build" >/dev/null || exit 1
       ahoy title "Running PHPCS"
       vendor/bin/phpcs
@@ -70,6 +67,9 @@ commands:
       vendor/bin/twig-cs-fixer
       [ ! -d node_modules ] || (ahoy title "Running ESLint" && npm run lint)
       popd >/dev/null || exit 1
+      ahoy title "Running CSpell"
+      [ -d node_modules ] || npm install --no-audit --no-fund
+      npm run lint-spell
 
   lint-fix:
     usage: Fix violations in coding standards.

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -39,25 +39,30 @@ All commands run from `.scaffold/tests/`. Install dependencies once with `compos
 
 ## Regenerating snapshot fixtures
 
-**HARD RULE - never edit fixtures directly.** Files under `.scaffold/tests/fixtures/init/` are generated artefacts. They must always be regenerated via `composer --working-dir=.scaffold/tests update-snapshots` after any source change that affects `init.php` output. Hand-editing a fixture risks drift between what the generator would produce and what is checked in - subsequent regenerations would then overwrite the manual edit and the failure mode would only surface in CI.
+**HARD RULE - never edit fixtures directly.** Files under `.scaffold/tests/fixtures/init/` are generated artefacts. They must always be regenerated with the `update-snapshots` Composer script - run from inside `.scaffold/tests` (see below) - after any source change that affects `init.php` output. Hand-editing a fixture risks drift between what the generator would produce and what is checked in - subsequent regenerations would then overwrite the manual edit and the failure mode would only surface in CI.
 
 `InitTest` runs `init.php` end-to-end and diffs the output against `fixtures/init/_baseline/` plus one fixture directory per dataset (`circleci/`, `gha_makefile/`, `theme/`, etc. - see `InitTest::dataProviderInit()`).
 
-When source files change (workflows, `.devtools/`, `init.php`, Claude settings, etc.), the fixtures fall out of date. Regenerate them:
+When source files change (workflows, `.devtools/`, `init.php`, Claude settings, etc.), the fixtures fall out of date. Regenerate them.
+
+**HARD RULE - `cd` into `.scaffold/tests` and regenerate serially with `--jobs=1`.**
 
 ```bash
-composer --working-dir=.scaffold/tests update-snapshots
+cd .scaffold/tests
+composer update-snapshots -- --jobs=1
 ```
+
+By default the runner regenerates the per-dataset fixtures in parallel. In automated or sandboxed environments - where `TMPDIR` may be a relative path that the runner resolves against its own working copy - the parallel workers race against each other and the shared temp area: one or more datasets are then silently dropped from, or written as raw diff garbage into, the regenerated set while the run still reports overall success, leaving broken fixtures that only surface as a CI failure later. `--jobs=1` forces a deterministic serial run so every dataset regenerates correctly. Always `git show --stat` the resulting commit and confirm it touches only the files your change should have affected.
 
 **HARD RULE - commit source changes before regenerating.** `update-snapshots` stages, commits, and amends the fixture diffs via `git`. Always commit your source changes (`.ahoy.yml`, `Makefile`, `.devtools/`, `init.php`, etc.) as their own commit **first**, then run `update-snapshots` so the regenerated fixtures land in a separate, clean commit on top. Running it with uncommitted source mixes the two changesets and leaves the branch history tangled.
 
 This wraps `vendor/bin/update-snapshots` from `alexskrypnyk/snapshot`. It:
 
 1. Runs the baseline dataset first and commits any baseline diff as its own commit.
-2. Runs the remaining datasets in parallel and amends the baseline commit with each fixture diff.
+2. Runs the remaining datasets (serially under `--jobs=1`) and amends the baseline commit with each fixture diff.
 3. Exits non-zero on the first run because the original tests failed against the stale snapshots - that is expected; the snapshots are now correct.
 
-Run `composer --working-dir=.scaffold/tests test -- --filter=InitTest` afterwards to confirm everything is green, then review the committed diffs before pushing.
+From inside `.scaffold/tests`, run `composer test -- --filter=InitTest` afterwards to confirm everything is green, then review the committed diffs before pushing.
 
 The trait that drives the diff-and-update behaviour is `SnapshotTrait` (see `tearDown()` in `InitTest`); it calls `snapshotUpdateOnFailure()` so a normal `test` run will also rewrite fixtures if you have not used the dedicated `update-snapshots` command.
 

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -56,9 +56,6 @@ commands:
   lint:
     usage: Check coding standards for violations.
     cmd: |
-      ahoy title "Running CSpell"
-      [ -d node_modules ] || npm install --no-audit --no-fund
-      npm run lint-spell
       pushd "build" >/dev/null || exit 1
       ahoy title "Running PHPCS"
       vendor/bin/phpcs
@@ -70,6 +67,9 @@ commands:
       vendor/bin/twig-cs-fixer
       [ ! -d node_modules ] || (ahoy title "Running ESLint" && npm run lint)
       popd >/dev/null || exit 1
+      ahoy title "Running CSpell"
+      [ -d node_modules ] || npm install --no-audit --no-fund
+      npm run lint-spell
 
   lint-fix:
     usage: Fix violations in coding standards.

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -98,9 +98,6 @@ provision:
 	./.devtools/provision
 
 lint:
-	$(call title,Running CSpell)
-	[ -d node_modules ] || npm install --no-audit --no-fund
-	npm run lint-spell
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)
@@ -111,6 +108,9 @@ lint:
 	pushd "build" >/dev/null || exit 1 && vendor/bin/twig-cs-fixer && popd >/dev/null || exit 1
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint) && popd >/dev/null || exit 1
+	$(call title,Running CSpell)
+	[ -d node_modules ] || npm install --no-audit --no-fund
+	npm run lint-spell
 
 lint-fix:
 	$(call title,Running Rector)

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -98,9 +98,6 @@ provision:
 	./.devtools/provision
 
 lint:
-	$(call title,Running CSpell)
-	[ -d node_modules ] || npm install --no-audit --no-fund
-	npm run lint-spell
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)
@@ -111,6 +108,9 @@ lint:
 	pushd "build" >/dev/null || exit 1 && vendor/bin/twig-cs-fixer && popd >/dev/null || exit 1
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint) && popd >/dev/null || exit 1
+	$(call title,Running CSpell)
+	[ -d node_modules ] || npm install --no-audit --no-fund
+	npm run lint-spell
 
 lint-fix:
 	$(call title,Running Rector)

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -98,9 +98,6 @@ provision:
 	./.devtools/provision
 
 lint:
-	$(call title,Running CSpell)
-	[ -d node_modules ] || npm install --no-audit --no-fund
-	npm run lint-spell
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)
@@ -111,6 +108,9 @@ lint:
 	pushd "build" >/dev/null || exit 1 && vendor/bin/twig-cs-fixer && popd >/dev/null || exit 1
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint) && popd >/dev/null || exit 1
+	$(call title,Running CSpell)
+	[ -d node_modules ] || npm install --no-audit --no-fund
+	npm run lint-spell
 
 lint-fix:
 	$(call title,Running Rector)

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -98,9 +98,6 @@ provision:
 	./.devtools/provision
 
 lint:
-	$(call title,Running CSpell)
-	[ -d node_modules ] || npm install --no-audit --no-fund
-	npm run lint-spell
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)
@@ -111,6 +108,9 @@ lint:
 	pushd "build" >/dev/null || exit 1 && vendor/bin/twig-cs-fixer && popd >/dev/null || exit 1
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint) && popd >/dev/null || exit 1
+	$(call title,Running CSpell)
+	[ -d node_modules ] || npm install --no-audit --no-fund
+	npm run lint-spell
 
 lint-fix:
 	$(call title,Running Rector)

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,6 @@ provision:
 	./.devtools/provision
 
 lint:
-	$(call title,Running CSpell)
-	[ -d node_modules ] || npm install --no-audit --no-fund
-	npm run lint-spell
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)
@@ -111,6 +108,9 @@ lint:
 	pushd "build" >/dev/null || exit 1 && vendor/bin/twig-cs-fixer && popd >/dev/null || exit 1
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint) && popd >/dev/null || exit 1
+	$(call title,Running CSpell)
+	[ -d node_modules ] || npm install --no-audit --no-fund
+	npm run lint-spell
 
 lint-fix:
 	$(call title,Running Rector)


### PR DESCRIPTION
Moved CSpell to run last in the `lint` and `lint-fix` targets.

## Summary

CSpell spell-checking now runs after all other linters (`phpcs`, `phpstan`, `rector`, `twig-cs-fixer`, `eslint`, `stylelint`) in both the `make lint` and `ahoy lint` targets. This change means faster structural and syntax errors are surfaced first, and the slower npm-based spell-check step only runs once all other checks have passed. The reordering is applied consistently to `Makefile`, `.ahoy.yml`, the baseline fixture, and all four init-scenario Makefile fixtures.

## Changes

**`Makefile` and `.ahoy.yml`**
- Moved the three CSpell lines (`npm install --no-audit --no-fund` guard + `npm run lint-spell`) from the top of the `lint` target to the bottom, after ESLint/Stylelint.

**`.scaffold/tests/fixtures/init/_baseline/.ahoy.yml`** and **`.scaffold/tests/fixtures/init/{circleci_both_wrappers,circleci_makefile,gha_both_wrappers,gha_makefile}/Makefile`**
- Same CSpell reordering applied to all generated fixture files to keep them in sync with the source templates.

**`.scaffold/CLAUDE.md`**
- Updated the snapshot-regeneration instructions to require `cd .scaffold/tests` before running `composer update-snapshots -- --jobs=1`, and expanded the explanation of why `--jobs=1` is necessary to avoid parallel-worker race conditions in sandboxed environments.

## Before / After

```
Before (lint target execution order)       After (lint target execution order)
──────────────────────────────────────     ──────────────────────────────────────
1. CSpell (npm install + lint-spell)       1. PHPCS
2. PHPCS                                   2. PHPStan
3. PHPStan                                 3. Rector (dry-run)
4. Rector (dry-run)                        4. Twig CS Fixer
5. Twig CS Fixer                           5. ESLint / Stylelint
6. ESLint / Stylelint                      6. CSpell (npm install + lint-spell)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Reorders the lint workflow so that CSpell (npm install guard + npm run lint-spell) runs last in both `make lint` and `ahoy lint` targets. This ensures faster structural and syntax errors (phpcs, phpstan, rector, twig-cs-fixer, eslint, stylelint) surface before the slower npm-based spell-check, allowing the workflow to fail fast on structural issues.

## Changes

### Root-level configuration files
- **Makefile**: Moved CSpell linting steps from the beginning of the `lint` target to after all other linting steps
- **.ahoy.yml**: Moved the three CSpell commands (`ahoy title "Running CSpell"`, conditional `npm install`, and `npm run lint-spell`) from the start of the `lint` command to after PHP-related tooling steps

### Test fixture files
Updated the following fixture Makefiles and configuration files to match the new lint order:
- `.scaffold/tests/fixtures/init/_baseline/.ahoy.yml`
- `.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile`
- `.scaffold/tests/fixtures/init/circleci_makefile/Makefile`
- `.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile`
- `.scaffold/tests/fixtures/init/gha_makefile/Makefile`

### Documentation
- **.scaffold/CLAUDE.md**: Updated snapshot-regeneration instructions with explicit hard rules: (1) never edit fixture files directly, (2) `cd .scaffold/tests` and run `composer update-snapshots -- --jobs=1` to force deterministic serial regeneration, (3) commit source changes before regenerating snapshots. Added explanation of the `--jobs=1` flag to avoid parallel-worker race conditions in sandboxed environments and included follow-up confirmation step.

## Execution order
The `lint` target now executes in this sequence: PHPCS → PHPStan → Rector → Twig CS Fixer → ESLint → CSpell (moved from position 1 to position 6).

## Possibly related

This optimization likely builds upon earlier enhancements to the lint pipeline, particularly `#391` which added CSpell spell checking initially, and `#401` which gated npm cache to prevent cache poisoning in the lint job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->