### PR TITLE
[#456] Suppressed verbose '.devtools' command output unless DEBUG is set.

### DIFF
--- a/.devtools/README.md
+++ b/.devtools/README.md
@@ -9,6 +9,10 @@ This directory contains scripts used for development. These can be used locally 
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
+## Verbose output
+
+By default the scripts print only their own `[TASK]`/`[ OK ]` progress and suppress the output of the tools they run (Composer, npm, Drush). When a tool fails, its captured output is shown so the failure is diagnosable. Set `DEBUG=1` to stream the full output of every tool live, for example `DEBUG=1 make build` or `DEBUG=1 ahoy build`.
+
 ## Custom scripts
 
 `assemble` and `provision` both look for `scripts/<prefix>-*.sh` in the project root and run any matches at the end of the phase. `assemble-*.sh` for post-assemble, `provision-*.sh` for post-provision. Scripts run in lexicographic order, inherit the parent environment, and a non-zero exit aborts the parent. See the "Custom assemble and provision scripts" section in the root `README.md` for the full convention.

--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -262,10 +262,13 @@ PASS("Extension's code symlinked.");
 if (file_exists($build_dir . '/package-lock.json') && !file_exists('.skip_npm_build')) {
   TASK('Processing front-end dependencies.');
 
-  $cmd = file_exists('.nvmrc') ? 'nvm use && ' : '';
-  $cmd .= is_dir($build_dir . '/node_modules') ? '' : 'npm --prefix ' . $build_dir . ' ci && ';
-  $cmd .= 'npm --prefix ' . $build_dir . ' run build';
-  passthru_or_fail($cmd);
+  $nvm = file_exists('.nvmrc') ? 'nvm use && ' : '';
+  // Suppress the dependency install noise, but show the build output - the
+  // build is the project's own and its output is meaningful.
+  if (!is_dir($build_dir . '/node_modules')) {
+    passthru_or_fail($nvm . 'npm --prefix ' . $build_dir . ' ci');
+  }
+  passthru_verbose_or_fail($nvm . 'npm --prefix ' . $build_dir . ' run build');
 
   PASS('Front-end dependencies processed.');
 }

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -610,8 +610,11 @@ function drush(string $command, mixed $args = NULL, ?int &$exit_code = NULL): st
   }
 
   if (!$exit_code_provided && $exit_code !== 0) {
-    // Surface the captured output so the failure is diagnosable.
-    echo $output;
+    // Surface the captured output on a quiet run so the failure is diagnosable;
+    // in debug mode it already streamed live.
+    if (!is_debug()) {
+      echo $output;
+    }
 
     FAIL('Drush command failed: %s', $command);
   }

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -477,14 +477,53 @@ function command_must_exist(string $command): void {
 }
 
 /**
+ * Run a command and capture its combined stdout and stderr.
+ *
+ * The command is wrapped in a brace group so both streams are captured
+ * together and the exit status is preserved, even for compound commands.
+ *
+ * @param string $cmd
+ *   The command to run.
+ * @param int|null &$exit_code
+ *   Populated with the command's exit code.
+ *
+ * @return string
+ *   The captured combined output.
+ */
+function passthru_capture(string $cmd, ?int &$exit_code = NULL): string {
+  ob_start();
+  passthru('{ ' . $cmd . '; } 2>&1', $exit_code);
+
+  return ob_get_clean() ?: '';
+}
+
+/**
  * Run a command via passthru, failing if exit code is non-zero.
+ *
+ * Command output is suppressed during a normal run and surfaced only when the
+ * command fails; set DEBUG=1 to stream it live instead.
  */
 function passthru_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
-  passthru($cmd, $exit_code);
+  $exit_code = 0;
+
+  if (is_debug()) {
+    passthru($cmd, $exit_code);
+  }
+  else {
+    $output = passthru_capture($cmd, $exit_code);
+
+    // Surface the captured output only on failure so the error stays
+    // diagnosable while a successful run remains quiet.
+    if ($exit_code !== 0) {
+      echo $output;
+    }
+  }
+
   if ($exit_code !== 0) {
     if ($format !== '') {
       FAIL($format, ...$args);
     }
+
     quit($exit_code);
   }
 }
@@ -556,15 +595,28 @@ function drush(string $command, mixed $args = NULL, ?int &$exit_code = NULL): st
 
   $command = 'build/vendor/bin/drush -r ' . escapeshellarg(getcwd() . '/build/web') . ' -y ' . $command;
 
