### PR TITLE
Moved CSpell scan control into '.cspell.json'.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,4 +1,7 @@
 {
+    "files": [
+        "**"
+    ],
     "dictionaries": [
         "bash",
         "misc",

--- a/.scaffold/tests/fixtures/init/_baseline/.cspell.json
+++ b/.scaffold/tests/fixtures/init/_baseline/.cspell.json
@@ -1,4 +1,7 @@
 {
+    "files": [
+        "**"
+    ],
     "dictionaries": [
         "bash",
         "misc",

--- a/.scaffold/tests/fixtures/init/_baseline/package.json
+++ b/.scaffold/tests/fixtures/init/_baseline/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint-js": "eslint web/modules/custom web/themes/custom --ext .js --max-warnings=0 --no-error-on-unmatched-pattern",
     "lint-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\"",
-    "lint-spell": "cspell --no-progress --gitignore .",
+    "lint-spell": "cspell --no-progress",
     "lint": "npm run lint-js && npm run lint-css",
     "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
     "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",

--- a/.scaffold/tests/fixtures/init/no_cspell/package.json
+++ b/.scaffold/tests/fixtures/init/no_cspell/package.json
@@ -2,7 +2,7 @@
    "scripts": {
      "lint-js": "eslint web/modules/custom web/themes/custom --ext .js --max-warnings=0 --no-error-on-unmatched-pattern",
      "lint-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\"",
--    "lint-spell": "cspell --no-progress --gitignore .",
+-    "lint-spell": "cspell --no-progress",
      "lint": "npm run lint-js && npm run lint-css",
      "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
      "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",

--- a/.scaffold/tests/fixtures/init/no_js_lint/package.json
+++ b/.scaffold/tests/fixtures/init/no_js_lint/package.json
@@ -4,7 +4,7 @@
    "scripts": {
 -    "lint-js": "eslint web/modules/custom web/themes/custom --ext .js --max-warnings=0 --no-error-on-unmatched-pattern",
 -    "lint-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\"",
-     "lint-spell": "cspell --no-progress --gitignore .",
+     "lint-spell": "cspell --no-progress",
 -    "lint": "npm run lint-js && npm run lint-css",
 -    "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
 -    "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",

--- a/.scaffold/tests/fixtures/init/no_tools/package.json
+++ b/.scaffold/tests/fixtures/init/no_tools/package.json
@@ -4,7 +4,7 @@
    "scripts": {
 -    "lint-js": "eslint web/modules/custom web/themes/custom --ext .js --max-warnings=0 --no-error-on-unmatched-pattern",
 -    "lint-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\"",
--    "lint-spell": "cspell --no-progress --gitignore .",
+-    "lint-spell": "cspell --no-progress",
 -    "lint": "npm run lint-js && npm run lint-css",
 -    "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
 -    "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint-js": "eslint web/modules/custom web/themes/custom --ext .js --max-warnings=0 --no-error-on-unmatched-pattern",
     "lint-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\"",
-    "lint-spell": "cspell --no-progress --gitignore .",
+    "lint-spell": "cspell --no-progress",
     "lint": "npm run lint-js && npm run lint-css",
     "lint-fix-js": "eslint web/modules/custom web/themes/custom --ext .js --no-error-on-unmatched-pattern --fix",
     "lint-fix-css": "stylelint --allow-empty-input \"web/modules/custom/**/*.css\" \"web/themes/custom/**/*.css\" --fix",


### PR DESCRIPTION
## Summary

Moves CSpell scan control out of the `lint-spell` CLI invocation and into `.cspell.json`, making the config file the single source of truth for what CSpell scans. The `--gitignore` flag was redundant with the pre-existing `useGitignore: true` setting in `.cspell.json`, and the `.` path argument is replaced by a top-level `files: ["**"]` key in the config. Equivalence was verified empirically: both invocations report "Files checked: 36, Issues found: 0" on the repo root - identical scan set, no coverage change.

## Changes

**`.cspell.json`** - Added a top-level `files` key (`["**"]`). Combined with the pre-existing `useGitignore: true` and `ignorePaths` settings, the config now fully describes the scan set without relying on CLI arguments.

**`package.json`** - `lint-spell` changed from `cspell --no-progress --gitignore .` to `cspell --no-progress`. The `--gitignore` flag is removed (superseded by `useGitignore: true` in the config); the `.` scan path is removed (superseded by `files: ["**"]` in the config). `--no-progress` is kept as it controls output formatting and has no config-file equivalent.

**Snapshot fixtures** - Four `package.json` fixtures under `.scaffold/tests/fixtures/init/` (`_baseline`, `no_cspell`, `no_js_lint`, `no_tools`) updated to reflect the new `lint-spell` value; `_baseline/.cspell.json` gains the `files` key. The four call sites (Makefile, `.ahoy.yml`, GitHub Actions, CircleCI) all invoke `npm run lint-spell` and required no changes.

## Before / After

**Before** - scan path and git-ignore behaviour controlled by CLI flags:
```
# package.json
"lint-spell": "cspell --no-progress --gitignore ."

# .cspell.json (no files key - path came from CLI)
{
    "useGitignore": true,
    "ignorePaths": [ ... ],
    ...
}
```

**After** - `.cspell.json` is the single source of truth:
```
# package.json
"lint-spell": "cspell --no-progress"

# .cspell.json
{
    "files": ["**"],
    "useGitignore": true,
    "ignorePaths": [ ... ],
    ...
}
```
