### PR TITLE
[#425] Added 'AGENTS.md' hard rule to use command wrappers, not tool binaries directly.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -25,13 +25,6 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 
 ### Build and Environment Management
 
-**Using Make (default):**
-- `make build` - Complete build (stop → assemble → start → provision)
-- `make assemble` - Assemble codebase with dependencies
-- `make start` - Start PHP development server
-- `make stop` - Stop development server
-- `make provision` - Install/provision Drupal site
-- `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
 
 **Using Ahoy (alternative):**
 - `ahoy build` - Complete build process
@@ -42,27 +35,27 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 ### Code Quality
 
 **Linting:**
-- `make lint` / `ahoy lint` - Run all linting tools
-- `make lint-fix` / `ahoy lint-fix` - Auto-fix coding standards violations
+- `ahoy lint` - Run all linting tools
+- `ahoy lint-fix` - Auto-fix coding standards violations
 
 **Testing:**
-- `make test` / `ahoy test` - Run all tests
-- `make test-unit` / `ahoy test-unit` - Run unit tests only
-- `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
-- `make test-functional` / `ahoy test-functional` - Run functional tests only
-- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
-- `make test-js` / `ahoy test-js` - Run JavaScript unit tests (Jest)
-- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
-- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
+- `ahoy test` - Run all tests
+- `ahoy test-unit` - Run unit tests only
+- `ahoy test-kernel` - Run kernel tests only
+- `ahoy test-functional` - Run functional tests only
+- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+- `ahoy test-js` - Run JavaScript unit tests (Jest)
+- `ahoy selenium-start` - Start Selenium container
+- `ahoy selenium-stop` - Stop Selenium container
 
 ### Drupal Commands
 
-- `make drush <command>` - Run Drush commands
-- `make login` / `ahoy login` - Get one-time login link
+- `ahoy drush <command>` - Run Drush commands
+- `ahoy login` - Get one-time login link
 
 ### Diagnostics
 
-- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (aliases: `make describe`, `ahoy describe`)
+- `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
 
 ## Project Structure
 

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -10,17 +10,18 @@ This is a Force Crystal template for creating contributed modules or themes. The
 
 **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
 
-Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
 
-- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
-- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
-- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
-- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
-- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
-- **CSpell**: `make lint` - never `npx cspell`.
-- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
-- **Jest**: `make test-js` - never `npx jest`.
-- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+Run each tool through its `ahoy` wrapper, never the binary directly:
+
+- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+- **CSpell**: `ahoy lint` - never `npx cspell`.
+- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+- **Jest**: `ahoy test-js` - never `npx jest`.
+- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
 
 ### Build and Environment Management
 

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -8,6 +8,20 @@ This is a Force Crystal template for creating contributed modules or themes. The
 
 ## Development Commands
 
+**HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+
+Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+
+- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
+- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
+- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+- **CSpell**: `make lint` - never `npx cspell`.
+- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+- **Jest**: `make test-js` - never `npx jest`.
+- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+
 ### Build and Environment Management
 
 **Using Make (default):**

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -10,7 +10,7 @@ This is a Force Crystal template for creating contributed modules or themes. The
 
 **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
 
-Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
 
 - **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 - **PHPStan**: `make lint` - never `vendor/bin/phpstan`.

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/AGENTS.md
@@ -1,0 +1,18 @@
+@@ -10,6 +10,17 @@
+ 
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+ 
++Run each tool through its `make` wrapper, never the binary directly:
++
++- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
++- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
++- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
++- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
++- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
++- **CSpell**: `make lint` - never `npx cspell`.
++- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
++- **Jest**: `make test-js` - never `npx jest`.
++- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ Run each tool through its `ahoy` wrapper, never the binary directly:
+ 

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/AGENTS.md
@@ -1,9 +1,9 @@
-@@ -10,6 +10,17 @@
+@@ -10,7 +10,18 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
 +Run each tool through its `make` wrapper, never the binary directly:
-+
+ 
 +- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 +- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
 +- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
@@ -13,6 +13,57 @@
 +- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
 +- **Jest**: `make test-js` - never `npx jest`.
 +- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
- 
++
  Run each tool through its `ahoy` wrapper, never the binary directly:
  
+ - **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+@@ -25,6 +36,13 @@
+ 
+ ### Build and Environment Management
+ 
++**Using Make (default):**
++- `make build` - Complete build (stop → assemble → start → provision)
++- `make assemble` - Assemble codebase with dependencies
++- `make start` - Start PHP development server
++- `make stop` - Stop development server
++- `make provision` - Install/provision Drupal site
++- `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
+ 
+ **Using Ahoy (alternative):**
+ - `ahoy build` - Complete build process
+@@ -35,10 +53,20 @@
+ ### Code Quality
+ 
+ **Linting:**
++- `make lint` - Run all linting tools
++- `make lint-fix` - Auto-fix coding standards violations
+ - `ahoy lint` - Run all linting tools
+ - `ahoy lint-fix` - Auto-fix coding standards violations
+ 
+ **Testing:**
++- `make test` - Run all tests
++- `make test-unit` - Run unit tests only
++- `make test-kernel` - Run kernel tests only
++- `make test-functional` - Run functional tests only
++- `make test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
++- `make test-js` - Run JavaScript unit tests (Jest)
++- `make selenium-start` - Start Selenium container
++- `make selenium-stop` - Stop Selenium container
+ - `ahoy test` - Run all tests
+ - `ahoy test-unit` - Run unit tests only
+ - `ahoy test-kernel` - Run kernel tests only
+@@ -50,11 +78,14 @@
+ 
+ ### Drupal Commands
+ 
++- `make drush <command>` - Run Drush commands
++- `make login` - Get one-time login link
+ - `ahoy drush <command>` - Run Drush commands
+ - `ahoy login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
++- `make info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `make describe`)
+ - `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
+ 
+ ## Project Structure

--- a/.scaffold/tests/fixtures/init/circleci_makefile/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/AGENTS.md
@@ -1,0 +1,29 @@
+@@ -10,18 +10,18 @@
+ 
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+ 
++Run each tool through its `make` wrapper, never the binary directly:
+ 
+-Run each tool through its `ahoy` wrapper, never the binary directly:
++- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
++- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
++- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
++- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
++- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
++- **CSpell**: `make lint` - never `npx cspell`.
++- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
++- **Jest**: `make test-js` - never `npx jest`.
++- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+-- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `ahoy lint` - never `npx cspell`.
+-- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `ahoy test-js` - never `npx jest`.
+-- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ ### Build and Environment Management
+ 

--- a/.scaffold/tests/fixtures/init/circleci_makefile/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -10,18 +10,18 @@
+@@ -10,52 +10,54 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
@@ -26,4 +26,58 @@
 -- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
  ### Build and Environment Management
+ 
++**Using Make (default):**
++- `make build` - Complete build (stop → assemble → start → provision)
++- `make assemble` - Assemble codebase with dependencies
++- `make start` - Start PHP development server
++- `make stop` - Stop development server
++- `make provision` - Install/provision Drupal site
++- `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
+ 
+-**Using Ahoy (alternative):**
+-- `ahoy build` - Complete build process
+-- `ahoy assemble` - Assemble codebase
+-- `ahoy start` - Start development server
+-- `ahoy provision` - Provision Drupal site
+ 
+ ### Code Quality
+ 
+ **Linting:**
+-- `ahoy lint` - Run all linting tools
+-- `ahoy lint-fix` - Auto-fix coding standards violations
++- `make lint` - Run all linting tools
++- `make lint-fix` - Auto-fix coding standards violations
+ 
+ **Testing:**
+-- `ahoy test` - Run all tests
+-- `ahoy test-unit` - Run unit tests only
+-- `ahoy test-kernel` - Run kernel tests only
+-- `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+-- `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
++- `make test` - Run all tests
++- `make test-unit` - Run unit tests only
++- `make test-kernel` - Run kernel tests only
++- `make test-functional` - Run functional tests only
++- `make test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
++- `make test-js` - Run JavaScript unit tests (Jest)
++- `make selenium-start` - Start Selenium container
++- `make selenium-stop` - Stop Selenium container
+ 
+ ### Drupal Commands
+ 
+-- `ahoy drush <command>` - Run Drush commands
+-- `ahoy login` - Get one-time login link
++- `make drush <command>` - Run Drush commands
++- `make login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
+-- `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
++- `make info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `make describe`)
+ 
+ ## Project Structure
  

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/AGENTS.md
@@ -1,9 +1,9 @@
-@@ -11,17 +11,6 @@
+@@ -11,51 +11,22 @@
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
  
 -Run each tool through its `ahoy` wrapper, never the binary directly:
--
+ 
 -- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 -- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
 -- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
@@ -13,6 +13,40 @@
 -- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
 -- **Jest**: `ahoy test-js` - never `npx jest`.
 -- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
- 
+-
  ### Build and Environment Management
+ 
+ 
+-**Using Ahoy (alternative):**
+-- `ahoy build` - Complete build process
+-- `ahoy assemble` - Assemble codebase
+-- `ahoy start` - Start development server
+-- `ahoy provision` - Provision Drupal site
+ 
+ ### Code Quality
+ 
+ **Linting:**
+-- `ahoy lint` - Run all linting tools
+-- `ahoy lint-fix` - Auto-fix coding standards violations
+ 
+ **Testing:**
+-- `ahoy test` - Run all tests
+-- `ahoy test-unit` - Run unit tests only
+-- `ahoy test-kernel` - Run kernel tests only
+-- `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+-- `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
+ 
+ ### Drupal Commands
+ 
+-- `ahoy drush <command>` - Run Drush commands
+-- `ahoy login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
+-- `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
+ 
+ ## Project Structure
  

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/AGENTS.md
@@ -1,0 +1,18 @@
+@@ -11,17 +11,6 @@
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+ 
+ 
+-Run each tool through its `ahoy` wrapper, never the binary directly:
+-
+-- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `ahoy lint` - never `npx cspell`.
+-- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `ahoy test-js` - never `npx jest`.
+-- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ ### Build and Environment Management
+ 

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/AGENTS.md
@@ -1,0 +1,18 @@
+@@ -10,6 +10,17 @@
+ 
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+ 
++Run each tool through its `make` wrapper, never the binary directly:
++
++- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
++- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
++- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
++- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
++- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
++- **CSpell**: `make lint` - never `npx cspell`.
++- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
++- **Jest**: `make test-js` - never `npx jest`.
++- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ Run each tool through its `ahoy` wrapper, never the binary directly:
+ 

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/AGENTS.md
@@ -1,9 +1,9 @@
-@@ -10,6 +10,17 @@
+@@ -10,7 +10,18 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
 +Run each tool through its `make` wrapper, never the binary directly:
-+
+ 
 +- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 +- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
 +- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
@@ -13,6 +13,57 @@
 +- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
 +- **Jest**: `make test-js` - never `npx jest`.
 +- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
- 
++
  Run each tool through its `ahoy` wrapper, never the binary directly:
  
+ - **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+@@ -25,6 +36,13 @@
+ 
+ ### Build and Environment Management
+ 
++**Using Make (default):**
++- `make build` - Complete build (stop → assemble → start → provision)
++- `make assemble` - Assemble codebase with dependencies
++- `make start` - Start PHP development server
++- `make stop` - Stop development server
++- `make provision` - Install/provision Drupal site
++- `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
+ 
+ **Using Ahoy (alternative):**
+ - `ahoy build` - Complete build process
+@@ -35,10 +53,20 @@
+ ### Code Quality
+ 
+ **Linting:**
++- `make lint` - Run all linting tools
++- `make lint-fix` - Auto-fix coding standards violations
+ - `ahoy lint` - Run all linting tools
+ - `ahoy lint-fix` - Auto-fix coding standards violations
+ 
+ **Testing:**
++- `make test` - Run all tests
++- `make test-unit` - Run unit tests only
++- `make test-kernel` - Run kernel tests only
++- `make test-functional` - Run functional tests only
++- `make test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
++- `make test-js` - Run JavaScript unit tests (Jest)
++- `make selenium-start` - Start Selenium container
++- `make selenium-stop` - Stop Selenium container
+ - `ahoy test` - Run all tests
+ - `ahoy test-unit` - Run unit tests only
+ - `ahoy test-kernel` - Run kernel tests only
+@@ -50,11 +78,14 @@
+ 
+ ### Drupal Commands
+ 
++- `make drush <command>` - Run Drush commands
++- `make login` - Get one-time login link
+ - `ahoy drush <command>` - Run Drush commands
+ - `ahoy login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
++- `make info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `make describe`)
+ - `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
+ 
+ ## Project Structure

--- a/.scaffold/tests/fixtures/init/gha_makefile/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_makefile/AGENTS.md
@@ -1,0 +1,29 @@
+@@ -10,18 +10,18 @@
+ 
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+ 
++Run each tool through its `make` wrapper, never the binary directly:
+ 
+-Run each tool through its `ahoy` wrapper, never the binary directly:
++- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
++- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
++- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
++- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
++- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
++- **CSpell**: `make lint` - never `npx cspell`.
++- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
++- **Jest**: `make test-js` - never `npx jest`.
++- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+-- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `ahoy lint` - never `npx cspell`.
+-- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `ahoy test-js` - never `npx jest`.
+-- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ ### Build and Environment Management
+ 

--- a/.scaffold/tests/fixtures/init/gha_makefile/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_makefile/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -10,18 +10,18 @@
+@@ -10,52 +10,54 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
@@ -26,4 +26,58 @@
 -- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
  ### Build and Environment Management
+ 
++**Using Make (default):**
++- `make build` - Complete build (stop → assemble → start → provision)
++- `make assemble` - Assemble codebase with dependencies
++- `make start` - Start PHP development server
++- `make stop` - Stop development server
++- `make provision` - Install/provision Drupal site
++- `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
+ 
+-**Using Ahoy (alternative):**
+-- `ahoy build` - Complete build process
+-- `ahoy assemble` - Assemble codebase
+-- `ahoy start` - Start development server
+-- `ahoy provision` - Provision Drupal site
+ 
+ ### Code Quality
+ 
+ **Linting:**
+-- `ahoy lint` - Run all linting tools
+-- `ahoy lint-fix` - Auto-fix coding standards violations
++- `make lint` - Run all linting tools
++- `make lint-fix` - Auto-fix coding standards violations
+ 
+ **Testing:**
+-- `ahoy test` - Run all tests
+-- `ahoy test-unit` - Run unit tests only
+-- `ahoy test-kernel` - Run kernel tests only
+-- `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+-- `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
++- `make test` - Run all tests
++- `make test-unit` - Run unit tests only
++- `make test-kernel` - Run kernel tests only
++- `make test-functional` - Run functional tests only
++- `make test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
++- `make test-js` - Run JavaScript unit tests (Jest)
++- `make selenium-start` - Start Selenium container
++- `make selenium-stop` - Stop Selenium container
+ 
+ ### Drupal Commands
+ 
+-- `ahoy drush <command>` - Run Drush commands
+-- `ahoy login` - Get one-time login link
++- `make drush <command>` - Run Drush commands
++- `make login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
+-- `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
++- `make info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `make describe`)
+ 
+ ## Project Structure
  

--- a/.scaffold/tests/fixtures/init/gha_no_command_wrapper/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_no_command_wrapper/AGENTS.md
@@ -1,9 +1,9 @@
-@@ -11,17 +11,6 @@
+@@ -11,51 +11,22 @@
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
  
 -Run each tool through its `ahoy` wrapper, never the binary directly:
--
+ 
 -- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 -- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
 -- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
@@ -13,6 +13,40 @@
 -- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
 -- **Jest**: `ahoy test-js` - never `npx jest`.
 -- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
- 
+-
  ### Build and Environment Management
+ 
+ 
+-**Using Ahoy (alternative):**
+-- `ahoy build` - Complete build process
+-- `ahoy assemble` - Assemble codebase
+-- `ahoy start` - Start development server
+-- `ahoy provision` - Provision Drupal site
+ 
+ ### Code Quality
+ 
+ **Linting:**
+-- `ahoy lint` - Run all linting tools
+-- `ahoy lint-fix` - Auto-fix coding standards violations
+ 
+ **Testing:**
+-- `ahoy test` - Run all tests
+-- `ahoy test-unit` - Run unit tests only
+-- `ahoy test-kernel` - Run kernel tests only
+-- `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+-- `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
+ 
+ ### Drupal Commands
+ 
+-- `ahoy drush <command>` - Run Drush commands
+-- `ahoy login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
+-- `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
+ 
+ ## Project Structure
  

--- a/.scaffold/tests/fixtures/init/gha_no_command_wrapper/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_no_command_wrapper/AGENTS.md
@@ -1,0 +1,18 @@
+@@ -11,17 +11,6 @@
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+ 
+ 
+-Run each tool through its `ahoy` wrapper, never the binary directly:
+-
+-- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `ahoy lint` - never `npx cspell`.
+-- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `ahoy test-js` - never `npx jest`.
+-- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ ### Build and Environment Management
+ 

--- a/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
@@ -6,7 +6,7 @@
  - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
  - **Jest**: `ahoy test-js` - never `npx jest`.
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
-@@ -103,7 +102,6 @@
+@@ -96,7 +95,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
@@ -1,4 +1,12 @@
-@@ -88,7 +88,6 @@
+@@ -17,7 +17,6 @@
+ - **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
+ - **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+ - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `make lint` - never `npx cspell`.
+ - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+ - **Jest**: `make test-js` - never `npx jest`.
+ - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+@@ -102,7 +101,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
@@ -1,12 +1,12 @@
-@@ -17,7 +17,6 @@
- - **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
- - **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
- - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
--- **CSpell**: `make lint` - never `npx cspell`.
- - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
- - **Jest**: `make test-js` - never `npx jest`.
- - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
-@@ -102,7 +101,6 @@
+@@ -18,7 +18,6 @@
+ - **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+ - **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+ - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `ahoy lint` - never `npx cspell`.
+ - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+ - **Jest**: `ahoy test-js` - never `npx jest`.
+ - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
+@@ -103,7 +102,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
@@ -1,11 +1,11 @@
-@@ -50,10 +50,7 @@
- - `make test-unit` / `ahoy test-unit` - Run unit tests only
- - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
- - `make test-functional` / `ahoy test-functional` - Run functional tests only
--- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
- - `make test-js` / `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
--- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
+@@ -43,10 +43,7 @@
+ - `ahoy test-unit` - Run unit tests only
+ - `ahoy test-kernel` - Run kernel tests only
+ - `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+ - `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -35,10 +35,7 @@
+@@ -49,10 +49,7 @@
  - `make test-unit` / `ahoy test-unit` - Run unit tests only
  - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
  - `make test-functional` / `ahoy test-functional` - Run functional tests only

--- a/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -49,10 +49,7 @@
+@@ -50,10 +50,7 @@
  - `make test-unit` / `ahoy test-unit` - Run unit tests only
  - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
  - `make test-functional` / `ahoy test-functional` - Run functional tests only

--- a/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
@@ -1,4 +1,12 @@
-@@ -36,7 +36,6 @@
+@@ -19,7 +19,6 @@
+ - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `make lint` - never `npx cspell`.
+ - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `make test-js` - never `npx jest`.
+ - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ ### Build and Environment Management
+@@ -50,7 +49,6 @@
  - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
  - `make test-functional` / `ahoy test-functional` - Run functional tests only
  - `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)

--- a/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
@@ -1,12 +1,12 @@
-@@ -19,7 +19,6 @@
- - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
- - **CSpell**: `make lint` - never `npx cspell`.
- - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
--- **Jest**: `make test-js` - never `npx jest`.
- - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+@@ -20,7 +20,6 @@
+ - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `ahoy lint` - never `npx cspell`.
+ - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `ahoy test-js` - never `npx jest`.
+ - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
  ### Build and Environment Management
-@@ -50,7 +49,6 @@
+@@ -51,7 +50,6 @@
  - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
  - `make test-functional` / `ahoy test-functional` - Run functional tests only
  - `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)