-  ob_start();
-  passthru($command, $exit_code);
-  $output = ob_get_clean();
+  if (is_debug()) {
+    // Stream drush's progress - which it writes to stderr - live, while still
+    // capturing stdout for the return value.
+    ob_start();
+    passthru($command, $exit_code);
+    $output = ob_get_clean() ?: '';
+  }
+  else {
+    // Fold stderr into the captured output so drush's progress notices stay
+    // hidden during a normal run; the return value is still available to
+    // callers that read it.
+    $output = passthru_capture($command, $exit_code);
+  }
 
   if (!$exit_code_provided && $exit_code !== 0) {
+    // Surface the captured output so the failure is diagnosable.
+    echo $output;
+
     FAIL('Drush command failed: %s', $command);
   }
 
-  return $output ?: '';
+  return $output;
 }
 
 /**

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -531,6 +531,26 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 }
 
 /**
+ * Run a command via passthru, always showing output, failing on non-zero exit.
+ *
+ * The counterpart to passthru_or_fail(): here the command's output is always
+ * streamed to the terminal rather than suppressed, for commands whose output
+ * is meaningful in its own right rather than dependency-tool noise.
+ */
+function passthru_verbose_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
+  $exit_code = 0;
+  passthru($cmd, $exit_code);
+
+  if ($exit_code !== 0) {
+    if ($format !== '') {
+      FAIL($format, ...$args);
+    }
+
+    quit($exit_code);
+  }
+}
+
+/**
  * Run custom shell scripts from a directory matching a filename prefix.
  *
  * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,
@@ -564,13 +584,9 @@ function run_custom_scripts(string $dir, string $prefix): void {
       continue;
     }
     TASK("Running custom script '%s'.", $file);
-    // Stream the hook's output live rather than suppressing it like the tool
-    // commands - these scripts are the project's own and their output is
-    // intentional.
-    passthru(escapeshellarg($file), $exit_code);
-    if ($exit_code !== 0) {
-      FAIL("Custom script '%s' failed.", $file);
-    }
+    // Show the hook's output - these scripts are the project's own and their
+    // output is intentional, unlike the suppressed dependency-tool commands.
+    passthru_verbose_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
     PASS("Completed custom script '%s'.", $file);
   }
 }

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -487,6 +487,8 @@ function command_must_exist(string $command): void {
  * @param int|null &$exit_code
  *   Populated with the command's exit code.
  *
+ * @param-out int $exit_code
+ *
  * @return string
  *   The captured combined output.
  */
@@ -562,7 +564,13 @@ function run_custom_scripts(string $dir, string $prefix): void {
       continue;
     }
     TASK("Running custom script '%s'.", $file);
