### PR TITLE
[#229] Collected browser test output under the '.logs' directory.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -205,7 +205,7 @@ entrypoint:
     # build) still find it. No-op when unset or already absolute.
     if [ -n "${TMPDIR:-}" ]; then case "$TMPDIR" in /*) ;; *) TMPDIR="$PWD/$TMPDIR" ;; esac; mkdir -p "$TMPDIR"; export TMPDIR; fi
     extension="$(basename -s .info.yml -- ./*.info.yml)"
-    export BROWSERTEST_OUTPUT_DIRECTORY="${TMPDIR:-/tmp}"
+    export BROWSERTEST_OUTPUT_DIRECTORY="$PWD/.logs/browser_output"
     export SIMPLETEST_BASE_URL=http://${WEBSERVER_HOST:-localhost}:${WEBSERVER_PORT:-8000}
     export SIMPLETEST_DB=sqlite://localhost/drupal_test_${extension}.sqlite
     bash -e -c "$0" "$@"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,14 +75,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -697,6 +697,50 @@ function chmod_recursive(string $path, int $mode): void {
   @chmod($path, $mode);
 }
 
+/**
+ * Redirect Drupal's browser test output directory into the logs directory.
+ *
+ * Drupal writes functional test HTML dumps - and, for JavaScript tests,
+ * screenshots - to a location hardcoded to "<webroot>/sites/simpletest/
+ * browser_output", ignoring any configured output directory
+ * (https://www.drupal.org/node/2992069). Replacing that location with a
+ * symlink into the logs directory gathers the output alongside the other
+ * test artefacts instead of leaving it in the docroot.
+ *
+ * Any existing file, directory, or symlink at the browser output location is
+ * removed first. Does nothing when the web root is absent.
+ *
+ * @param string $webroot
+ *   Absolute path to the Drupal web root: the directory that contains "sites".
+ * @param string $logs_dir
+ *   Absolute path to the directory that gathers test artefacts.
+ */
+function link_browser_output(string $webroot, string $logs_dir): void {
+  if (!is_dir($webroot)) {
+    return;
+  }
+
+  $target = $logs_dir . '/browser_output';
+  if (!is_dir($target)) {
+    mkdir($target, 0755, TRUE);
+  }
+
+  $simpletest_dir = $webroot . '/sites/simpletest';
+  if (!is_dir($simpletest_dir)) {
+    mkdir($simpletest_dir, 0755, TRUE);
+  }
+
+  $link = $simpletest_dir . '/browser_output';
+  if (is_link($link) || is_file($link)) {
+    unlink($link);
+  }
+  elseif (is_dir($link)) {
+    remove_dir($link);
+  }
+
+  symlink($target, $link);
+}
+
 // Never run the real quit() function during tests. This also avoids bleeding
 // into global namespace when running multiple tests that share the same
 // test process.

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -705,7 +705,7 @@ function chmod_recursive(string $path, int $mode): void {
  * browser_output", ignoring any configured output directory
  * (https://www.drupal.org/node/2992069). Replacing that location with a
  * symlink into the logs directory gathers the output alongside the other
- * test artefacts instead of leaving it in the docroot.
+ * test artifacts instead of leaving it under the web root.
  *
  * Any existing file, directory, or symlink at the browser output location is
  * removed first. Does nothing when the web root is absent.
@@ -713,7 +713,7 @@ function chmod_recursive(string $path, int $mode): void {
  * @param string $webroot
  *   Absolute path to the Drupal web root: the directory that contains "sites".
  * @param string $logs_dir
- *   Absolute path to the directory that gathers test artefacts.
+ *   Absolute path to the directory that gathers test artifacts.
  */
 function link_browser_output(string $webroot, string $logs_dir): void {
   if (!is_dir($webroot)) {

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -86,6 +86,10 @@ TASK('Pre-warming caches.');
 @file_get_contents(sprintf('http://%s:%s', $webserver_host, $webserver_port));
 PASS('Caches pre-warmed.');
 
+TASK('Linking browser test output into %s.', '.logs/browser_output');
+link_browser_output(getcwd() . '/build/web', getcwd() . '/.logs');
+PASS('Browser test output linked.');
+
 // Run custom post-provision scripts from "scripts/provision-*.sh", if any.
 run_custom_scripts('scripts', 'provision-');
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
         run: php -d pcov.directory=.. vendor/bin/phpunit
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
         env:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
       - name: Upload test results as an artifact
@@ -219,7 +219,7 @@ jobs:
         if: always()
         with:
           name: Artifacts (${{ matrix.name }})
-          path: build/web/sites/simpletest/browser_output
+          path: .logs/browser_output
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,6 +220,7 @@ jobs:
         with:
           name: Artifacts (${{ matrix.name }})
           path: .logs/browser_output
+          include-hidden-files: true
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -173,7 +173,7 @@ entrypoint:
     # build) still find it. No-op when unset or already absolute.
     if [ -n "${TMPDIR:-}" ]; then case "$TMPDIR" in /*) ;; *) TMPDIR="$PWD/$TMPDIR" ;; esac; mkdir -p "$TMPDIR"; export TMPDIR; fi
     extension="$(basename -s .info.yml -- ./*.info.yml)"
-    export BROWSERTEST_OUTPUT_DIRECTORY="${TMPDIR:-/tmp}"
+    export BROWSERTEST_OUTPUT_DIRECTORY="$PWD/.logs/browser_output"
     export SIMPLETEST_BASE_URL=http://${WEBSERVER_HOST:-localhost}:${WEBSERVER_PORT:-8000}
     export SIMPLETEST_DB=sqlite://localhost/drupal_test_${extension}.sqlite
     bash -e -c "$0" "$@"

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -697,6 +697,50 @@ function chmod_recursive(string $path, int $mode): void {
   @chmod($path, $mode);
 }
 
+/**
+ * Redirect Drupal's browser test output directory into the logs directory.
+ *
+ * Drupal writes functional test HTML dumps - and, for JavaScript tests,
+ * screenshots - to a location hardcoded to "<webroot>/sites/simpletest/
+ * browser_output", ignoring any configured output directory
+ * (https://www.drupal.org/node/2992069). Replacing that location with a
+ * symlink into the logs directory gathers the output alongside the other
+ * test artefacts instead of leaving it in the docroot.
+ *
+ * Any existing file, directory, or symlink at the browser output location is
+ * removed first. Does nothing when the web root is absent.
+ *
+ * @param string $webroot
+ *   Absolute path to the Drupal web root: the directory that contains "sites".
+ * @param string $logs_dir
+ *   Absolute path to the directory that gathers test artefacts.
+ */
+function link_browser_output(string $webroot, string $logs_dir): void {
+  if (!is_dir($webroot)) {
+    return;
+  }
+
+  $target = $logs_dir . '/browser_output';
+  if (!is_dir($target)) {
+    mkdir($target, 0755, TRUE);
+  }
+
+  $simpletest_dir = $webroot . '/sites/simpletest';
+  if (!is_dir($simpletest_dir)) {
+    mkdir($simpletest_dir, 0755, TRUE);
+  }
+
+  $link = $simpletest_dir . '/browser_output';
+  if (is_link($link) || is_file($link)) {
+    unlink($link);
+  }
+  elseif (is_dir($link)) {
+    remove_dir($link);
+  }
+
+  symlink($target, $link);
+}
+
 // Never run the real quit() function during tests. This also avoids bleeding
 // into global namespace when running multiple tests that share the same
 // test process.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -705,7 +705,7 @@ function chmod_recursive(string $path, int $mode): void {
  * browser_output", ignoring any configured output directory
  * (https://www.drupal.org/node/2992069). Replacing that location with a
  * symlink into the logs directory gathers the output alongside the other
- * test artefacts instead of leaving it in the docroot.
+ * test artifacts instead of leaving it under the web root.
  *
  * Any existing file, directory, or symlink at the browser output location is
  * removed first. Does nothing when the web root is absent.
@@ -713,7 +713,7 @@ function chmod_recursive(string $path, int $mode): void {
  * @param string $webroot
  *   Absolute path to the Drupal web root: the directory that contains "sites".
  * @param string $logs_dir
- *   Absolute path to the directory that gathers test artefacts.
+ *   Absolute path to the directory that gathers test artifacts.
  */
 function link_browser_output(string $webroot, string $logs_dir): void {
   if (!is_dir($webroot)) {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -86,6 +86,10 @@ TASK('Pre-warming caches.');
 @file_get_contents(sprintf('http://%s:%s', $webserver_host, $webserver_port));
 PASS('Caches pre-warmed.');
 
+TASK('Linking browser test output into %s.', '.logs/browser_output');
+link_browser_output(getcwd() . '/build/web', getcwd() . '/.logs');
+PASS('Browser test output linked.');
+
 // Run custom post-provision scripts from "scripts/provision-*.sh", if any.
 run_custom_scripts('scripts', 'provision-');
 

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
         run: php -d pcov.directory=.. vendor/bin/phpunit
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
         env:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
       - name: Upload test results as an artifact
@@ -198,7 +198,7 @@ jobs:
         if: always()
         with:
           name: Artifacts (${{ matrix.name }})
-          path: build/web/sites/simpletest/browser_output
+          path: .logs/browser_output
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -199,6 +199,7 @@ jobs:
         with:
           name: Artifacts (${{ matrix.name }})
           path: .logs/browser_output
+          include-hidden-files: true
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
@@ -70,14 +70,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
@@ -70,14 +70,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -133,7 +133,7 @@ lint-fix:
 
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
@@ -149,12 +149,12 @@ test-kernel:
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript: selenium-start
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
 selenium-start:

--- a/.scaffold/tests/fixtures/init/circleci_d10_only/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_d10_only/.circleci/config.yml
@@ -70,14 +70,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_d11_only/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_d11_only/.circleci/config.yml
@@ -70,14 +70,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
@@ -70,14 +70,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -133,7 +133,7 @@ lint-fix:
 
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
@@ -149,12 +149,12 @@ test-kernel:
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript: selenium-start
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
 selenium-start:

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
@@ -70,14 +70,14 @@ job-test: &job-test
         command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
-          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
           SIMPLETEST_DB: sqlite://tmp/db.sqlite
 
     - store_test_results:
         path: .logs/test_results
 
     - store_artifacts:
-        path: build/web/sites/simpletest/browser_output
+        path: .logs/browser_output
 
     - store_artifacts:
         path: .logs/coverage

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -133,7 +133,7 @@ lint-fix:
 
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
@@ -149,12 +149,12 @@ test-kernel:
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript: selenium-start
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
 selenium-start:

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -133,7 +133,7 @@ lint-fix:
 
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
@@ -149,12 +149,12 @@ test-kernel:
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript: selenium-start
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
 selenium-start:

--- a/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
@@ -10,7 +10,7 @@
  
      name: ${{ matrix.name }}
  
-@@ -185,35 +180,3 @@
+@@ -185,36 +180,3 @@
          run: npm test
          continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
  
@@ -28,6 +28,7 @@
 -        with:
 -          name: Artifacts (${{ matrix.name }})
 -          path: .logs/browser_output
+-          include-hidden-files: true
 -
 -      - name: Upload coverage report as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
@@ -19,7 +19,7 @@
 -        run: php -d pcov.directory=.. vendor/bin/phpunit
 -        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 -        env:
--          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+-          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
 -          SIMPLETEST_DB: sqlite://tmp/db.sqlite
 -
 -      - name: Upload test results as an artifact
@@ -27,7 +27,7 @@
 -        if: always()
 -        with:
 -          name: Artifacts (${{ matrix.name }})
--          path: build/web/sites/simpletest/browser_output
+-          path: .logs/browser_output
 -
 -      - name: Upload coverage report as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
@@ -52,7 +52,7 @@
  
      name: ${{ matrix.name }}
  
-@@ -179,41 +150,4 @@
+@@ -179,42 +150,4 @@
        - name: Provision site
          run: .devtools/provision
  
@@ -76,6 +76,7 @@
 -        with:
 -          name: Artifacts (${{ matrix.name }})
 -          path: .logs/browser_output
+-          include-hidden-files: true
 -
 -      - name: Upload coverage report as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
@@ -67,7 +67,7 @@
 -        run: php -d pcov.directory=.. vendor/bin/phpunit
 -        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 -        env:
--          BROWSERTEST_OUTPUT_DIRECTORY: /tmp
+-          BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
 -          SIMPLETEST_DB: sqlite://tmp/db.sqlite
 -
 -      - name: Upload test results as an artifact
@@ -75,7 +75,7 @@
 -        if: always()
 -        with:
 -          name: Artifacts (${{ matrix.name }})
--          path: build/web/sites/simpletest/browser_output
+-          path: .logs/browser_output
 -
 -      - name: Upload coverage report as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.scaffold/tests/src/Unit/HelpersLinkBrowserOutputTest.php
+++ b/.scaffold/tests/src/Unit/HelpersLinkBrowserOutputTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\link_browser_output;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\link_browser_output')]
+#[Group('p0')]
+final class HelpersLinkBrowserOutputTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testMissingWebrootIsNoop(): void {
+    $webroot = self::$tmp . '/web_' . uniqid();
+    $logs = self::$tmp . '/logs_' . uniqid();
+
+    link_browser_output($webroot, $logs);
+
+    $this->assertDirectoryDoesNotExist($logs . '/browser_output');
+    $this->assertDirectoryDoesNotExist($webroot);
+  }
+
+  public function testCreatesSymlinkFromScratch(): void {
+    [$webroot, $logs] = $this->createWebroot();
+
+    link_browser_output($webroot, $logs);
+
+    $target = $logs . '/browser_output';
+    $link = $webroot . '/sites/simpletest/browser_output';
+
+    $this->assertDirectoryExists($target);
+    $this->assertTrue(is_link($link));
+    $this->assertSame($target, readlink($link));
+
+    // Output written through the link lands in the logs directory.
+    file_put_contents($link . '/page.html', 'dump');
+    $this->assertFileExists($target . '/page.html');
+  }
+
+  public function testReusesExistingTargetAndSimpletestDir(): void {
+    [$webroot, $logs] = $this->createWebroot();
+    mkdir($logs . '/browser_output', 0755, TRUE);
+    file_put_contents($logs . '/browser_output/existing.html', 'keep');
+    mkdir($webroot . '/sites/simpletest', 0755, TRUE);
+
+    link_browser_output($webroot, $logs);
+
+    $link = $webroot . '/sites/simpletest/browser_output';
+    $this->assertTrue(is_link($link));
+    // The pre-existing target directory and its contents are preserved.
+    $this->assertFileExists($logs . '/browser_output/existing.html');
+  }
+
+  public function testReplacesExistingDirectory(): void {
+    [$webroot, $logs] = $this->createWebroot();
+    $link = $webroot . '/sites/simpletest/browser_output';
+    mkdir($link, 0755, TRUE);
+    file_put_contents($link . '/stale.html', 'stale');
+
+    link_browser_output($webroot, $logs);
+
+    $this->assertTrue(is_link($link));
+    $this->assertSame($logs . '/browser_output', readlink($link));
+  }
+
+  public function testReplacesExistingSymlink(): void {
+    [$webroot, $logs] = $this->createWebroot();
+    mkdir($webroot . '/sites/simpletest', 0755, TRUE);
+    $link = $webroot . '/sites/simpletest/browser_output';
+    $other = self::$tmp . '/other_' . uniqid();
+    mkdir($other, 0755, TRUE);
+    symlink($other, $link);
+
+    link_browser_output($webroot, $logs);
+
+    $this->assertTrue(is_link($link));
+    $this->assertSame($logs . '/browser_output', readlink($link));
+  }
+
+  public function testReplacesExistingFile(): void {
+    [$webroot, $logs] = $this->createWebroot();
+    mkdir($webroot . '/sites/simpletest', 0755, TRUE);
+    $link = $webroot . '/sites/simpletest/browser_output';
+    file_put_contents($link, 'i am a file');
+
+    link_browser_output($webroot, $logs);
+
+    $this->assertTrue(is_link($link));
+    $this->assertSame($logs . '/browser_output', readlink($link));
+  }
+
+  /**
+   * Create a throwaway project layout with an assembled web root.
+   *
+   * @return array{0: string, 1: string}
+   *   Tuple of [webroot, logs_dir] absolute paths.
+   */
+  protected function createWebroot(): array {
+    $base = self::$tmp . '/proj_' . uniqid();
+    $webroot = $base . '/build/web';
+    mkdir($webroot, 0755, TRUE);
+
+    return [$webroot, $base . '/.logs'];
+  }
+
+}

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -136,6 +136,7 @@ final class ProvisionTest extends UnitTestCase {
     $this->assertStringContainsString('Clearing caches', $output);
     $this->assertStringContainsString('Suggested modules enabled', $output);
     $this->assertStringContainsString('Caches pre-warmed', $output);
+    $this->assertStringContainsString('Browser test output linked', $output);
     $this->assertStringContainsString('PROVISION COMPLETE', $output);
     $this->assertStringContainsString('http://' . $expected_host . ':' . $expected_port, $output);
 

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -42,7 +42,8 @@ final class ProvisionTest extends UnitTestCase {
 
     $extension_name = 'test_extension';
     $info_content = $extension_type === 'theme' ? "name: Test\ntype: theme\n" : "name: Test\ntype: module\n";
-    $cwd = '/test/project';
+    $cwd = self::$tmp . '/provision_' . uniqid();
+    mkdir($cwd . '/build/web', 0755, TRUE);
 
     $this->registerMock('getcwd', 'DrupalExtensionScaffold\\DevTools', fn(): string => $cwd);
 
@@ -139,6 +140,10 @@ final class ProvisionTest extends UnitTestCase {
     $this->assertStringContainsString('Browser test output linked', $output);
     $this->assertStringContainsString('PROVISION COMPLETE', $output);
     $this->assertStringContainsString('http://' . $expected_host . ':' . $expected_port, $output);
+
+    $browser_output_link = $cwd . '/build/web/sites/simpletest/browser_output';
+    $this->assertTrue(is_link($browser_output_link));
+    $this->assertSame($cwd . '/.logs/browser_output', readlink($browser_output_link));
 
     if ($has_ahoy) {
       $this->assertStringContainsString('Run `ahoy` to see available commands', $output);

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ lint-fix:
 test:
 	@#;< DEV_PHPUNIT
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
 	@#;> DEV_PHPUNIT
 	@#;< DEV_JEST
 	$(call title,Running Jest)
@@ -190,14 +190,14 @@ test-kernel:
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
 #;> DEV_PHPUNIT
 
 #;< DEV_FUNCTIONAL_JAVASCRIPT
 test-functional-javascript: selenium-start
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 #;> DEV_FUNCTIONAL_JAVASCRIPT
 


### PR DESCRIPTION
Closes #229

## Summary

Functional and JavaScript browser tests write debug output (per-request HTML dumps and JS screenshots) to `web/sites/simpletest/browser_output`, a path Drupal core hardcodes in `BrowserHtmlDebugTrait` regardless of configuration (see [drupal.org/node/2992069](https://www.drupal.org/node/2992069)). That path sits outside the consolidated `.logs/` directory where JUnit results and coverage are already collected, so CI and local runs end up archiving test artifacts from two disconnected locations. This change symlinks the hardcoded browser output path into `.logs/browser_output` at provision time so every test artifact lands in one place.

## Changes

- Added `link_browser_output()` to `.devtools/helpers.php`: creates `.logs/browser_output`, ensures `sites/simpletest` exists, removes any pre-existing file, directory, or symlink at the browser output location, then symlinks it to the logs directory.
- Called the helper from `.devtools/provision` as a new `TASK()` step after cache pre-warming.
- Repointed `BROWSERTEST_OUTPUT_DIRECTORY` from `/tmp` (or `${TMPDIR:-/tmp}`) to `.logs/browser_output` in `.ahoy.yml` and the three `Makefile` test targets (`test`, `test-functional`, `test-functional-javascript`).
- Updated `.circleci/config.yml` and `.github/workflows/test.yml` to set `BROWSERTEST_OUTPUT_DIRECTORY` to `.logs/browser_output` and to archive artifacts from that path instead of `build/web/sites/simpletest/browser_output`; the GitHub Actions upload step now sets `include-hidden-files: true` so dotfiles under the symlinked directory are included.
- Added `HelpersLinkBrowserOutputTest`, covering symlink creation from scratch, reuse of an existing target directory, and replacement of a pre-existing directory, symlink, or file at the link location.
- Extended `ProvisionTest` to assert the new provision step runs and creates the expected symlink.
- Regenerated the `.scaffold/tests/fixtures/init/*` snapshots to reflect the updated `.devtools/provision`, `.devtools/helpers.php`, `.ahoy.yml`, `Makefile`, `.circleci/config.yml`, and `.github/workflows/test.yml`.

## Before / After

```
BEFORE                                      AFTER
───────────────────────────                 ───────────────────────────
build/web/sites/simpletest/                 build/web/sites/simpletest/
└── browser_output/                         └── browser_output@  (symlink)
     (HTML dumps + screenshots)                      │
                                                       ▼
.logs/                                      .logs/
├── test_results/    (JUnit)                ├── test_results/    (JUnit)
└── coverage/         (PCOV)                ├── coverage/         (PCOV)
                                             └── browser_output/   (HTML dumps + screenshots)

CI collects .logs/* as one artifact         CI collects .logs/* as one artifact -
bundle, but browser output is               browser output now included alongside
archived separately, from a path            JUnit results and coverage.
outside that bundle.
```