--- a/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
@@ -6,11 +6,11 @@
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
  ### Build and Environment Management
-@@ -51,7 +50,6 @@
- - `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
- - `make test-functional` / `ahoy test-functional` - Run functional tests only
- - `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
--- `make test-js` / `ahoy test-js` - Run JavaScript unit tests (Jest)
- - `make selenium-start` / `ahoy selenium-start` - Start Selenium container
- - `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
+@@ -44,7 +43,6 @@
+ - `ahoy test-kernel` - Run kernel tests only
+ - `ahoy test-functional` - Run functional tests only
+ - `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+-- `ahoy test-js` - Run JavaScript unit tests (Jest)
+ - `ahoy selenium-start` - Start Selenium container
+ - `ahoy selenium-stop` - Stop Selenium container
  

--- a/.scaffold/tests/fixtures/init/no_js_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_js_lint/AGENTS.md
@@ -1,0 +1,8 @@
+@@ -16,7 +16,6 @@
+ - **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
+ - **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
+ - **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `make lint` - never `npx cspell`.
+ - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+ - **Jest**: `make test-js` - never `npx jest`.

--- a/.scaffold/tests/fixtures/init/no_js_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_js_lint/AGENTS.md
@@ -1,8 +1,8 @@
-@@ -16,7 +16,6 @@
- - **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
- - **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
- - **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
--- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
- - **CSpell**: `make lint` - never `npx cspell`.
- - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
- - **Jest**: `make test-js` - never `npx jest`.
+@@ -17,7 +17,6 @@
+ - **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+ - **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+ - **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `ahoy lint` - never `npx cspell`.
+ - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+ - **Jest**: `ahoy test-js` - never `npx jest`.