-    passthru_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
+    // Stream the hook's output live rather than suppressing it like the tool
+    // commands - these scripts are the project's own and their output is
+    // intentional.
+    passthru(escapeshellarg($file), $exit_code);
+    if ($exit_code !== 0) {
+      FAIL("Custom script '%s' failed.", $file);
+    }
     PASS("Completed custom script '%s'.", $file);
   }
 }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/README.md
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/README.md
@@ -9,6 +9,10 @@ This directory contains scripts used for development. These can be used locally 
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
+## Verbose output
+
+By default the scripts print only their own `[TASK]`/`[ OK ]` progress and suppress the output of the tools they run (Composer, npm, Drush). When a tool fails, its captured output is shown so the failure is diagnosable. Set `DEBUG=1` to stream the full output of every tool live, for example `DEBUG=1 make build` or `DEBUG=1 ahoy build`.
+
 ## Custom scripts
 
 `assemble` and `provision` both look for `scripts/<prefix>-*.sh` in the project root and run any matches at the end of the phase. `assemble-*.sh` for post-assemble, `provision-*.sh` for post-provision. Scripts run in lexicographic order, inherit the parent environment, and a non-zero exit aborts the parent. See the "Custom assemble and provision scripts" section in the root `README.md` for the full convention.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -262,10 +262,13 @@ PASS("Extension's code symlinked.");
 if (file_exists($build_dir . '/package-lock.json') && !file_exists('.skip_npm_build')) {
   TASK('Processing front-end dependencies.');
 
-  $cmd = file_exists('.nvmrc') ? 'nvm use && ' : '';
-  $cmd .= is_dir($build_dir . '/node_modules') ? '' : 'npm --prefix ' . $build_dir . ' ci && ';
-  $cmd .= 'npm --prefix ' . $build_dir . ' run build';
-  passthru_or_fail($cmd);
+  $nvm = file_exists('.nvmrc') ? 'nvm use && ' : '';
+  // Suppress the dependency install noise, but show the build output - the
+  // build is the project's own and its output is meaningful.
+  if (!is_dir($build_dir . '/node_modules')) {
+    passthru_or_fail($nvm . 'npm --prefix ' . $build_dir . ' ci');
+  }
+  passthru_verbose_or_fail($nvm . 'npm --prefix ' . $build_dir . ' run build');
 
   PASS('Front-end dependencies processed.');
 }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -610,8 +610,11 @@ function drush(string $command, mixed $args = NULL, ?int &$exit_code = NULL): st
   }
 
   if (!$exit_code_provided && $exit_code !== 0) {
-    // Surface the captured output so the failure is diagnosable.
-    echo $output;
+    // Surface the captured output on a quiet run so the failure is diagnosable;
+    // in debug mode it already streamed live.
+    if (!is_debug()) {
+      echo $output;
+    }
 
     FAIL('Drush command failed: %s', $command);
   }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -477,14 +477,53 @@ function command_must_exist(string $command): void {
 }
 
 /**
+ * Run a command and capture its combined stdout and stderr.
+ *
+ * The command is wrapped in a brace group so both streams are captured
+ * together and the exit status is preserved, even for compound commands.
+ *
+ * @param string $cmd
+ *   The command to run.
+ * @param int|null &$exit_code
+ *   Populated with the command's exit code.
+ *
+ * @return string
+ *   The captured combined output.
+ */
+function passthru_capture(string $cmd, ?int &$exit_code = NULL): string {
+  ob_start();
+  passthru('{ ' . $cmd . '; } 2>&1', $exit_code);
+
+  return ob_get_clean() ?: '';
+}
+
+/**
  * Run a command via passthru, failing if exit code is non-zero.
+ *
+ * Command output is suppressed during a normal run and surfaced only when the
+ * command fails; set DEBUG=1 to stream it live instead.
  */
 function passthru_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
-  passthru($cmd, $exit_code);
+  $exit_code = 0;
+
+  if (is_debug()) {
+    passthru($cmd, $exit_code);
+  }
+  else {
+    $output = passthru_capture($cmd, $exit_code);
+
+    // Surface the captured output only on failure so the error stays
+    // diagnosable while a successful run remains quiet.
+    if ($exit_code !== 0) {
+      echo $output;
+    }
+  }
+
   if ($exit_code !== 0) {
     if ($format !== '') {
       FAIL($format, ...$args);
     }
+
     quit($exit_code);
   }
 }
@@ -556,15 +595,28 @@ function drush(string $command, mixed $args = NULL, ?int &$exit_code = NULL): st
 
   $command = 'build/vendor/bin/drush -r ' . escapeshellarg(getcwd() . '/build/web') . ' -y ' . $command;
 
-  ob_start();
-  passthru($command, $exit_code);
-  $output = ob_get_clean();
+  if (is_debug()) {
+    // Stream drush's progress - which it writes to stderr - live, while still
+    // capturing stdout for the return value.
+    ob_start();
+    passthru($command, $exit_code);
+    $output = ob_get_clean() ?: '';
+  }
+  else {
+    // Fold stderr into the captured output so drush's progress notices stay
+    // hidden during a normal run; the return value is still available to
+    // callers that read it.
+    $output = passthru_capture($command, $exit_code);
+  }
 
   if (!$exit_code_provided && $exit_code !== 0) {
+    // Surface the captured output so the failure is diagnosable.
+    echo $output;
+
     FAIL('Drush command failed: %s', $command);
   }
 
