### PR TITLE
[#384] Made PHPStan config compatible with Drupal.org CI.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
+++ b/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
@@ -24,8 +24,8 @@ parameters:
     -
       # Hook implementations do not provide docblocks for parameters, so there
       # is no way to provide this information. These are left unscoped (no
-      # 'paths') so they apply regardless of the directory PHPStan is run from:
-      # some environments analyse from within the module directory, where a
+      # 'paths') so they apply regardless of the working directory: some
+      # environments run PHPStan from within the module directory, where a
       # 'web/modules/custom/*' scope would never match.
       messages:
         - '#.* no value type specified in iterable type array#'

--- a/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
+++ b/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
@@ -23,10 +23,7 @@ parameters:
   ignoreErrors:
     -
       # Hook implementations do not provide docblocks for parameters, so there
-      # is no way to provide this information. These are left unscoped (no
-      # 'paths') so they apply regardless of the working directory: some
-      # environments run PHPStan from within the module directory, where a
-      # 'web/modules/custom/*' scope would never match.
+      # is no way to provide this information.
       messages:
         - '#.* no value type specified in iterable type array#'
         - '#.* has no return type specified#'

--- a/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
+++ b/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
@@ -23,13 +23,13 @@ parameters:
   ignoreErrors:
     -
       # Hook implementations do not provide docblocks for parameters, so there
-      # is no way to provide this information.
+      # is no way to provide this information. These are left unscoped (no
+      # 'paths') so they apply regardless of the directory PHPStan is run from:
+      # some environments analyse from within the module directory, where a
+      # 'web/modules/custom/*' scope would never match.
       messages:
         - '#.* no value type specified in iterable type array#'
         - '#.* has no return type specified#'
-      paths:
-        - web/modules/custom/*
-        - web/themes/custom/*
       reportUnmatched: false
 
   reportUnmatchedIgnoredErrors: false

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ and push the code to [Drupal.org](https://drupal.org).
   - CI providers: [GitHub Actions](.github/workflows/test.yml)
     and [CircleCI](.circleci/config.yml)
   - Code coverage with https://github.com/krakjoe/pcov pushed to [codecov.io](https://codecov.io).
+  - Compatible with Drupal.org GitLab CI ([DrupalCI](#drupalorg-ci-drupalci)).
 - Develop locally using PHP running on your host using
   identical [`.devtools`](.devtools) scripts as in CI:
   - Uses [drupal/recommended-project](https://www.drupal.org/docs/develop/using-composer/starting-a-site-using-drupal-composer-project-templates)
@@ -444,6 +445,28 @@ ssh-keygen -m PEM -t rsa -b 4096 -C "your_email+project_name@example.com"
 - `DEPLOY_PROCEED` - set to `1` once CI is working, and you are ready to
   deploy. Without this variable, the deployment job will run but will not
   push the code. This is useful for testing the deployment job.
+
+### Drupal.org CI (DrupalCI)
+
+Once your extension is mirrored to Drupal.org, its GitLab CI ("DrupalCI") runs
+automatically. The scaffold's configuration is compatible with DrupalCI out of
+the box - the PHPStan error suppressions resolve correctly even though DrupalCI
+runs the analysis from within the module directory.
+
+PHPUnit needs one override: disable code coverage on DrupalCI. DrupalCI symlinks
+your project back into the built site's `web/modules/custom/<name>/` directory,
+so PHPUnit's coverage scan follows that recursive symlink into
+`web/core/node_modules` and exhausts the available file descriptors. Coverage is
+already collected by GitHub Actions and CircleCI, so turning it off on DrupalCI
+is safe.
+
+Add the [standard DrupalCI includes](https://git.drupalcode.org/project/gitlab_templates)
+to a `.gitlab-ci.yml` in your project root and set the override:
+
+```yaml
+variables:
+  _PHPUNIT_EXTRA: '--no-coverage'
+```
 
 ## Updating your extension
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,13 +26,13 @@ parameters:
   ignoreErrors:
     -
       # Hook implementations do not provide docblocks for parameters, so there
-      # is no way to provide this information.
+      # is no way to provide this information. These are left unscoped (no
+      # 'paths') so they apply regardless of the directory PHPStan is run from:
+      # some environments analyse from within the module directory, where a
+      # 'web/modules/custom/*' scope would never match.
       messages:
         - '#.* no value type specified in iterable type array#'
         - '#.* has no return type specified#'
-      paths:
-        - web/modules/custom/*
-        - web/themes/custom/*
       reportUnmatched: false
 
   reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,10 +26,7 @@ parameters:
   ignoreErrors:
     -
       # Hook implementations do not provide docblocks for parameters, so there
-      # is no way to provide this information. These are left unscoped (no
-      # 'paths') so they apply regardless of the working directory: some
-      # environments run PHPStan from within the module directory, where a
-      # 'web/modules/custom/*' scope would never match.
+      # is no way to provide this information.
       messages:
         - '#.* no value type specified in iterable type array#'
         - '#.* has no return type specified#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,8 +27,8 @@ parameters:
     -
       # Hook implementations do not provide docblocks for parameters, so there
       # is no way to provide this information. These are left unscoped (no
-      # 'paths') so they apply regardless of the directory PHPStan is run from:
-      # some environments analyse from within the module directory, where a
+      # 'paths') so they apply regardless of the working directory: some
+      # environments run PHPStan from within the module directory, where a
       # 'web/modules/custom/*' scope would never match.
       messages:
         - '#.* no value type specified in iterable type array#'


### PR DESCRIPTION
Closes #384

## Summary

Extensions generated from this scaffold fail PHPStan on Drupal.org's GitLab CI ("DrupalCI") because DrupalCI analyzes from inside `web/modules/custom/<module>/`, a working directory where the scaffold's path-scoped `ignoreErrors` entry never matches. This makes `phpstan.neon` compatible with that working directory so DrupalCI's PHPStan step passes, and documents the one PHPUnit override consumers need when they wire up their own `.gitlab-ci.yml`. No `.gitlab-ci.yml` is shipped or generated by the scaffold - only the configuration is made compatible and the setup is documented.

## Changes

- `phpstan.neon`: removed the `paths: [web/modules/custom/*, web/themes/custom/*]` scope from the `ignoreErrors` entry so the suppressions apply regardless of the working directory PHPStan runs from; DrupalCI runs `phpstan analyze .` from inside `web/modules/custom/<module>/`, where that scope never matches, so the suppressions were silently skipped and the legitimate ignores surfaced as failures. The scaffold's own analysis is unaffected because its scan is already limited to module/theme files via the top-level `paths:`.
- `README.md`: added a Features bullet and a new `### Drupal.org CI (DrupalCI)` subsection documenting DrupalCI compatibility, plus the one manual override a consumer needs when they add their own `.gitlab-ci.yml`: `_PHPUNIT_EXTRA: '--no-coverage'`. DrupalCI symlinks the project back into the built site recursively, so PHPUnit's coverage scan follows that loop into `web/core/node_modules` and exhausts available file descriptors; coverage is already collected by GitHub Actions and CircleCI, so disabling it on DrupalCI is safe.
- `.scaffold/tests/fixtures/init/_baseline/phpstan.neon`: regenerated the snapshot fixture to match the updated `phpstan.neon`.
- No `.gitlab-ci.yml` is shipped or generated by this change - only the configuration compatibility and its documentation.

## Before / After

```
BEFORE (ignoreErrors scoped to paths)
┌────────────────────────────────────────────┐
│ DrupalCI cwd: web/modules/custom/<module>/ │
│ $ phpstan analyze .                        │
│                                            │
│ ignoreErrors:                              │
│   paths:                                   │
│     - web/modules/custom/*                 │
│     - web/themes/custom/*                  │
│                                            │
│ Glob never matches (cwd is already inside  │
│ that path) -> suppressions SKIPPED         │
│                                            │
│ Result: FAIL - legitimate ignores surface  │
│ as real errors                             │
└────────────────────────────────────────────┘

AFTER (ignoreErrors unscoped)
┌────────────────────────────────────────────┐
│ DrupalCI cwd: web/modules/custom/<module>/ │
│ $ phpstan analyze .                        │
│                                            │
│ ignoreErrors:                              │
│   (no paths key)                           │
│                                            │
│ No scope to match against -> applies       │
│ regardless of cwd -> suppressions MATCH    │
│                                            │
│ Result: PASS - ignores stay suppressed     │
└────────────────────────────────────────────┘
```