--- a/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
@@ -9,7 +9,7 @@
  - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
  - **CSpell**: `ahoy lint` - never `npx cspell`.
  - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
-@@ -104,10 +100,6 @@
+@@ -97,10 +93,6 @@
  ## Code Quality Tools
  
  - **CSpell**: Spell checking across the codebase (config at `.cspell.json`)

--- a/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
@@ -1,4 +1,15 @@
-@@ -89,10 +89,6 @@
+@@ -12,10 +12,6 @@
+ 
+ Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+ 
+-- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+ - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `make lint` - never `npx cspell`.
+ - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+@@ -103,10 +99,6 @@
  ## Code Quality Tools
  
  - **CSpell**: Spell checking across the codebase (config at `.cspell.json`)

--- a/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
@@ -1,6 +1,6 @@
 @@ -12,10 +12,6 @@
  
- Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+ Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
  
 -- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 -- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.

--- a/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
@@ -1,15 +1,15 @@
-@@ -12,10 +12,6 @@
+@@ -13,10 +13,6 @@
  
- Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
+ Run each tool through its `ahoy` wrapper, never the binary directly:
  
--- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
--- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
--- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
--- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
- - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
- - **CSpell**: `make lint` - never `npx cspell`.
- - **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
-@@ -103,10 +99,6 @@
+-- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+ - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `ahoy lint` - never `npx cspell`.
+ - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+@@ -104,10 +100,6 @@
  ## Code Quality Tools
  
  - **CSpell**: Spell checking across the codebase (config at `.cspell.json`)