-  return $output ?: '';
+  return $output;
 }
 
 /**

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -531,6 +531,26 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 }
 
 /**
+ * Run a command via passthru, always showing output, failing on non-zero exit.
+ *
+ * The counterpart to passthru_or_fail(): here the command's output is always
+ * streamed to the terminal rather than suppressed, for commands whose output
+ * is meaningful in its own right rather than dependency-tool noise.
+ */
+function passthru_verbose_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
+  $exit_code = 0;
+  passthru($cmd, $exit_code);
+
+  if ($exit_code !== 0) {
+    if ($format !== '') {
+      FAIL($format, ...$args);
+    }
+
+    quit($exit_code);
+  }
+}
+
+/**
  * Run custom shell scripts from a directory matching a filename prefix.
  *
  * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,
@@ -564,13 +584,9 @@ function run_custom_scripts(string $dir, string $prefix): void {
       continue;
     }
     TASK("Running custom script '%s'.", $file);
-    // Stream the hook's output live rather than suppressing it like the tool
-    // commands - these scripts are the project's own and their output is
-    // intentional.
-    passthru(escapeshellarg($file), $exit_code);
-    if ($exit_code !== 0) {
-      FAIL("Custom script '%s' failed.", $file);
-    }
+    // Show the hook's output - these scripts are the project's own and their
+    // output is intentional, unlike the suppressed dependency-tool commands.
+    passthru_verbose_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
     PASS("Completed custom script '%s'.", $file);
   }
 }

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -487,6 +487,8 @@ function command_must_exist(string $command): void {
  * @param int|null &$exit_code
  *   Populated with the command's exit code.
  *
+ * @param-out int $exit_code
+ *
  * @return string
  *   The captured combined output.
  */
@@ -562,7 +564,13 @@ function run_custom_scripts(string $dir, string $prefix): void {
       continue;
     }
     TASK("Running custom script '%s'.", $file);
-    passthru_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
+    // Stream the hook's output live rather than suppressing it like the tool
+    // commands - these scripts are the project's own and their output is
+    // intentional.
+    passthru(escapeshellarg($file), $exit_code);
+    if ($exit_code !== 0) {
+      FAIL("Custom script '%s' failed.", $file);
+    }
     PASS("Completed custom script '%s'.", $file);
   }
 }

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -84,6 +84,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `WEBSERVER_HOST` - Development server host (default: localhost)
 - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
