### PR TITLE
[#420] Added a separate CircleCI lint job to mirror GitHub Actions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,16 +49,6 @@ job-test: &job-test
           fi
 
     - run:
-        name: Install Node.js dependencies
-        command: npm ci --ignore-scripts
-
-    #;< DEV_CSPELL
-    - run:
-        name: Lint code with CSpell
-        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-    #;> DEV_CSPELL
-
-    - run:
         name: Assemble the codebase
         command: .devtools/assemble
 
@@ -71,41 +61,6 @@ job-test: &job-test
     - run:
         name: Provision site
         command: .devtools/provision
-
-    #;< DEV_PHPCS
-    - run:
-        name: Lint code with PHPCS
-        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-    #;> DEV_PHPCS
-
-    #;< DEV_PHPSTAN
-    - run:
-        name: Lint code with PHPStan
-        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-    #;> DEV_PHPSTAN
-
-    #;< DEV_RECTOR
-    - run:
-        name: Lint code with Rector
-        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-    #;> DEV_RECTOR
-
-    #;< DEV_TWIGCS
-    - run:
-        name: Lint code with Twig CS Fixer
-        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-    #;> DEV_TWIGCS
-
-    #;< DEV_NODEJS_LINT
-    - run:
-        name: Lint module code with NodeJS linters
-        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-        working_directory: build
-    #;> DEV_NODEJS_LINT
 
     #;< DEV_JEST
     - run:
@@ -142,6 +97,62 @@ job-test: &job-test
     #;> DEV_PHPUNIT
 
 jobs:
+  lint:
+    <<: *container_config
+    docker:
+      - image: cimg/php:8.5-browsers
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node.js dependencies
+          command: npm ci --ignore-scripts
+
+      #;< DEV_CSPELL
+      - run:
+          name: Lint code with CSpell
+          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+      #;> DEV_CSPELL
+
+      - run:
+          name: Assemble the codebase
+          command: .devtools/assemble
+
+      #;< DEV_PHPCS
+      - run:
+          name: Lint code with PHPCS
+          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+      #;> DEV_PHPCS
+
+      #;< DEV_PHPSTAN
+      - run:
+          name: Lint code with PHPStan
+          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+      #;> DEV_PHPSTAN
+
+      #;< DEV_RECTOR
+      - run:
+          name: Lint code with Rector
+          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+      #;> DEV_RECTOR
+
+      #;< DEV_TWIGCS
+      - run:
+          name: Lint code with Twig CS Fixer
+          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+      #;> DEV_TWIGCS
+
+      #;< DEV_NODEJS_LINT
+      - run:
+          name: Lint module code with NodeJS linters
+          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+          working_directory: build
+      #;> DEV_NODEJS_LINT
+
   test-php-min-d10-stable:
     <<: *container_config
     docker:
@@ -206,9 +217,6 @@ jobs:
       #;> DEV_FUNCTIONAL_JAVASCRIPT
     environment:
       DRUPAL_VERSION: 11@beta
-      #;< DEV_PHPSTAN
-      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
-      #;> DEV_PHPSTAN
     <<: *job-test
 
   deploy:
@@ -233,6 +241,10 @@ workflows:
   version: 2
   commit:
     jobs:
+      - lint:
+          filters:
+            tags:
+              only: /.*/
       - test-php-min-d10-stable:
           filters:
             tags:
@@ -259,6 +271,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
+            - lint
             - test-php-min-d10-stable
             - test-php-max-d10-stable
             - test-php-min-d11-stable

--- a/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
@@ -47,14 +47,6 @@ job-test: &job-test
           fi
 
     - run:
-        name: Install Node.js dependencies
-        command: npm ci --ignore-scripts
-
-    - run:
-        name: Lint code with CSpell
-        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-    - run:
         name: Assemble the codebase
         command: .devtools/assemble
 
@@ -67,31 +59,6 @@ job-test: &job-test
     - run:
         name: Provision site
         command: .devtools/provision
-
-    - run:
-        name: Lint code with PHPCS
-        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with PHPStan
-        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Rector
-        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Twig CS Fixer
-        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint module code with NodeJS linters
-        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-        working_directory: build
 
     - run:
         name: Run JS tests
@@ -124,6 +91,50 @@ job-test: &job-test
           fi
 
 jobs:
+  lint:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node.js dependencies
+          command: npm ci --ignore-scripts
+
+      - run:
+          name: Lint code with CSpell
+          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+      - run:
+          name: Assemble the codebase
+          command: .devtools/assemble
+
+      - run:
+          name: Lint code with PHPCS
+          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with PHPStan
+          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Rector
+          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Twig CS Fixer
+          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint module code with NodeJS linters
+          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+          working_directory: build
+
   test-php-min-d10-stable:
     <<: *container_config
     docker:
@@ -176,7 +187,6 @@ jobs:
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
-      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
   deploy:
@@ -201,6 +211,10 @@ workflows:
   version: 2
   commit:
     jobs:
+      - lint:
+          filters:
+            tags:
+              only: /.*/
       - test-php-min-d10-stable:
           filters:
             tags:
@@ -227,6 +241,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
+            - lint
             - test-php-min-d10-stable
             - test-php-max-d10-stable
             - test-php-min-d11-stable

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
@@ -47,14 +47,6 @@ job-test: &job-test
           fi
 
     - run:
-        name: Install Node.js dependencies
-        command: npm ci --ignore-scripts
-
-    - run:
-        name: Lint code with CSpell
-        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-    - run:
         name: Assemble the codebase
         command: .devtools/assemble
 
@@ -67,31 +59,6 @@ job-test: &job-test
     - run:
         name: Provision site
         command: .devtools/provision
-
-    - run:
-        name: Lint code with PHPCS
-        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with PHPStan
-        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Rector
-        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Twig CS Fixer
-        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint module code with NodeJS linters
-        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-        working_directory: build
 
     - run:
         name: Run JS tests
@@ -124,6 +91,50 @@ job-test: &job-test
           fi
 
 jobs:
+  lint:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node.js dependencies
+          command: npm ci --ignore-scripts
+
+      - run:
+          name: Lint code with CSpell
+          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+      - run:
+          name: Assemble the codebase
+          command: .devtools/assemble
+
+      - run:
+          name: Lint code with PHPCS
+          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with PHPStan
+          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Rector
+          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Twig CS Fixer
+          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint module code with NodeJS linters
+          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+          working_directory: build
+
   test-php-min-d10-stable:
     <<: *container_config
     docker:
@@ -176,7 +187,6 @@ jobs:
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
-      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
   deploy:
@@ -201,6 +211,10 @@ workflows:
   version: 2
   commit:
     jobs:
+      - lint:
+          filters:
+            tags:
+              only: /.*/
       - test-php-min-d10-stable:
           filters:
             tags:
@@ -227,6 +241,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
+            - lint
             - test-php-min-d10-stable
             - test-php-max-d10-stable
             - test-php-min-d11-stable

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
@@ -47,14 +47,6 @@ job-test: &job-test
           fi
 
     - run:
-        name: Install Node.js dependencies
-        command: npm ci --ignore-scripts
-
-    - run:
-        name: Lint code with CSpell
-        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-    - run:
         name: Assemble the codebase
         command: .devtools/assemble
 
@@ -67,31 +59,6 @@ job-test: &job-test
     - run:
         name: Provision site
         command: .devtools/provision
-
-    - run:
-        name: Lint code with PHPCS
-        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with PHPStan
-        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Rector
-        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Twig CS Fixer
-        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint module code with NodeJS linters
-        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-        working_directory: build
 
     - run:
         name: Run JS tests
@@ -124,6 +91,50 @@ job-test: &job-test
           fi
 
 jobs:
+  lint:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node.js dependencies
+          command: npm ci --ignore-scripts
+
+      - run:
+          name: Lint code with CSpell
+          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+      - run:
+          name: Assemble the codebase
+          command: .devtools/assemble
+
+      - run:
+          name: Lint code with PHPCS
+          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with PHPStan
+          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Rector
+          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Twig CS Fixer
+          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint module code with NodeJS linters
+          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+          working_directory: build
+
   test-php-min-d10-stable:
     <<: *container_config
     docker:
@@ -176,7 +187,6 @@ jobs:
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
-      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
   deploy:
@@ -201,6 +211,10 @@ workflows:
   version: 2
   commit:
     jobs:
+      - lint:
+          filters:
+            tags:
+              only: /.*/
       - test-php-min-d10-stable:
           filters:
             tags:
@@ -227,6 +241,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
+            - lint
             - test-php-min-d10-stable
             - test-php-max-d10-stable
             - test-php-min-d11-stable

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
@@ -47,14 +47,6 @@ job-test: &job-test
           fi
 
     - run:
-        name: Install Node.js dependencies
-        command: npm ci --ignore-scripts
-
-    - run:
-        name: Lint code with CSpell
-        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-    - run:
         name: Assemble the codebase
         command: .devtools/assemble
 
@@ -67,31 +59,6 @@ job-test: &job-test
     - run:
         name: Provision site
         command: .devtools/provision
-
-    - run:
-        name: Lint code with PHPCS
-        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with PHPStan
-        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Rector
-        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint code with Twig CS Fixer
-        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-        working_directory: build
-
-    - run:
-        name: Lint module code with NodeJS linters
-        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-        working_directory: build
 
     - run:
         name: Run JS tests
@@ -124,6 +91,50 @@ job-test: &job-test
           fi
 
 jobs:
+  lint:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node.js dependencies
+          command: npm ci --ignore-scripts
+
+      - run:
+          name: Lint code with CSpell
+          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+      - run:
+          name: Assemble the codebase
+          command: .devtools/assemble
+
+      - run:
+          name: Lint code with PHPCS
+          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with PHPStan
+          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Rector
+          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint code with Twig CS Fixer
+          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+          working_directory: build
+
+      - run:
+          name: Lint module code with NodeJS linters
+          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+          working_directory: build
+
   test-php-min-d10-stable:
     <<: *container_config
     docker:
@@ -176,7 +187,6 @@ jobs:
       - *selenium_image
     environment:
       DRUPAL_VERSION: 11@beta
-      CI_PHPSTAN_IGNORE_FAILURE: 1 # PHPStan levels for canary releases are not the same as for this project.
     <<: *job-test
 
   deploy:
@@ -201,6 +211,10 @@ workflows:
   version: 2
   commit:
     jobs:
+      - lint:
+          filters:
+            tags:
+              only: /.*/
       - test-php-min-d10-stable:
           filters:
             tags:
@@ -227,6 +241,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
+            - lint
             - test-php-min-d10-stable
             - test-php-max-d10-stable
             - test-php-min-d11-stable


### PR DESCRIPTION
Closes #420

## Summary

CircleCI ran the full linter suite (CSpell, PHPCS, PHPStan, Rector, Twig CS Fixer, NodeJS linters) inside the shared `&job-test` anchor, so every matrix job repeated all six linters on every push - wasting pipeline minutes and burying lint failures in per-version test output. This adds a dedicated `lint` job that mirrors the GitHub Actions topology: linters run once on a single `cimg/php:8.5-browsers` container, and the `test-*` matrix jobs are slimmed down to assemble, provision, and run PHPUnit/Jest only.

## Changes

- **New `lint` job**: standalone job using `cimg/php:8.5-browsers` (no Selenium) that installs Node deps, runs CSpell, assembles the codebase, then runs PHPCS, PHPStan, Rector, Twig CS Fixer, and the NodeJS linters once.
- **Slimmed `&job-test` anchor**: removed the six linter steps (CSpell, PHPCS, PHPStan, Rector, Twig CS Fixer, NodeJS linters) and the now-orphaned root `npm ci` step whose only consumer (CSpell) moved to the `lint` job.
- **Canary job**: removed the orphaned `CI_PHPSTAN_IGNORE_FAILURE: 1` env var from `test-php-max-d11-canary` (PHPStan no longer runs in any `test-*` job).
- **Workflow wiring**: `lint` added to the `commit` workflow with `filters: tags: only: /.*/`, and added to `deploy`'s `requires:` list so a deploy cannot proceed if linting fails.
- **Snapshots**: regenerated all four `circleci*` init fixtures (`circleci`, `circleci_makefile`, `circleci_both_wrappers`, `circleci_no_command_wrapper`) to match the new structure.

## Before / After

```
BEFORE
┌─────────────────────────────────────────────────────────────────┐
│  test-php-min-d10  │  test-php-max-d10  │  test-php-min-d11  │ …│
│  ─────────────     │  ─────────────     │  ─────────────     │  │
│  npm ci            │  npm ci            │  npm ci            │  │
│  CSpell            │  CSpell            │  CSpell            │  │
│  assemble          │  assemble          │  assemble          │  │
│  provision         │  provision         │  provision         │  │
│  PHPCS             │  PHPCS             │  PHPCS             │  │
│  PHPStan           │  PHPStan           │  PHPStan           │  │
│  Rector            │  Rector            │  Rector            │  │
│  TwigCS            │  TwigCS            │  TwigCS            │  │
│  NodeJS lint       │  NodeJS lint       │  NodeJS lint       │  │
│  PHPUnit/Jest      │  PHPUnit/Jest      │  PHPUnit/Jest      │  │
└─────────────────────────────────────────────────────────────────┘
        │                    │                    │
        └────────────────────┴────────────────────┘
                             │
                           deploy

AFTER
┌──────────────────────────┐
│  lint                    │
│  ──────────────────────  │
│  npm ci                  │
│  CSpell                  │
│  assemble                │
│  PHPCS / PHPStan         │
│  Rector / TwigCS         │
│  NodeJS lint             │
└──────────────────────────┘
  │
  ├──────────┬──────────┬──────────┬──────────┬──────────┐
  │          │          │          │          │          │
  ▼          ▼          ▼          ▼          ▼          ▼
min-d10   max-d10   min-d11   max-d11   canary   …
assemble  assemble  assemble  assemble  assemble
provision provision provision provision provision
PHPUnit   PHPUnit   PHPUnit   PHPUnit   PHPUnit
Jest      Jest      Jest      Jest      Jest
  │          │          │          │          │          │
  └──────────┴──────────┴──────────┴──────────┴──────────┘
                             │
                           deploy
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refactors the CircleCI pipeline configuration to mirror the GitHub Actions CI topology by separating linting and testing concerns into distinct jobs, addressing issue `#420`.

## Changes

**Main Configuration (.circleci/config.yml):**
- Introduced a new dedicated `lint` job that runs on `cimg/php:8.5-browsers` and executes:
  - Node.js dependency installation
  - CSpell validation
  - Codebase assembly
  - PHPCS, PHPStan, Rector, Twig CS Fixer, and Node.js linters
- Removed linter steps from the shared `&job-test` anchor (Node.js install, CSpell, PHPCS, PHPStan, Rector, Twig CS Fixer, and Node.js linters), leaving it to only handle assembly, provisioning, and PHPUnit/Jest execution
- Removed the orphaned `CI_PHPSTAN_IGNORE_FAILURE: 1` environment variable from the PHP 11 canary test job
- Updated the `commit` workflow to include the new `lint` job with appropriate tag filters
- Updated the `deploy` workflow to require `lint` completion before proceeding, ensuring deploys are blocked by lint failures

**Fixture Updates:**
Regenerated all four CircleCI scaffolding fixtures to match the new job structure:
- `.scaffold/tests/fixtures/init/circleci/.circleci/config.yml`
- `.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml`
- `.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml`
- `.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml`

## Impact

- Eliminates redundant linter execution across the test matrix, improving CI runtime efficiency
- Aligns CircleCI pipeline topology with GitHub Actions
- Preserves CircleCI-specific ignore-failure patterns for optional tooling
- Maintains dev scaffolding fences so `init.php` can continue to strip optional tooling
- Pipeline now has a single lint job that runs once, rather than repeating linters in every test job

<!-- end of auto-generated comment: release notes by coderabbit.ai -->