--- a/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
@@ -6,21 +6,21 @@
  - **Jest**: `ahoy test-js` - never `npx jest`.
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
-@@ -47,13 +46,7 @@
+@@ -40,13 +39,7 @@
  
  **Testing:**
- - `make test` / `ahoy test` - Run all tests
--- `make test-unit` / `ahoy test-unit` - Run unit tests only
--- `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
--- `make test-functional` / `ahoy test-functional` - Run functional tests only
--- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
- - `make test-js` / `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
--- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
+ - `ahoy test` - Run all tests
+-- `ahoy test-unit` - Run unit tests only
+-- `ahoy test-kernel` - Run kernel tests only
+-- `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+ - `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
  
  ### Drupal Commands
  
-@@ -68,7 +61,6 @@
+@@ -61,7 +54,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)

--- a/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
@@ -1,4 +1,12 @@
-@@ -32,13 +32,7 @@
+@@ -18,7 +18,6 @@
+ - **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+ - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `make lint` - never `npx cspell`.
+-- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+ - **Jest**: `make test-js` - never `npx jest`.
+ - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+@@ -46,13 +45,7 @@
  
  **Testing:**
  - `make test` / `ahoy test` - Run all tests
@@ -12,7 +20,7 @@
  
  ### Drupal Commands
  
-@@ -53,7 +47,6 @@
+@@ -67,7 +60,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)