+- `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
 
 ## Development Workflow
 

--- a/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
@@ -6,7 +6,7 @@
  - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
  - **Jest**: `ahoy test-js` - never `npx jest`.
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
-@@ -96,7 +95,6 @@
+@@ -97,7 +96,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
@@ -9,7 +9,7 @@
  - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
  - **CSpell**: `ahoy lint` - never `npx cspell`.
  - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
-@@ -97,10 +93,6 @@
+@@ -98,10 +94,6 @@
  ## Code Quality Tools
  
  - **CSpell**: Spell checking across the codebase (config at `.cspell.json`)

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -71,7 +71,7 @@
  - `config/schema/` - Configuration schema definitions
  - `build/` - Assembled Drupal codebase (symlinked extension)
  - `.devtools/` - Build and deployment scripts used by CI
-@@ -96,11 +96,6 @@
+@@ -97,11 +97,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/src/Traits/MockTrait.php
+++ b/.scaffold/tests/src/Traits/MockTrait.php
@@ -224,8 +224,19 @@ trait MockTrait {
 
       /** @var array{cmd: string, output: string, result_code: int, return: NULL|FALSE} $response */
 
+      // The quiet-mode command runners - passthru_or_fail() and drush() without
+      // DEBUG - wrap the command in a brace group ("{ <cmd>; } 2>&1") so a
+      // normal run captures stdout and stderr together. Strip that wrapper
+      // before matching so expectations assert the logical command regardless
+      // of whether the runner is capturing or streaming (DEBUG=1) it. The
+      // wrapper format itself is asserted in HelpersPassthruCaptureTest.
+      $matched = $command;
+      if (str_starts_with($matched, '{ ') && str_ends_with($matched, '; } 2>&1')) {
+        $matched = substr($matched, 2, -8);
+      }
+
       // Expectation error.
-      if ($response['cmd'] !== $command) {
+      if ($response['cmd'] !== $matched) {
         throw new \RuntimeException(sprintf('passthru() called with unexpected command. Expected "%s", got "%s".', $response['cmd'], $command));
       }
 

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -260,12 +260,13 @@ final class AssembleTest extends UnitTestCase {
       $passthru_responses[] = ['cmd' => sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest))];
     }
 
-    // 8. NPM install and build (if applicable).
+    // 8. NPM install (suppressed) and build (shown), if applicable.
     if ($config['has_package_lock'] && !$config['has_skip_npm_build']) {
-      $cmd = $config['has_nvmrc'] ? 'nvm use && ' : '';
-      $cmd .= $config['has_node_modules'] ? '' : 'npm --prefix build ci && ';
-      $cmd .= 'npm --prefix build run build';
-      $passthru_responses[] = ['cmd' => $cmd];
+      $nvm = $config['has_nvmrc'] ? 'nvm use && ' : '';
+      if (!$config['has_node_modules']) {
+        $passthru_responses[] = ['cmd' => $nvm . 'npm --prefix build ci'];
+      }
+      $passthru_responses[] = ['cmd' => $nvm . 'npm --prefix build run build'];
     }
 
     $this->mockPassthruMultiple($passthru_responses);

--- a/.scaffold/tests/src/Unit/HelpersDrushTest.php
+++ b/.scaffold/tests/src/Unit/HelpersDrushTest.php
@@ -88,4 +88,15 @@ final class HelpersDrushTest extends UnitTestCase {
     $this->assertSame(2, $exit_code);
   }
 
+  public function testDrushStreamsLiveInDebugMode(): void {
+    $this->envSet('DEBUG', '1');
+    $cwd = getcwd();
+    $expected_cmd = 'build/vendor/bin/drush -r ' . escapeshellarg($cwd . '/build/web') . ' -y status';
+    $this->mockPassthru(['cmd' => $expected_cmd, 'output' => 'Drupal version : 11', 'result_code' => 0]);
+    $exit_code = 0;
+    $result = drush('status', NULL, $exit_code);
+    $this->assertSame('Drupal version : 11', $result);
+    $this->assertSame(0, $exit_code);
+  }
+
 }

--- a/.scaffold/tests/src/Unit/HelpersPassthruCaptureTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruCaptureTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\passthru_capture;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\passthru_capture')]
+#[Group('p0')]
+final class HelpersPassthruCaptureTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  #[DataProvider('dataProviderWrapsCommand')]
+  public function testWrapsCommand(string $cmd, string $expected_wrapped): void {
+    $captured_cmd = NULL;
+    $this->mockRawPassthru($captured_cmd, 'output', 0);
+
+    passthru_capture($cmd);
+
+    $this->assertSame($expected_wrapped, $captured_cmd);
+  }
+
+  public static function dataProviderWrapsCommand(): \Iterator {
+    yield 'simple command' => [
+      'cmd' => 'composer install',
+      'expected_wrapped' => '{ composer install; } 2>&1',
+    ];
+    yield 'compound command' => [
+      'cmd' => 'nvm use && npm ci && npm run build',
+      'expected_wrapped' => '{ nvm use && npm ci && npm run build; } 2>&1',
+    ];
+  }
+
+  public function testReturnsCapturedOutputAndExitCode(): void {
+    $captured_cmd = NULL;
+    $this->mockRawPassthru($captured_cmd, 'combined stdout and stderr', 3);
+
+    $exit_code = 0;
+    $result = passthru_capture('some-command', $exit_code);
+
+    $this->assertSame('combined stdout and stderr', $result);
+    $this->assertSame(3, $exit_code);
+  }
+
+  public function testReturnsEmptyStringWhenNoOutput(): void {
+    $captured_cmd = NULL;
+    $this->mockRawPassthru($captured_cmd, '', 0);
+
+    $exit_code = 99;
+    $result = passthru_capture('quiet-command', $exit_code);
+
+    $this->assertSame('', $result);
+    $this->assertSame(0, $exit_code);
+  }
+
+  /**
+   * Register a low-level passthru mock that records the raw command it is
+   * called with, emits the given output and reports the given exit code.
+   *
+   * @param string|null &$captured_cmd
+   *   Populated with the exact command string passed to passthru().
+   * @param string $output
+   *   Output the mocked command emits.
+   * @param int $result_code
+   *   Exit code the mocked command reports.
+   */
+  protected function mockRawPassthru(?string &$captured_cmd, string $output, int $result_code): void {
+    $this->registerMock('passthru', 'DrupalExtensionScaffold\\DevTools', function ($cmd, &...$args) use (&$captured_cmd, $output, $result_code): null {
+      $captured_cmd = $cmd;
+      echo $output;
+      if (count($args) > 0) {
+        $args[0] = $result_code;
+      }
+
+      return NULL;
+    });
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
@@ -7,6 +7,7 @@ namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 use function DrupalExtensionScaffold\DevTools\passthru_or_fail;
 use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 #[CoversFunction('DrupalExtensionScaffold\DevTools\passthru_or_fail')]
@@ -70,6 +71,46 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
       $this->assertIsString($output);
       $this->assertStringContainsString('Failed to download from http://example.com.', $output);
     }
+  }
+
+  #[DataProvider('dataProviderOutputVisibility')]
+  public function testOutputVisibility(bool $debug, int $result_code, bool $expect_visible): void {
+    if ($debug) {
+      $this->envSet('DEBUG', '1');
+    }
+    else {
+      $this->envUnset('DEBUG');
+    }
+
+    $this->mockPassthru(['cmd' => 'run-tool', 'output' => 'TOOL_NOISE', 'result_code' => $result_code]);
+
+    if ($result_code !== 0) {
+      $this->mockQuit($result_code);
+    }
+
+    ob_start();
+    try {
+      passthru_or_fail('run-tool');
+    }
+    catch (QuitErrorException) {
+      // Expected when the command fails.
+    }
+    finally {
+      $output = (string) ob_get_clean();
+    }
+
+    if ($expect_visible) {
+      $this->assertStringContainsString('TOOL_NOISE', $output);
+    }
+    else {
+      $this->assertStringNotContainsString('TOOL_NOISE', $output);
+    }
+  }
+
+  public static function dataProviderOutputVisibility(): \Iterator {
+    yield 'debug streams output live' => ['debug' => TRUE, 'result_code' => 0, 'expect_visible' => TRUE];
+    yield 'quiet suppresses output on success' => ['debug' => FALSE, 'result_code' => 0, 'expect_visible' => FALSE];
+    yield 'quiet shows captured output on failure' => ['debug' => FALSE, 'result_code' => 1, 'expect_visible' => TRUE];
   }
 
 }

--- a/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
@@ -88,16 +88,19 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
       $this->mockQuit($result_code);
     }
 
+    $quit_thrown = FALSE;
     ob_start();
     try {
       passthru_or_fail('run-tool');
     }
     catch (QuitErrorException) {
-      // Expected when the command fails.
+      $quit_thrown = TRUE;
     }
     finally {
       $output = (string) ob_get_clean();
     }
+
+    $this->assertSame($result_code !== 0, $quit_thrown);
 
     if ($expect_visible) {
       $this->assertStringContainsString('TOOL_NOISE', $output);

--- a/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\passthru_verbose_or_fail;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversFunction('DrupalExtensionScaffold\DevTools\passthru_verbose_or_fail')]
+#[Group('p0')]
+final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testShowsOutputOnSuccess(): void {
+    $this->mockPassthru(['cmd' => 'echo hello', 'output' => 'BUILD_OUTPUT', 'result_code' => 0]);
+    ob_start();
+    passthru_verbose_or_fail('echo hello');
+    $output = (string) ob_get_clean();
+    $this->assertStringContainsString('BUILD_OUTPUT', $output);
+  }
+
+  public function testFailureNoMessage(): void {
+    $this->mockPassthru(['cmd' => 'false', 'result_code' => 42]);
+    $this->mockQuit(42);
+    $this->expectException(QuitErrorException::class);
+    $this->expectExceptionCode(42);
+    passthru_verbose_or_fail('false');
+  }
+
+  public function testFailureWithMessage(): void {
+    $this->mockPassthru(['cmd' => 'false', 'result_code' => 1]);
+    $this->mockQuit(1);
+    ob_start();
+    try {
+      passthru_verbose_or_fail('false', 'Command failed.');
+      $this->fail('Expected QuitErrorException to be thrown');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertEquals(1, $e->getCode());
+    }
+    finally {
+      $output = (string) ob_get_clean();
+      $this->assertStringContainsString('Command failed.', $output);
+    }
+  }
+
+  public function testFailureWithFormatArgs(): void {
+    $this->mockPassthru(['cmd' => 'curl http://example.com', 'result_code' => 1]);
+    $this->mockQuit(1);
+    ob_start();
+    try {
+      passthru_verbose_or_fail('curl http://example.com', 'Failed to download from %s.', 'http://example.com');
+      $this->fail('Expected QuitErrorException to be thrown');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertEquals(1, $e->getCode());
+    }
+    finally {
+      $output = (string) ob_get_clean();
+      $this->assertStringContainsString('Failed to download from http://example.com.', $output);
+    }
+  }
+
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `WEBSERVER_HOST` - Development server host (default: localhost)
 - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
+- `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
 
 ## Development Workflow
 


