### PR TITLE
Made twig-cs-fixer follow symlinks so symlinked templates are linted.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/.twig-cs-fixer.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.twig-cs-fixer.php
@@ -6,6 +6,10 @@ $ruleset = new TwigCsFixer\Ruleset\Ruleset();
 $ruleset->addStandard(new TwigCsFixer\Standard\Twig());
 
 $finder = new TwigCsFixer\File\Finder();
+// Extensions are symlinked into the build directory (each top-level item,
+// including templates/, is a symlink), so the Finder must follow symlinks to
+// discover the templates it needs to lint.
+$finder->followLinks();
 $finder->in(__DIR__ . '/web/modules/custom');
 $finder->in(__DIR__ . '/web/themes/custom');
 

--- a/.scaffold/tests/src/Functional/AhoyTest.php
+++ b/.scaffold/tests/src/Functional/AhoyTest.php
@@ -30,6 +30,37 @@ final class AhoyTest extends DevtoolsTestCase {
     $this->assertProcessAnyOutputNotContains('Would run build');
   }
 
+  public function testLintTwigFollowsSymlinkedTemplates(): void {
+    $this->processRun('ahoy', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+
+    // A freshly assembled project lints clean.
+    $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+
+    // assemble symlinks each top-level extension item into the build, so a
+    // real templates/ directory becomes a symlink inside the tree that
+    // twig-cs-fixer scans. Recreate that layout with a template carrying a
+    // fixable delimiter-spacing violation, reachable from the scanned build
+    // directory only by following the templates/ symlink.
+    mkdir(self::$sut . '/templates');
+    file_put_contents(self::$sut . '/templates/your_extension.html.twig', '{{content}}' . PHP_EOL);
+    symlink(self::$sut . '/templates', self::$sut . '/build/web/modules/custom/your_extension/templates');
+
+    // twig-cs-fixer only sees the template if it follows the symlink, so lint
+    // must now fail and name the offending template.
+    $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('your_extension.html.twig');
+
+    // lint-fix repairs the template through the symlink; lint passes again.
+    $this->processRun('ahoy', ['lint-fix'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+
+    $this->processRun('ahoy', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+  }
+
   public function testWorkflow(): void {
     // Start without build fails.
     $this->processRun('ahoy', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);

--- a/.scaffold/tests/src/Functional/MakeTest.php
+++ b/.scaffold/tests/src/Functional/MakeTest.php
@@ -30,6 +30,37 @@ final class MakeTest extends DevtoolsTestCase {
     $this->assertProcessAnyOutputNotContains('Would run build');
   }
 
+  public function testLintTwigFollowsSymlinkedTemplates(): void {
+    $this->processRun('make', ['assemble'], [], [], $this->longTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('ASSEMBLE COMPLETE');
+
+    // A freshly assembled project lints clean.
+    $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+
+    // assemble symlinks each top-level extension item into the build, so a
+    // real templates/ directory becomes a symlink inside the tree that
+    // twig-cs-fixer scans. Recreate that layout with a template carrying a
+    // fixable delimiter-spacing violation, reachable from the scanned build
+    // directory only by following the templates/ symlink.
+    mkdir(self::$sut . '/templates');
+    file_put_contents(self::$sut . '/templates/your_extension.html.twig', '{{content}}' . PHP_EOL);
+    symlink(self::$sut . '/templates', self::$sut . '/build/web/modules/custom/your_extension/templates');
+
+    // twig-cs-fixer only sees the template if it follows the symlink, so lint
+    // must now fail and name the offending template.
+    $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('your_extension.html.twig');
+
+    // lint-fix repairs the template through the symlink; lint passes again.
+    $this->processRun('make', ['lint-fix'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+
+    $this->processRun('make', ['lint'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);
+    $this->assertProcessSuccessful();
+  }
+
   public function testWorkflow(): void {
     // Start without build fails.
     $this->processRun('make', ['start'], [], [], $this->defaultTimeout, $this->defaultIdleTimeout);

--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -6,6 +6,10 @@ $ruleset = new TwigCsFixer\Ruleset\Ruleset();
 $ruleset->addStandard(new TwigCsFixer\Standard\Twig());
 
 $finder = new TwigCsFixer\File\Finder();
+// Extensions are symlinked into the build directory (each top-level item,
+// including templates/, is a symlink), so the Finder must follow symlinks to
+// discover the templates it needs to lint.
+$finder->followLinks();
 $finder->in(__DIR__ . '/web/modules/custom');
 $finder->in(__DIR__ . '/web/themes/custom');
 


### PR DESCRIPTION
## Summary

`twig-cs-fixer` was silently skipping all Twig templates in an assembled extension because `.devtools/assemble` symlinks each top-level extension item - including `templates/` - into `build/web/{modules,themes}/custom/<ext>/`, and `TwigCsFixer\File\Finder` (a Symfony Finder) does not follow symlinks by default. The Finder descended into the real extension directory, encountered the `templates/` symlink, and stopped there, reporting `Files linted: 0` while returning success. Calling `$finder->followLinks()` makes it descend through symlinked directories, so every template under a symlinked `templates/` is now scanned.

## Changes

- `.twig-cs-fixer.php`: added `$finder->followLinks()` with an explanatory comment so the Finder follows the symlinked `templates/` (and any other symlinked top-level dirs) inside the build.
- `.scaffold/tests/src/Functional/AhoyTest.php` and `.scaffold/tests/src/Functional/MakeTest.php`: added `testLintTwigFollowsSymlinkedTemplates()`. The test assembles the project, confirms lint is clean, then writes a template with a fixable delimiter-spacing violation (`{{content}}`) into `templates/` and symlinks that directory into the build exactly as `assemble` does. It asserts `lint` now fails and names the template, and that `lint-fix` repairs it so `lint` passes again. Without the `followLinks()` fix the Finder reports `Files linted: 0`, lint stays green, and the test fails - proving the bug.
- `.scaffold/tests/fixtures/init/_baseline/.twig-cs-fixer.php`: regenerated InitTest baseline snapshot to reflect the new `followLinks()` call and its comment.

## Before / After

```
Before
------
build/web/modules/custom/
  your_extension/         (real dir)
    templates/            (symlink → <src>/templates/)  <-- Finder STOPS here, 0 files linted

After
-----
build/web/modules/custom/
  your_extension/         (real dir)
    templates/            (symlink → <src>/templates/)
      *.html.twig         <-- Finder follows symlink, files linted
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enables twig-cs-fixer to follow symbolic links, ensuring that Twig templates discovered via symlinked directories in the assembled build environment are properly linted.

## Problem

When the project is assembled via `.devtools/assemble`, it creates symlinks for top-level extension items (including `templates/`) into `build/web/{modules,themes}/custom/<ext>/`. However, Symfony Finder (used internally by TwigCsFixer\File\Finder) does not follow symlinks by default, causing the linter to stop at the `templates/` symlink and report "Files linted: 0".

## Changes

**`.twig-cs-fixer.php`**
- Added `$finder->followLinks()` call to instruct the TwigCsFixer Finder to descend into symlinked directories
- Includes explanatory comment documenting why symlink following is necessary

**`.scaffold/tests/src/Functional/AhoyTest.php` and `.scaffold/tests/src/Functional/MakeTest.php`**
- Added `testLintTwigFollowsSymlinkedTemplates()` functional test to both test classes
- Tests verify the complete workflow: assembles project, creates a template with a fixable Twig violation, symlinks the directory into the build, confirms linting detects and reports the violation, runs lint-fix to repair it, and verifies the fix succeeds

**`.scaffold/tests/fixtures/init/_baseline/.twig-cs-fixer.php`**
- Updated baseline fixture snapshot to reflect the new `followLinks()` call and its accompanying comment

## Result

After this change, the Finder correctly follows symlinks and lints all templates under symlinked directories, ensuring complete template coverage in the assembled build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->