--- a/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
@@ -1,12 +1,12 @@
-@@ -18,7 +18,6 @@
- - **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
- - **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
- - **CSpell**: `make lint` - never `npx cspell`.
--- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
- - **Jest**: `make test-js` - never `npx jest`.
- - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+@@ -19,7 +19,6 @@
+ - **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+ - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+ - **CSpell**: `ahoy lint` - never `npx cspell`.
+-- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+ - **Jest**: `ahoy test-js` - never `npx jest`.
+ - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
-@@ -46,13 +45,7 @@
+@@ -47,13 +46,7 @@
  
  **Testing:**
  - `make test` / `ahoy test` - Run all tests
@@ -20,7 +20,7 @@
  
  ### Drupal Commands
  
-@@ -67,7 +60,6 @@
+@@ -68,7 +61,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -1,6 +1,6 @@
 @@ -12,14 +12,6 @@
  
- Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+ Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
  
 -- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
 -- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -1,4 +1,19 @@
-@@ -32,13 +32,6 @@
+@@ -12,14 +12,6 @@
+ 
+ Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+ 
+-- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `make lint` - never `npx cspell`.
+-- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `make test-js` - never `npx jest`.
+ - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+ 
+ ### Build and Environment Management
+@@ -46,13 +38,6 @@
  
  **Testing:**
  - `make test` / `ahoy test` - Run all tests
@@ -12,7 +27,7 @@
  
  ### Drupal Commands
  
-@@ -53,7 +46,6 @@
+@@ -67,7 +52,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)
@@ -20,7 +35,7 @@
  - `config/schema/` - Configuration schema definitions
  - `build/` - Assembled Drupal codebase (symlinked extension)
  - `.devtools/` - Build and deployment scripts used by CI
-@@ -88,11 +80,6 @@
+@@ -102,11 +86,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -1,19 +1,25 @@
-@@ -12,14 +12,6 @@
+@@ -10,17 +10,12 @@
  
- Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
+ **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
--- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
--- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
--- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
--- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
--- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
--- **CSpell**: `make lint` - never `npx cspell`.
--- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
--- **Jest**: `make test-js` - never `npx jest`.
- - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
++Run each tool through its `make` wrapper, never the binary directly:
+ 
++- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
++
+ Run each tool through its `ahoy` wrapper, never the binary directly:
+ 
+-- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+-- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+-- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+-- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+-- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+-- **CSpell**: `ahoy lint` - never `npx cspell`.
+-- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+-- **Jest**: `ahoy test-js` - never `npx jest`.
+ - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
  ### Build and Environment Management
-@@ -46,13 +38,6 @@
+@@ -47,13 +42,6 @@
  
  **Testing:**
  - `make test` / `ahoy test` - Run all tests
@@ -27,7 +33,7 @@
  
  ### Drupal Commands
  
-@@ -67,7 +52,6 @@
+@@ -68,7 +56,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)
@@ -35,7 +41,7 @@
  - `config/schema/` - Configuration schema definitions
  - `build/` - Assembled Drupal codebase (symlinked extension)
  - `.devtools/` - Build and deployment scripts used by CI
-@@ -102,11 +86,6 @@
+@@ -103,11 +90,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -10,17 +10,12 @@
+@@ -10,21 +10,23 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
@@ -19,21 +19,51 @@
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
  ### Build and Environment Management