### PR DESCRIPTION
Closes #456

## Summary

The `.devtools` scripts previously streamed the full stdout/stderr of every external tool they ran, so a normal `ahoy build` printed around 540 lines - almost all of it dependency-manager noise from `composer install`, `composer create-project`/`require`/`validate`, `npm ci`, and drush `[notice]`/`[success]` lines. This PR suppresses that tool noise during normal runs and surfaces it only when a command fails, while `DEBUG=1` restores full live verbosity. The project's own output - the front-end build (`npm run build`) and the `scripts/*` lifecycle hooks - stays visible, since it is meaningful rather than noise. As a result, `ahoy build` drops to around 60 clean `[TASK]`/`[ OK ]` lines.

## Changes

- Added `passthru_capture()` to `.devtools/helpers.php`, which runs a command wrapped in a brace group (`{ <cmd>; } 2>&1`) so both stdout and stderr are captured together with the exit code preserved, including for compound commands.
- `passthru_or_fail()` (used for the dependency tools) now streams live under `DEBUG=1` and otherwise captures combined output, echoing it only when the command fails.
- Added `passthru_verbose_or_fail()` as an always-visible counterpart and routed the project's own commands through it: the `run_custom_scripts()` lifecycle hooks and the front-end build. `assemble` now splits the npm step so `npm ci` is suppressed while `npm run build` output stays visible.
- `drush()` now streams drush's stderr progress live under `DEBUG=1` while still capturing stdout for its return value; otherwise it captures combined output and surfaces it only when a quiet run fails (debug mode has already streamed it).
- Documented the new `DEBUG` environment variable in `AGENTS.md` (Environment Variables) and added a "Verbose output" section to `.devtools/README.md`.
- Added `HelpersPassthruCaptureTest` and `HelpersPassthruVerboseOrFailTest`; extended `HelpersPassthruOrFailTest` and `HelpersDrushTest` with data-provider cases covering debug vs. quiet output visibility on success and failure.
- Updated `MockTrait` to strip the quiet-mode `{ ...; } 2>&1` wrapper before matching mocked commands, so expectations assert the logical command regardless of debug mode.
- Regenerated the `.scaffold/tests/fixtures/init/**` snapshot fixtures to match the updated `.devtools/*` and `AGENTS.md` content.