-@@ -47,13 +42,6 @@
+ 
++**Using Make (default):**
++- `make build` - Complete build (stop → assemble → start → provision)
++- `make assemble` - Assemble codebase with dependencies
++- `make start` - Start PHP development server
++- `make stop` - Stop development server
++- `make provision` - Install/provision Drupal site
++- `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
+ 
+ **Using Ahoy (alternative):**
+ - `ahoy build` - Complete build process
+@@ -35,26 +37,25 @@
+ ### Code Quality
+ 
+ **Linting:**
++- `make lint` - Run all linting tools
++- `make lint-fix` - Auto-fix coding standards violations
+ - `ahoy lint` - Run all linting tools
+ - `ahoy lint-fix` - Auto-fix coding standards violations
  
  **Testing:**
- - `make test` / `ahoy test` - Run all tests
--- `make test-unit` / `ahoy test-unit` - Run unit tests only
--- `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
--- `make test-functional` / `ahoy test-functional` - Run functional tests only
--- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
--- `make test-js` / `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
--- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
++- `make test` - Run all tests
+ - `ahoy test` - Run all tests
+-- `ahoy test-unit` - Run unit tests only
+-- `ahoy test-kernel` - Run kernel tests only
+-- `ahoy test-functional` - Run functional tests only
+-- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+-- `ahoy test-js` - Run JavaScript unit tests (Jest)
+-- `ahoy selenium-start` - Start Selenium container
+-- `ahoy selenium-stop` - Stop Selenium container
  
  ### Drupal Commands
  
-@@ -68,7 +56,6 @@
++- `make drush <command>` - Run Drush commands
++- `make login` - Get one-time login link
+ - `ahoy drush <command>` - Run Drush commands
+ - `ahoy login` - Get one-time login link
+ 
+ ### Diagnostics
+ 
++- `make info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `make describe`)
+ - `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
+ 
+ ## Project Structure
+@@ -61,7 +62,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)
@@ -41,7 +71,7 @@
  - `config/schema/` - Configuration schema definitions
  - `build/` - Assembled Drupal codebase (symlinked extension)
  - `.devtools/` - Build and deployment scripts used by CI
-@@ -103,11 +90,6 @@
+@@ -96,11 +96,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -351,6 +351,31 @@ final class InitProcessTest extends UnitTestCase {
   }
 
   /**
+   * The 'AGENTS.md' wrapper blocks follow the command wrapper selection.
+   *
+   * @param array<string> $command_wrapper
+   */
+  #[DataProvider('dataProviderProcessRemovesWrapperDocs')]
+  public function testProcessRemovesWrapperDocs(array $command_wrapper, bool $expect_make, bool $expect_ahoy): void {
+    process('My Extension', 'my_extension', 'module', 'gha', $command_wrapper, [], 'n');
+
+    $agents = (string) file_get_contents(self::$sut . '/AGENTS.md');
+
+    $make_block = '`make lint` / `make lint-fix` - never `vendor/bin/phpcs`';
+    $ahoy_block = '`ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs`';
+
+    $this->assertSame($expect_make, str_contains($agents, $make_block), 'AGENTS.md make wrapper block presence mismatch.');
+    $this->assertSame($expect_ahoy, str_contains($agents, $ahoy_block), 'AGENTS.md ahoy wrapper block presence mismatch.');
+  }
+
+  public static function dataProviderProcessRemovesWrapperDocs(): \Iterator {
+    yield 'both wrappers' => [['ahoy', 'makefile'], TRUE, TRUE];
+    yield 'ahoy only' => [['ahoy'], FALSE, TRUE];
+    yield 'makefile only' => [['makefile'], TRUE, FALSE];
+    yield 'no wrappers' => [[], FALSE, FALSE];
+  }
+
+  /**
    * @param array<string> $tools_remove
    * @param array<string> $expected_absent
    */

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -361,11 +361,15 @@ final class InitProcessTest extends UnitTestCase {
 
     $agents = (string) file_get_contents(self::$sut . '/AGENTS.md');
 
-    $make_block = '`make lint` / `make lint-fix` - never `vendor/bin/phpcs`';
-    $ahoy_block = '`ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs`';
+    $make_rule = '`make lint` / `make lint-fix` - never `vendor/bin/phpcs`';
+    $ahoy_rule = '`ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs`';
+    $make_command = '- `make build` - Complete build';
+    $ahoy_command = '- `ahoy build` - Complete build';
 
-    $this->assertSame($expect_make, str_contains($agents, $make_block), 'AGENTS.md make wrapper block presence mismatch.');
-    $this->assertSame($expect_ahoy, str_contains($agents, $ahoy_block), 'AGENTS.md ahoy wrapper block presence mismatch.');
+    $this->assertSame($expect_make, str_contains($agents, $make_rule), 'AGENTS.md make rule block presence mismatch.');
+    $this->assertSame($expect_ahoy, str_contains($agents, $ahoy_rule), 'AGENTS.md ahoy rule block presence mismatch.');
+    $this->assertSame($expect_make, str_contains($agents, $make_command), 'AGENTS.md make command list presence mismatch.');
+    $this->assertSame($expect_ahoy, str_contains($agents, $ahoy_command), 'AGENTS.md ahoy command list presence mismatch.');
   }
 
   public static function dataProviderProcessRemovesWrapperDocs(): \Iterator {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This is a Drupal extension scaffold template for creating contributed modules or
 
 **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
 
-Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
 
 <!-- #;< DEV_PHPCS -->
 - **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,36 @@ This is a Drupal extension scaffold template for creating contributed modules or
 
 ## Development Commands
 
+**HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
+
+Run each tool through its wrapper (the `make` targets below; `ahoy` mirrors each one) - never the binary directly:
+
+<!-- #;< DEV_PHPCS -->
+- **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+<!-- #;> DEV_PHPCS -->
+<!-- #;< DEV_PHPSTAN -->
+- **PHPStan**: `make lint` - never `vendor/bin/phpstan`.
+<!-- #;> DEV_PHPSTAN -->
+<!-- #;< DEV_RECTOR -->
+- **Rector**: `make lint` (dry-run) / `make lint-fix` - never `vendor/bin/rector`.
+<!-- #;> DEV_RECTOR -->
+<!-- #;< DEV_TWIGCS -->
+- **Twig CS Fixer**: `make lint` / `make lint-fix` - never `vendor/bin/twig-cs-fixer`.
+<!-- #;> DEV_TWIGCS -->
+<!-- #;< DEV_NODEJS_LINT -->
+- **ESLint / Stylelint**: `make lint` / `make lint-fix` - never `npx eslint` or `npx stylelint`.
+<!-- #;> DEV_NODEJS_LINT -->
+<!-- #;< DEV_CSPELL -->
+- **CSpell**: `make lint` - never `npx cspell`.
+<!-- #;> DEV_CSPELL -->
+<!-- #;< DEV_PHPUNIT -->
+- **PHPUnit**: `make test` / `make test-unit` / `make test-kernel` / `make test-functional` - never `vendor/bin/phpunit`.
+<!-- #;> DEV_PHPUNIT -->
+<!-- #;< DEV_JEST -->
+- **Jest**: `make test-js` - never `npx jest`.
+<!-- #;> DEV_JEST -->
+- **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+
 ### Build and Environment Management
 
 **Using Make (default):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 
 ### Build and Environment Management
 
+<!-- #;< DEV_MAKEFILE -->
 **Using Make (default):**
 - `make build` - Complete build (stop → assemble → start → provision)
 - `make assemble` - Assemble codebase with dependencies
@@ -79,45 +80,85 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `make stop` - Stop development server
 - `make provision` - Install/provision Drupal site
 - `make reset` - Clean build directory and logs (aliases: `make delete`, `make destroy`)
+<!-- #;> DEV_MAKEFILE -->
 
+<!-- #;< DEV_AHOY -->
 **Using Ahoy (alternative):**
 - `ahoy build` - Complete build process
 - `ahoy assemble` - Assemble codebase
 - `ahoy start` - Start development server
 - `ahoy provision` - Provision Drupal site
+<!-- #;> DEV_AHOY -->
 
 ### Code Quality
 
 **Linting:**
-- `make lint` / `ahoy lint` - Run all linting tools
-- `make lint-fix` / `ahoy lint-fix` - Auto-fix coding standards violations
+<!-- #;< DEV_MAKEFILE -->
+- `make lint` - Run all linting tools
+- `make lint-fix` - Auto-fix coding standards violations
+<!-- #;> DEV_MAKEFILE -->
+<!-- #;< DEV_AHOY -->
+- `ahoy lint` - Run all linting tools
+- `ahoy lint-fix` - Auto-fix coding standards violations
+<!-- #;> DEV_AHOY -->
 
 **Testing:**
-- `make test` / `ahoy test` - Run all tests
+<!-- #;< DEV_MAKEFILE -->
+- `make test` - Run all tests
 <!-- #;< DEV_PHPUNIT -->
-- `make test-unit` / `ahoy test-unit` - Run unit tests only
-- `make test-kernel` / `ahoy test-kernel` - Run kernel tests only
-- `make test-functional` / `ahoy test-functional` - Run functional tests only
+- `make test-unit` - Run unit tests only
+- `make test-kernel` - Run kernel tests only
+- `make test-functional` - Run functional tests only
 <!-- #;> DEV_PHPUNIT -->
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
-- `make test-functional-javascript` / `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+- `make test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 <!-- #;< DEV_JEST -->
-- `make test-js` / `ahoy test-js` - Run JavaScript unit tests (Jest)
+- `make test-js` - Run JavaScript unit tests (Jest)
 <!-- #;> DEV_JEST -->
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
-- `make selenium-start` / `ahoy selenium-start` - Start Selenium container
-- `make selenium-stop` / `ahoy selenium-stop` - Stop Selenium container
+- `make selenium-start` - Start Selenium container
+- `make selenium-stop` - Stop Selenium container
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
+<!-- #;> DEV_MAKEFILE -->
+<!-- #;< DEV_AHOY -->
+- `ahoy test` - Run all tests
+<!-- #;< DEV_PHPUNIT -->
+- `ahoy test-unit` - Run unit tests only
+- `ahoy test-kernel` - Run kernel tests only
+- `ahoy test-functional` - Run functional tests only
+<!-- #;> DEV_PHPUNIT -->
+<!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
+- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (requires Selenium)
+<!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
+<!-- #;< DEV_JEST -->
+- `ahoy test-js` - Run JavaScript unit tests (Jest)
+<!-- #;> DEV_JEST -->
+<!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
+- `ahoy selenium-start` - Start Selenium container
+- `ahoy selenium-stop` - Stop Selenium container
+<!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
+<!-- #;> DEV_AHOY -->
 
 ### Drupal Commands
 
+<!-- #;< DEV_MAKEFILE -->
 - `make drush <command>` - Run Drush commands
-- `make login` / `ahoy login` - Get one-time login link
+- `make login` - Get one-time login link
+<!-- #;> DEV_MAKEFILE -->
+<!-- #;< DEV_AHOY -->
+- `ahoy drush <command>` - Run Drush commands
+- `ahoy login` - Get one-time login link
+<!-- #;> DEV_AHOY -->
 
 ### Diagnostics
 
-- `make info` / `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (aliases: `make describe`, `ahoy describe`)
+<!-- #;< DEV_MAKEFILE -->
+- `make info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `make describe`)
+<!-- #;> DEV_MAKEFILE -->
+<!-- #;< DEV_AHOY -->
+- `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
+<!-- #;> DEV_AHOY -->
 
 ## Project Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ This is a Drupal extension scaffold template for creating contributed modules or
 
 **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
 
-Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
+<!-- #;< DEV_MAKEFILE -->
+Run each tool through its `make` wrapper, never the binary directly:
 
 <!-- #;< DEV_PHPCS -->
 - **PHPCS / PHPCBF**: `make lint` / `make lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
@@ -37,6 +38,37 @@ Each tool runs through its `make` / `ahoy` wrapper - never the binary directly:
 - **Jest**: `make test-js` - never `npx jest`.
 <!-- #;> DEV_JEST -->
 - **Drush**: `make drush <command>` - never `build/vendor/bin/drush` directly.
+<!-- #;> DEV_MAKEFILE -->
+
+<!-- #;< DEV_AHOY -->
+Run each tool through its `ahoy` wrapper, never the binary directly:
+
+<!-- #;< DEV_PHPCS -->
+- **PHPCS / PHPCBF**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/phpcs` or `vendor/bin/phpcbf`.
+<!-- #;> DEV_PHPCS -->
+<!-- #;< DEV_PHPSTAN -->
+- **PHPStan**: `ahoy lint` - never `vendor/bin/phpstan`.
+<!-- #;> DEV_PHPSTAN -->
+<!-- #;< DEV_RECTOR -->
+- **Rector**: `ahoy lint` (dry-run) / `ahoy lint-fix` - never `vendor/bin/rector`.
+<!-- #;> DEV_RECTOR -->
+<!-- #;< DEV_TWIGCS -->
+- **Twig CS Fixer**: `ahoy lint` / `ahoy lint-fix` - never `vendor/bin/twig-cs-fixer`.
+<!-- #;> DEV_TWIGCS -->
+<!-- #;< DEV_NODEJS_LINT -->
+- **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
+<!-- #;> DEV_NODEJS_LINT -->
+<!-- #;< DEV_CSPELL -->
+- **CSpell**: `ahoy lint` - never `npx cspell`.
+<!-- #;> DEV_CSPELL -->
+<!-- #;< DEV_PHPUNIT -->
+- **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
+<!-- #;> DEV_PHPUNIT -->
+<!-- #;< DEV_JEST -->
+- **Jest**: `ahoy test-js` - never `npx jest`.
+<!-- #;> DEV_JEST -->
+- **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
+<!-- #;> DEV_AHOY -->
 
 ### Build and Environment Management
 