## Screenshots

N/A - CLI tooling output change only, nothing visual.

## Before / After

```
BEFORE - ahoy build (~540 lines, full tool output streamed live)
+-----------------------------------------------------------+
| [TASK] Installing dependencies.                           |
| Loading composer repositories with package information    |
|   - Locking symfony/console (v7.4.14)                     |
|   - Installing drupal/core (11.4.4): Extracting archive   |
|   ... (~360 more lines of composer output)                |
| npm warn deprecated inflight@1.0.6: ...                   |
|   added 710 packages ... 11 vulnerabilities               |
|   ... (~20 more lines of npm ci noise)                    |
|  [notice] Performed install task: install_base_system     |
|  [success] Installation complete.                         |
|   ... (~24 more lines of drush notices)                   |
+-----------------------------------------------------------+

AFTER - ahoy build (~60 lines: quiet tools, visible project output)
+---------------------------------------------------+
| [TASK] Installing dependencies.                   |
| [ OK ] Dependencies installed.        <- composer |
| [TASK] Processing front-end dependencies.         |
| > echo Would run build                            |
| Would run build                       <- npm build|
| [ OK ] Front-end dependencies processed.          |
| [TASK] Running custom script 'scripts/assemble... |
| [example] post-assemble script ran.   <- hook     |
| [ OK ] Completed custom script ...                |
| [TASK] Installing Drupal ...                      |
| [ OK ] Drupal installed.              <- drush    |
+---------------------------------------------------+

AFTER - on failure, either mode (captured tool output surfaced)
+-------------------------------------------------+
| [TASK] Installing dependencies.                 |
| <captured composer/npm/drush output shown here> |
| [FAIL] ...                                       |
+-------------------------------------------------+

DEBUG=1 ahoy build  ->  restores the full live-streaming BEFORE behaviour for every command.
```