--- a/init.php
+++ b/init.php
@@ -220,12 +220,15 @@ function process(string $extension_name, string $extension_machine_name, string 
     remove_dir('.circleci');
   }
 
-  // Remove unwanted command wrappers.
+  // Remove unwanted command wrappers and their wrapper-specific documentation
+  // blocks (marked with '#;< DEV_AHOY' / '#;< DEV_MAKEFILE').
   if (!in_array('ahoy', $command_wrapper, TRUE)) {
     @unlink('.ahoy.yml');
+    remove_tokens_with_content('DEV_AHOY');
   }
   if (!in_array('makefile', $command_wrapper, TRUE)) {
     @unlink('Makefile');
+    remove_tokens_with_content('DEV_MAKEFILE');
   }
 
   // Trim wrapper-specific permissions from Claude settings to match selection.


### PR DESCRIPTION
Closes #425

## Summary

Adds a HARD RULE to `AGENTS.md` stating that the `make` / `ahoy` command wrappers are the only supported entry points and the underlying tool binaries (PHPCS, PHPStan, PHPUnit, Drush, etc.) must never be invoked directly. The wrappers `chdir` into `build/` and run each tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. Because `AGENTS.md` is inherited by every project created from the template, the guidance now propagates to all consumers.

The entire `## Development Commands` section is rendered per command wrapper: every wrapper-specific line lives in a `make` block or an `ahoy` block, each gated by a new conditional-content marker. A consumer that keeps only one wrapper (or neither) gets an `AGENTS.md` that never references a wrapper it removed - in the HARD RULE's per-tool list and in the command reference alike.

## Changes

### `AGENTS.md`

- Added a HARD RULE paragraph at the top of `## Development Commands` explaining why raw binary invocations diverge from CI and what to do when no wrapped command covers a task.
- Added a per-tool wrapper reference as two lists - a `make` list and an `ahoy` list - mapping each tool (PHPCS/PHPCBF, PHPStan, Rector, Twig CS Fixer, ESLint/Stylelint, CSpell, PHPUnit, Jest, Drush) to its wrapper command and the binary not to call directly.
- Made the existing command reference (Build, Code Quality, Testing, Drupal Commands, Diagnostics) wrapper-conditional: the combined `make X` / `ahoy X` lines are split into a `make` block and an `ahoy` block.
- Marker scheme: each whole wrapper block is wrapped in a new `<!-- #;< DEV_MAKEFILE -->` or `<!-- #;< DEV_AHOY -->` marker (stripped when that wrapper is deselected); tool-specific lines stay wrapped in their existing `<!-- #;< DEV_<TOOL> -->` markers (stripped when the tool is removed). The markers nest, so a line disappears if either its wrapper or its tool is removed.

### `init.php`

- Extended the command-wrapper removal step to strip the wrapper-specific documentation blocks: `remove_tokens_with_content('DEV_AHOY')` when Ahoy is not selected and `remove_tokens_with_content('DEV_MAKEFILE')` when the Makefile is not selected. Markers for kept wrappers are cleaned up by the existing `remove_special_comments()` pass.

### Tests

- Added `InitProcessTest::testProcessRemovesWrapperDocs`, a data-provider test that runs `process()` for each of the four wrapper selections (both, Ahoy only, Makefile only, neither) and asserts that both the HARD RULE list and the command reference contain the `make` content, the `ahoy` content, both, or neither accordingly - verifying the conditional output independently of the snapshots.

### Snapshot fixtures

- Regenerated `.scaffold/tests/fixtures/init/`. The wrapper-selection datasets (`gha_makefile`, `gha_both_wrappers`, `gha_no_command_wrapper`, and their CircleCI counterparts) now carry an `AGENTS.md` diff reflecting which wrapper survives; the tool-removal datasets were updated for the new structure.

## Before / After

What each consumer's `AGENTS.md` `## Development Commands` contains after `init.php` runs:

```
BEFORE
------
- No wrapper-vs-binary rule.
- Command lists always show both `make X` / `ahoy X`,
  regardless of the wrapper the consumer selected.

AFTER
-----
**HARD RULE - use the wrappers, never the tool binaries directly.**

  selected wrapper   ->  what survives in AGENTS.md
  ----------------------------------------------------------------
  make + ahoy        ->  HARD RULE + make list + ahoy list,
                         and every command shown for both wrappers
  Makefile only      ->  HARD RULE + make content only
  Ahoy only          ->  HARD RULE + ahoy content only
  neither            ->  HARD RULE paragraph only

Each wrapper block:           Nested tool markers inside it:
<!-- #;< DEV_MAKEFILE -->        <!-- #;< DEV_PHPUNIT -->
  ...make commands...             - `make test-unit` ...
<!-- #;> DEV_MAKEFILE -->        <!-- #;> DEV_PHPUNIT -->
(line drops if either its wrapper or its tool is removed)
```
