### PR TITLE
[#432] Added an opt-in login-link QR code and a Cloudflare init opt-out.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -54,12 +54,12 @@ commands:
       # without `qrencode`). Every other Drush command streams through.
       case " $* " in
         *" uli "*)
-          url="$(build/vendor/bin/drush -l "$uri" $*)"
+          url="$(build/vendor/bin/drush -l "$uri" "$@")"
           printf '%s\n' "$url"
           ./.devtools/qrcode "$url"
           ;;
         *)
-          build/vendor/bin/drush -l "$uri" $*
+          build/vendor/bin/drush -l "$uri" "$@"
           ;;
       esac
 

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -47,25 +47,14 @@ commands:
 
   drush:
     usage: Run Drush command.
-    cmd: |
-      uri="$(./.devtools/info site-url)"
-      # A `uli` command yields a one-time login URL worth scanning from a
-      # phone, so capture its output, print it, then render a QR code (a no-op
-      # without `qrencode`). Every other Drush command streams through.
-      case " $* " in
-        *" uli "*)
-          url="$(build/vendor/bin/drush -l "$uri" "$@")"
-          printf '%s\n' "$url"
-          ./.devtools/qrcode "$url"
-          ;;
-        *)
-          build/vendor/bin/drush -l "$uri" "$@"
-          ;;
-      esac
+    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" $*
 
   login:
     usage: Login to a website.
-    cmd: ahoy drush uli
+    cmd: |
+      url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
+      printf '%s\n' "$url"
+      ./.devtools/qrcode "$url"
 
   lint:
     usage: Check coding standards for violations.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -47,7 +47,21 @@ commands:
 
   drush:
     usage: Run Drush command.
-    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" $*
+    cmd: |
+      uri="$(./.devtools/info site-url)"
+      # A `uli` command yields a one-time login URL worth scanning from a
+      # phone, so capture its output, print it, then render a QR code (a no-op
+      # without `qrencode`). Every other Drush command streams through.
+      case " $* " in
+        *" uli "*)
+          url="$(build/vendor/bin/drush -l "$uri" $*)"
+          printf '%s\n' "$url"
+          ./.devtools/qrcode "$url"
+          ;;
+        *)
+          build/vendor/bin/drush -l "$uri" $*
+          ;;
+      esac
 
   login:
     usage: Login to a website.

--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,8 @@
     "words": [
         "ahoy",
         "alexskrypnyk",
+        "ansiutf",
+        "ansiutf8",
         "autologout",
         "autoloading",
         "autoupdate",
@@ -70,6 +72,8 @@
         "prompty",
         "prophesize",
         "pushd",
+        "qrcode",
+        "qrencode",
         "rector",
         "renovatebot",
         "ruleset",

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -492,16 +492,23 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 /**
  * Render a URL as a scannable QR code in the terminal.
  *
- * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
- * A no-op when the URL is empty or the `qrencode` binary is not installed,
- * so callers may invoke it unconditionally and terminals without qrencode
- * (including CI) keep their output unchanged.
+ * Opt-in: draws nothing unless the QRCODE variable - read from the shell
+ * environment or '.env' - is set to a truthy value ('1', 'true', 'yes',
+ * 'on'). When enabled it uses `qrencode -t ANSIUTF8` to draw the code with
+ * Unicode block glyphs, and is still a no-op when the URL is empty or the
+ * `qrencode` binary is not installed, so callers may invoke it
+ * unconditionally.
  *
  * @param string $url
  *   The URL to encode. An empty string renders nothing.
  */
 function print_qrcode(string $url): void {
   if ($url === '') {
+    return;
+  }
+
+  [$enabled] = resolve_env_value('QRCODE', '');
+  if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
     return;
   }
 

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -490,6 +490,29 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 }
 
 /**
+ * Render a URL as a scannable QR code in the terminal.
+ *
+ * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
+ * A no-op when the URL is empty or the `qrencode` binary is not installed,
+ * so callers may invoke it unconditionally and terminals without qrencode
+ * (including CI) keep their output unchanged.
+ *
+ * @param string $url
+ *   The URL to encode. An empty string renders nothing.
+ */
+function print_qrcode(string $url): void {
+  if ($url === '') {
+    return;
+  }
+
+  if (!command_path('qrencode')) {
+    return;
+  }
+
+  passthru(sprintf('qrencode -t ANSIUTF8 %s', escapeshellarg($url)));
+}
+
+/**
  * Run custom shell scripts from a directory matching a filename prefix.
  *
  * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -102,7 +102,9 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Site URL:            ' . $site_url . PHP_EOL;
 echo 'One-time login link: ';
-echo drush(sprintf('uli -l %s --no-browser', $site_url));
+$login_link = trim(drush(sprintf('uli -l %s --no-browser', $site_url)));
+echo $login_link . PHP_EOL;
+print_qrcode($login_link);
 echo PHP_EOL;
 if (file_exists('.ahoy.yml')) {
   echo 'Run `ahoy` to see available commands.' . PHP_EOL;

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -102,9 +102,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Site URL:            ' . $site_url . PHP_EOL;
 echo 'One-time login link: ';
-$login_link = trim(drush(sprintf('uli -l %s --no-browser', $site_url)));
-echo $login_link . PHP_EOL;
-print_qrcode($login_link);
+echo drush(sprintf('uli -l %s --no-browser', $site_url));
 echo PHP_EOL;
 if (file_exists('.ahoy.yml')) {
   echo 'Run `ahoy` to see available commands.' . PHP_EOL;

--- a/.devtools/qrcode
+++ b/.devtools/qrcode
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @file
+ * Render a URL as a scannable QR code in the terminal.
+ *
+ * Reads the URL from the first CLI argument and prints a QR code using
+ * `qrencode`. A no-op when no URL is given or `qrencode` is not installed,
+ * so callers can pipe an optional URL through without guarding first.
+ */
+
+declare(strict_types=1);
+
+namespace DrupalExtensionScaffold\DevTools;
+
+require_once __DIR__ . '/helpers.php';
+
+print_qrcode($argv[1] ?? '');

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -54,12 +54,12 @@ commands:
       # without `qrencode`). Every other Drush command streams through.
       case " $* " in
         *" uli "*)
-          url="$(build/vendor/bin/drush -l "$uri" $*)"
+          url="$(build/vendor/bin/drush -l "$uri" "$@")"
           printf '%s\n' "$url"
           ./.devtools/qrcode "$url"
           ;;
         *)
-          build/vendor/bin/drush -l "$uri" $*
+          build/vendor/bin/drush -l "$uri" "$@"
           ;;
       esac
 

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -47,25 +47,14 @@ commands:
 
   drush:
     usage: Run Drush command.
-    cmd: |
-      uri="$(./.devtools/info site-url)"
-      # A `uli` command yields a one-time login URL worth scanning from a
-      # phone, so capture its output, print it, then render a QR code (a no-op
-      # without `qrencode`). Every other Drush command streams through.
-      case " $* " in
-        *" uli "*)
-          url="$(build/vendor/bin/drush -l "$uri" "$@")"
-          printf '%s\n' "$url"
-          ./.devtools/qrcode "$url"
-          ;;
-        *)
-          build/vendor/bin/drush -l "$uri" "$@"
-          ;;
-      esac
+    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" $*
 
   login:
     usage: Login to a website.
-    cmd: ahoy drush uli
+    cmd: |
+      url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
+      printf '%s\n' "$url"
+      ./.devtools/qrcode "$url"
 
   lint:
     usage: Check coding standards for violations.

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -47,7 +47,21 @@ commands:
 
   drush:
     usage: Run Drush command.
-    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" $*
+    cmd: |
+      uri="$(./.devtools/info site-url)"
+      # A `uli` command yields a one-time login URL worth scanning from a
+      # phone, so capture its output, print it, then render a QR code (a no-op
+      # without `qrencode`). Every other Drush command streams through.
+      case " $* " in
+        *" uli "*)
+          url="$(build/vendor/bin/drush -l "$uri" $*)"
+          printf '%s\n' "$url"
+          ./.devtools/qrcode "$url"
+          ;;
+        *)
+          build/vendor/bin/drush -l "$uri" $*
+          ;;
+      esac
 
   login:
     usage: Login to a website.

--- a/.scaffold/tests/fixtures/init/_baseline/.cspell.json
+++ b/.scaffold/tests/fixtures/init/_baseline/.cspell.json
@@ -11,6 +11,8 @@
     ],
     "words": [
         "ahoy",
+        "ansiutf",
+        "ansiutf8",
         "autoloading",
         "autologout",
         "autoupdate",
@@ -70,6 +72,8 @@
         "prompty",
         "prophesize",
         "pushd",
+        "qrcode",
+        "qrencode",
         "rector",
         "renovatebot",
         "ruleset",

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -492,16 +492,23 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 /**
  * Render a URL as a scannable QR code in the terminal.
  *
- * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
- * A no-op when the URL is empty or the `qrencode` binary is not installed,
- * so callers may invoke it unconditionally and terminals without qrencode
- * (including CI) keep their output unchanged.
+ * Opt-in: draws nothing unless the QRCODE variable - read from the shell
+ * environment or '.env' - is set to a truthy value ('1', 'true', 'yes',
+ * 'on'). When enabled it uses `qrencode -t ANSIUTF8` to draw the code with
+ * Unicode block glyphs, and is still a no-op when the URL is empty or the
+ * `qrencode` binary is not installed, so callers may invoke it
+ * unconditionally.
  *
  * @param string $url
  *   The URL to encode. An empty string renders nothing.
  */
 function print_qrcode(string $url): void {
   if ($url === '') {
+    return;
+  }
+
+  [$enabled] = resolve_env_value('QRCODE', '');
+  if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
     return;
   }
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -490,6 +490,29 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
 }
 
 /**
+ * Render a URL as a scannable QR code in the terminal.
+ *
+ * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
+ * A no-op when the URL is empty or the `qrencode` binary is not installed,
+ * so callers may invoke it unconditionally and terminals without qrencode
+ * (including CI) keep their output unchanged.
+ *
+ * @param string $url
+ *   The URL to encode. An empty string renders nothing.
+ */
+function print_qrcode(string $url): void {
+  if ($url === '') {
+    return;
+  }
+
+  if (!command_path('qrencode')) {
+    return;
+  }
+
+  passthru(sprintf('qrencode -t ANSIUTF8 %s', escapeshellarg($url)));
+}
+
+/**
  * Run custom shell scripts from a directory matching a filename prefix.
  *
  * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -102,7 +102,9 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Site URL:            ' . $site_url . PHP_EOL;
 echo 'One-time login link: ';
-echo drush(sprintf('uli -l %s --no-browser', $site_url));
+$login_link = trim(drush(sprintf('uli -l %s --no-browser', $site_url)));
+echo $login_link . PHP_EOL;
+print_qrcode($login_link);
 echo PHP_EOL;
 if (file_exists('.ahoy.yml')) {
   echo 'Run `ahoy` to see available commands.' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -102,9 +102,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Site URL:            ' . $site_url . PHP_EOL;
 echo 'One-time login link: ';
-$login_link = trim(drush(sprintf('uli -l %s --no-browser', $site_url)));
-echo $login_link . PHP_EOL;
-print_qrcode($login_link);
+echo drush(sprintf('uli -l %s --no-browser', $site_url));
 echo PHP_EOL;
 if (file_exists('.ahoy.yml')) {
   echo 'Run `ahoy` to see available commands.' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @file
+ * Render a URL as a scannable QR code in the terminal.
+ *
+ * Reads the URL from the first CLI argument and prints a QR code using
+ * `qrencode`. A no-op when no URL is given or `qrencode` is not installed,
+ * so callers can pipe an optional URL through without guarding first.
+ */
+
+declare(strict_types=1);
+
+namespace DrupalExtensionScaffold\DevTools;
+
+require_once __DIR__ . '/helpers.php';
+
+print_qrcode($argv[1] ?? '');

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -97,14 +97,8 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
-# A `uli` command yields a one-time login URL worth scanning from a phone, so
-# capture its output, print it, then render a QR code (a no-op without
-# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	@case " $(DRUSH_RUN_ARGS) " in \
-	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
-	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
-	esac
+	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
 
 login:
 	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -97,11 +97,17 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
+# A `uli` command yields a one-time login URL worth scanning from a phone, so
+# capture its output, print it, then render a QR code (a no-op without
+# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
+	@case " $(DRUSH_RUN_ARGS) " in \
+	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
+	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
+	esac
 
 login:
-	build/vendor/bin/drush -l $(DRUSH_URI) uli
+	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -97,14 +97,8 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
-# A `uli` command yields a one-time login URL worth scanning from a phone, so
-# capture its output, print it, then render a QR code (a no-op without
-# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	@case " $(DRUSH_RUN_ARGS) " in \
-	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
-	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
-	esac
+	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
 
 login:
 	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -97,11 +97,17 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
+# A `uli` command yields a one-time login URL worth scanning from a phone, so
+# capture its output, print it, then render a QR code (a no-op without
+# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
+	@case " $(DRUSH_RUN_ARGS) " in \
+	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
+	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
+	esac
 
 login:
-	build/vendor/bin/drush -l $(DRUSH_URI) uli
+	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -97,14 +97,8 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
-# A `uli` command yields a one-time login URL worth scanning from a phone, so
-# capture its output, print it, then render a QR code (a no-op without
-# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	@case " $(DRUSH_RUN_ARGS) " in \
-	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
-	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
-	esac
+	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
 
 login:
 	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -97,11 +97,17 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
+# A `uli` command yields a one-time login URL worth scanning from a phone, so
+# capture its output, print it, then render a QR code (a no-op without
+# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
+	@case " $(DRUSH_RUN_ARGS) " in \
+	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
+	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
+	esac
 
 login:
-	build/vendor/bin/drush -l $(DRUSH_URI) uli
+	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -97,14 +97,8 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
-# A `uli` command yields a one-time login URL worth scanning from a phone, so
-# capture its output, print it, then render a QR code (a no-op without
-# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	@case " $(DRUSH_RUN_ARGS) " in \
-	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
-	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
-	esac
+	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
 
 login:
 	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -97,11 +97,17 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
+# A `uli` command yields a one-time login URL worth scanning from a phone, so
+# capture its output, print it, then render a QR code (a no-op without
+# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
+	@case " $(DRUSH_RUN_ARGS) " in \
+	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
+	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
+	esac
 
 login:
-	build/vendor/bin/drush -l $(DRUSH_URI) uli
+	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/no_cspell/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_cspell/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -81,9 +81,6 @@
+@@ -70,9 +70,6 @@
        vendor/bin/twig-cs-fixer
        [ ! -d node_modules ] || (ahoy title "Running ESLint" && npm run lint)
        popd >/dev/null || exit 1

--- a/.scaffold/tests/fixtures/init/no_cspell/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_cspell/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -67,9 +67,6 @@
+@@ -81,9 +81,6 @@
        vendor/bin/twig-cs-fixer
        [ ! -d node_modules ] || (ahoy title "Running ESLint" && npm run lint)
        popd >/dev/null || exit 1

--- a/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -128,13 +128,6 @@
+@@ -117,13 +117,6 @@
        php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional "$@"
        popd >/dev/null || exit 1
  
@@ -12,7 +12,7 @@
  
    test-js:
      usage: Run JavaScript unit tests.
-@@ -143,25 +136,6 @@
+@@ -132,25 +125,6 @@
        [ ! -d node_modules ] || npm test
        popd >/dev/null || exit 1
  

--- a/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -114,13 +114,6 @@
+@@ -128,13 +128,6 @@
        php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional "$@"
        popd >/dev/null || exit 1
  
@@ -12,7 +12,7 @@
  
    test-js:
      usage: Run JavaScript unit tests.
-@@ -129,25 +122,6 @@
+@@ -143,25 +136,6 @@
        [ ! -d node_modules ] || npm test
        popd >/dev/null || exit 1
  

--- a/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -90,7 +90,6 @@
+@@ -104,7 +104,6 @@
        pushd "build" >/dev/null || exit 1
        ahoy title "Running PHPUnit"
        php -d pcov.directory=.. vendor/bin/phpunit "$@"
@@ -6,7 +6,7 @@
        popd >/dev/null || exit 1
  
    test-unit:
-@@ -122,12 +121,6 @@
+@@ -136,12 +135,6 @@
        php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
        popd >/dev/null || exit 1
  

--- a/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -104,7 +104,6 @@
+@@ -93,7 +93,6 @@
        pushd "build" >/dev/null || exit 1
        ahoy title "Running PHPUnit"
        php -d pcov.directory=.. vendor/bin/phpunit "$@"
@@ -6,7 +6,7 @@
        popd >/dev/null || exit 1
  
    test-unit:
-@@ -136,12 +135,6 @@
+@@ -125,12 +124,6 @@
        php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
        popd >/dev/null || exit 1
  

--- a/.scaffold/tests/fixtures/init/no_js_lint/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_js_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -79,7 +79,6 @@
+@@ -68,7 +68,6 @@
        vendor/bin/rector --clear-cache --dry-run
        ahoy title "Running Twig CS Fixer"
        vendor/bin/twig-cs-fixer
@@ -6,7 +6,7 @@
        popd >/dev/null || exit 1
        ahoy title "Running CSpell"
        [ -d node_modules ] || npm install --no-audit --no-fund
-@@ -95,7 +94,6 @@
+@@ -84,7 +83,6 @@
        vendor/bin/phpcbf
        ahoy title "Running Twig CS Fixer"
        vendor/bin/twig-cs-fixer --no-cache --fix

--- a/.scaffold/tests/fixtures/init/no_js_lint/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_js_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -65,7 +65,6 @@
+@@ -79,7 +79,6 @@
        vendor/bin/rector --clear-cache --dry-run
        ahoy title "Running Twig CS Fixer"
        vendor/bin/twig-cs-fixer
@@ -6,7 +6,7 @@
        popd >/dev/null || exit 1
        ahoy title "Running CSpell"
        [ -d node_modules ] || npm install --no-audit --no-fund
-@@ -81,7 +80,6 @@
+@@ -95,7 +94,6 @@
        vendor/bin/phpcbf
        ahoy title "Running Twig CS Fixer"
        vendor/bin/twig-cs-fixer --no-cache --fix

--- a/.scaffold/tests/fixtures/init/no_php_lint/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_php_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -71,14 +71,6 @@
+@@ -60,14 +60,6 @@
      usage: Check coding standards for violations.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -13,7 +13,7 @@
        [ ! -d node_modules ] || (ahoy title "Running ESLint" && npm run lint)
        popd >/dev/null || exit 1
        ahoy title "Running CSpell"
-@@ -89,12 +81,6 @@
+@@ -78,12 +70,6 @@
      usage: Fix violations in coding standards.
      cmd: |
        pushd "build" >/dev/null || exit 1

--- a/.scaffold/tests/fixtures/init/no_php_lint/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_php_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -57,14 +57,6 @@
+@@ -71,14 +71,6 @@
      usage: Check coding standards for violations.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -13,7 +13,7 @@
        [ ! -d node_modules ] || (ahoy title "Running ESLint" && npm run lint)
        popd >/dev/null || exit 1
        ahoy title "Running CSpell"
-@@ -75,12 +67,6 @@
+@@ -89,12 +81,6 @@
      usage: Fix violations in coding standards.
      cmd: |
        pushd "build" >/dev/null || exit 1

--- a/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -102,40 +102,11 @@
+@@ -91,40 +91,11 @@
      usage: Run tests.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -39,7 +39,7 @@
    test-js:
      usage: Run JavaScript unit tests.
      cmd: |
-@@ -143,25 +114,6 @@
+@@ -132,25 +103,6 @@
        [ ! -d node_modules ] || npm test
        popd >/dev/null || exit 1
  

--- a/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -88,40 +88,11 @@
+@@ -102,40 +102,11 @@
      usage: Run tests.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -39,7 +39,7 @@
    test-js:
      usage: Run JavaScript unit tests.
      cmd: |
-@@ -129,25 +100,6 @@
+@@ -143,25 +114,6 @@
        [ ! -d node_modules ] || npm test
        popd >/dev/null || exit 1
  

--- a/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -57,31 +57,12 @@
+@@ -71,31 +71,12 @@
      usage: Check coding standards for violations.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -30,7 +30,7 @@
        popd >/dev/null || exit 1
  
    test:
-@@ -88,66 +69,11 @@
+@@ -102,66 +83,11 @@
      usage: Run tests.
      cmd: |
        pushd "build" >/dev/null || exit 1

--- a/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -71,31 +71,12 @@
+@@ -60,31 +60,12 @@
      usage: Check coding standards for violations.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -30,7 +30,7 @@
        popd >/dev/null || exit 1
  
    test:
-@@ -102,66 +83,11 @@
+@@ -91,66 +72,11 @@
      usage: Run tests.
      cmd: |
        pushd "build" >/dev/null || exit 1

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -87,14 +87,8 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
-# A `uli` command yields a one-time login URL worth scanning from a phone, so
-# capture its output, print it, then render a QR code (a no-op without
-# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	@case " $(DRUSH_RUN_ARGS) " in \
-	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
-	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
-	esac
+	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
 
 login:
 	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -87,11 +87,17 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
+# A `uli` command yields a one-time login URL worth scanning from a phone, so
+# capture its output, print it, then render a QR code (a no-op without
+# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
+	@case " $(DRUSH_RUN_ARGS) " in \
+	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
+	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
+	esac
 
 login:
-	build/vendor/bin/drush -l $(DRUSH_URI) uli
+	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/src/Functional/InitTest.php
+++ b/.scaffold/tests/src/Functional/InitTest.php
@@ -152,6 +152,12 @@ final class InitTest extends FunctionalTestCase {
       ],
     ];
 
+    yield 'no_cloudflare' => [
+      [
+        'cloudflare' => 'false',
+      ],
+    ];
+
     yield 'no_php_lint' => [
       [
         'tools' => 'eslint,stylelint,cspell,jest,phpunit,functional_javascript,renovate',
@@ -211,6 +217,7 @@ final class InitTest extends FunctionalTestCase {
       'drupal_version' => '10,11',
       'command_wrapper' => 'ahoy',
       'tools' => 'phpcs,phpstan,rector,twigcs,eslint,stylelint,cspell,jest,phpunit,functional_javascript,renovate',
+      'cloudflare' => 'true',
       'remove_self' => 'true',
       'proceed' => 'true',
     ];

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use function DrupalExtensionScaffold\DevTools\print_qrcode;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for the print_qrcode() helper.
+ *
+ * Runs in isolated processes so the exec() mock that stands in for the
+ * `qrencode` probe is not polluted by sibling tests that invoke the real
+ * command_path() in the shared process.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[RunTestsInSeparateProcesses]
+#[CoversFunction('DrupalExtensionScaffold\DevTools\print_qrcode')]
+#[Group('p0')]
+final class HelpersPrintQrcodeTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testEmptyUrlRendersNothing(): void {
+    // An empty URL must short-circuit before qrencode is probed or invoked,
+    // so neither exec() nor passthru() is mocked here.
+    ob_start();
+    print_qrcode('');
+    $output = (string) ob_get_clean();
+
+    $this->assertSame('', $output);
+  }
+
+  public function testQrencodeAbsentRendersNothing(): void {
+    $this->mockQrencodeAvailable(FALSE);
+
+    ob_start();
+    print_qrcode('https://example.com');
+    $output = (string) ob_get_clean();
+
+    $this->assertSame('', $output);
+  }
+
+  public function testQrencodePresentRendersCode(): void {
+    $this->mockQrencodeAvailable(TRUE);
+    $this->mockPassthru([
+      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
+      'output' => '[QR-CODE]',
+    ]);
+
+    ob_start();
+    print_qrcode('https://example.com');
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('[QR-CODE]', $output);
+  }
+
+  /**
+   * Mock command_path('qrencode') resolution via the underlying exec().
+   */
+  protected function mockQrencodeAvailable(bool $available): void {
+    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL) use ($available): bool {
+      $output ??= [];
+      if ($available && str_contains($cmd, 'command -v qrencode')) {
+        $output[] = '/usr/bin/qrencode';
+        $code = 0;
+
+        return TRUE;
+      }
+      $code = 1;
+
+      return FALSE;
+    });
+  }
+
+}

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -29,9 +29,13 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
+  protected function tearDown(): void {
+    self::envReset();
+    parent::tearDown();
+  }
+
   public function testEmptyUrlRendersNothing(): void {
-    // An empty URL must short-circuit before qrencode is probed or invoked,
-    // so neither exec() nor passthru() is mocked here.
+    // An empty URL short-circuits before the opt-in check or any probe.
     ob_start();
     print_qrcode('');
     $output = (string) ob_get_clean();
@@ -39,7 +43,31 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testQrencodeAbsentRendersNothing(): void {
+  public function testDisabledByDefaultRendersNothing(): void {
+    // QRCODE unset in both the environment and '.env': opt-in means nothing is
+    // drawn, and qrencode is never even probed.
+    self::envUnset('QRCODE');
+    $this->mockDotenvAbsent();
+
+    ob_start();
+    print_qrcode('https://example.com');
+    $output = (string) ob_get_clean();
+
+    $this->assertSame('', $output);
+  }
+
+  public function testExplicitlyDisabledRendersNothing(): void {
+    self::envSet('QRCODE', '0');
+
+    ob_start();
+    print_qrcode('https://example.com');
+    $output = (string) ob_get_clean();
+
+    $this->assertSame('', $output);
+  }
+
+  public function testEnabledButQrencodeAbsentRendersNothing(): void {
+    self::envSet('QRCODE', '1');
     $this->mockQrencodeAvailable(FALSE);
 
     ob_start();
@@ -49,7 +77,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testQrencodePresentRendersCode(): void {
+  public function testEnabledViaEnvRendersCode(): void {
+    self::envSet('QRCODE', '1');
     $this->mockQrencodeAvailable(TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
@@ -61,6 +90,30 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $output = (string) ob_get_clean();
 
     $this->assertStringContainsString('[QR-CODE]', $output);
+  }
+
+  public function testEnabledViaDotenvRendersCode(): void {
+    self::envUnset('QRCODE');
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(string $file): string => $file === '.env' ? "QRCODE=1\n" : '');
+    $this->mockQrencodeAvailable(TRUE);
+    $this->mockPassthru([
+      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
+      'output' => '[QR-CODE]',
+    ]);
+
+    ob_start();
+    print_qrcode('https://example.com');
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('[QR-CODE]', $output);
+  }
+
+  /**
+   * Mock '.env' as not present so QRCODE resolves to its default.
+   */
+  protected function mockDotenvAbsent(): void {
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
   }
 
   /**

--- a/.scaffold/tests/src/Unit/InitHelpersTest.php
+++ b/.scaffold/tests/src/Unit/InitHelpersTest.php
@@ -498,7 +498,7 @@ final class InitHelpersTest extends UnitTestCase {
   public function testProcessValidation(string $extension_name, string $machine_name, string $type, string $ci, array $drupal_versions, array $wrapper, string $expected_message): void {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage($expected_message);
-    process($extension_name, $machine_name, $type, $ci, $drupal_versions, $wrapper, [], 'n');
+    process($extension_name, $machine_name, $type, $ci, $drupal_versions, $wrapper, [], 'n', 'n');
   }
 
   public static function dataProviderProcessValidation(): \Iterator {

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -62,7 +62,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcess')]
   public function testProcess(string $name, string $machine_name, string $type, string $ci_provider, array $command_wrapper, array $expected_exists, array $expected_not_exists, array $expected_claude_allow, bool $info_yml_has_base_theme): void {
-    process($name, $machine_name, $type, $ci_provider, ['10', '11'], $command_wrapper, [], 'n');
+    process($name, $machine_name, $type, $ci_provider, ['10', '11'], $command_wrapper, [], 'n', 'n');
 
     foreach ($expected_exists as $path) {
       $this->assertFileExists(self::$sut . '/' . $path, 'Expected to exist: ' . $path);
@@ -208,7 +208,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessRemovesTools')]
   public function testProcessRemovesTools(array $tools_remove, array $expected_not_exists, array $expected_composer_dev_absent, array $expected_package_json_absent, array $expected_pipeline_absent): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy', 'makefile'], $tools_remove, 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy', 'makefile'], $tools_remove, 'n', 'n');
 
     foreach ($expected_not_exists as $path) {
       $this->assertFileDoesNotExist(self::$sut . '/' . $path, 'Expected removed: ' . $path);
@@ -351,13 +351,45 @@ final class InitProcessTest extends UnitTestCase {
   }
 
   /**
+   * The Cloudflare tunnel opt-out removes only the tunnel scripts.
+   *
+   * @param string $remove_cloudflare
+   *   The 'y'/'n' flag passed to process().
+   * @param bool $expect_exists
+   *   Whether the '*-cloudflared.sh' scripts should survive.
+   */
+  #[DataProvider('dataProviderProcessCloudflare')]
+  public function testProcessCloudflare(string $remove_cloudflare, bool $expect_exists): void {
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], $remove_cloudflare, 'n');
+
+    foreach (['provision', 'start', 'stop'] as $phase) {
+      $path = self::$sut . '/scripts/' . $phase . '-cloudflared.sh';
+      if ($expect_exists) {
+        $this->assertFileExists($path, 'Expected to keep: ' . $path);
+      }
+      else {
+        $this->assertFileDoesNotExist($path, 'Expected removed: ' . $path);
+      }
+    }
+
+    // The generic example lifecycle scripts are not Cloudflare-specific and are
+    // never removed by the tunnel opt-out.
+    $this->assertFileExists(self::$sut . '/scripts/start-example.sh');
+  }
+
+  public static function dataProviderProcessCloudflare(): \Iterator {
+    yield 'keep' => ['n', TRUE];
+    yield 'remove' => ['y', FALSE];
+  }
+
+  /**
    * The 'AGENTS.md' wrapper blocks follow the command wrapper selection.
    *
    * @param array<string> $command_wrapper
    */
   #[DataProvider('dataProviderProcessRemovesWrapperDocs')]
   public function testProcessRemovesWrapperDocs(array $command_wrapper, bool $expect_make, bool $expect_ahoy): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], $command_wrapper, [], 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], $command_wrapper, [], 'n', 'n');
 
     $agents = (string) file_get_contents(self::$sut . '/AGENTS.md');
 
@@ -385,7 +417,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessRemovesGitattributes')]
   public function testProcessRemovesGitattributes(array $tools_remove, array $expected_absent): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], $tools_remove, 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], $tools_remove, 'n', 'n');
 
     $gitattributes = (string) file_get_contents(self::$sut . '/.gitattributes');
     foreach ($expected_absent as $needle) {
@@ -415,7 +447,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessPrunesDrupalVersions')]
   public function testProcessPrunesDrupalVersions(string $ci_provider, array $drupal_versions, string $ci_file, array $expected_present, array $expected_absent): void {
-    process('My Extension', 'my_extension', 'module', $ci_provider, $drupal_versions, ['ahoy'], [], 'n');
+    process('My Extension', 'my_extension', 'module', $ci_provider, $drupal_versions, ['ahoy'], [], 'n', 'n');
 
     $content = (string) file_get_contents(self::$sut . '/' . $ci_file);
 
@@ -451,7 +483,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessNarrowsAssembleDefault')]
   public function testProcessNarrowsAssembleDefault(array $drupal_versions, string $expected_default): void {
-    process('My Extension', 'my_extension', 'module', 'gha', $drupal_versions, ['ahoy'], [], 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', $drupal_versions, ['ahoy'], [], 'n', 'n');
 
     $assemble = (string) file_get_contents(self::$sut . '/.devtools/assemble');
     $this->assertStringContainsString("getenv_default('DRUPAL_VERSION', '" . $expected_default . "')", $assemble);
@@ -467,7 +499,7 @@ final class InitProcessTest extends UnitTestCase {
     file_put_contents(self::$sut . '/.claude/settings.json', '{invalid json');
 
     $this->expectException(\JsonException::class);
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n', 'n');
   }
 
   public function testProcessThrowsOnInvalidClaudeSettingsStructure(): void {
@@ -475,13 +507,13 @@ final class InitProcessTest extends UnitTestCase {
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Invalid .claude/settings.json structure.');
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n', 'n');
   }
 
   public function testProcessSkipsWhenClaudeSettingsMissing(): void {
     @unlink(self::$sut . '/.claude/settings.json');
 
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n', 'n');
 
     $this->assertFileExists(self::$sut . '/my_extension.info.yml');
     $this->assertFileDoesNotExist(self::$sut . '/.claude/settings.json');

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -352,11 +352,6 @@ final class InitProcessTest extends UnitTestCase {
 
   /**
    * The Cloudflare tunnel opt-out removes only the tunnel scripts.
-   *
-   * @param string $remove_cloudflare
-   *   The 'y'/'n' flag passed to process().
-   * @param bool $expect_exists
-   *   Whether the '*-cloudflared.sh' scripts should survive.
    */
   #[DataProvider('dataProviderProcessCloudflare')]
   public function testProcessCloudflare(string $remove_cloudflare, bool $expect_exists): void {

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -21,18 +21,6 @@ final class ProvisionTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
-
-    // The completion banner renders the login link as a QR code via
-    // print_qrcode(), which shells out to `qrencode` when it is present. Force
-    // it absent so the banner assertions stay deterministic regardless of what
-    // the host has installed; print_qrcode()'s own branches are covered by
-    // HelpersPrintQrcodeTest.
-    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
-      $output ??= [];
-      $code = 1;
-
-      return FALSE;
-    });
   }
 
   /**

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -21,6 +21,18 @@ final class ProvisionTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+
+    // The completion banner renders the login link as a QR code via
+    // print_qrcode(), which shells out to `qrencode` when it is present. Force
+    // it absent so the banner assertions stay deterministic regardless of what
+    // the host has installed; print_qrcode()'s own branches are covered by
+    // HelpersPrintQrcodeTest.
+    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
+      $output ??= [];
+      $code = 1;
+
+      return FALSE;
+    });
   }
 
   /**

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -22,7 +22,14 @@ final class QrcodeTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
+  protected function tearDown(): void {
+    self::envReset();
+    parent::tearDown();
+  }
+
   public function testRendersQrcodeForUrlArgument(): void {
+    // Rendering is opt-in; enable it for this run.
+    self::envSet('QRCODE', '1');
     $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
       $output ??= [];
       if (str_contains($cmd, 'command -v qrencode')) {

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for the qrcode devtools script.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[RunTestsInSeparateProcesses]
+#[Group('p0')]
+final class QrcodeTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
+  }
+
+  public function testRendersQrcodeForUrlArgument(): void {
+    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
+      $output ??= [];
+      if (str_contains($cmd, 'command -v qrencode')) {
+        $output[] = '/usr/bin/qrencode';
+        $code = 0;
+
+        return TRUE;
+      }
+      $code = 1;
+
+      return FALSE;
+    });
+    $this->mockPassthru([
+      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
+      'output' => '[QR-CODE]',
+    ]);
+
+    $argv = ['qrcode', 'https://example.com'];
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/qrcode';
+    $output = (string) ob_get_clean();
+
+    $this->assertStringContainsString('[QR-CODE]', $output);
+  }
+
+  public function testRendersNothingWithoutUrlArgument(): void {
+    $argv = ['qrcode'];
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/qrcode';
+    $output = (string) ob_get_clean();
+
+    $this->assertSame('', $output);
+  }
+
+}

--- a/Makefile
+++ b/Makefile
@@ -113,14 +113,8 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
-# A `uli` command yields a one-time login URL worth scanning from a phone, so
-# capture its output, print it, then render a QR code (a no-op without
-# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	@case " $(DRUSH_RUN_ARGS) " in \
-	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
-	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
-	esac
+	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
 
 login:
 	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"

--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,17 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
   $(eval $(DRUSH_RUN_ARGS):;@:)
 endif
 
+# A `uli` command yields a one-time login URL worth scanning from a phone, so
+# capture its output, print it, then render a QR code (a no-op without
+# `qrencode`). Every other Drush command streams through untouched.
 drush:
-	build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS)
+	@case " $(DRUSH_RUN_ARGS) " in \
+	  *" uli "*) url="$$(build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS))"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url" ;; \
+	  *) build/vendor/bin/drush -l $(DRUSH_URI) $(DRUSH_RUN_ARGS) ;; \
+	esac
 
 login:
-	build/vendor/bin/drush -l $(DRUSH_URI) uli
+	@url="$$(build/vendor/bin/drush -l $(DRUSH_URI) uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
 
 provision:
 	./.devtools/provision

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Any tool that writes a `TUNNEL_URL` to `.env` (ngrok, tailscale funnel, etc.) is
 
 #### Scannable QR codes
 
-When [`qrencode`](https://fukuchi.org/works/qrencode/) is on `PATH`, the one-time login link in the `provision` output is also rendered as a terminal QR code, and `make login` / `ahoy login` (and `make drush uli` / `ahoy drush uli`) print one for the link they generate. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Without `qrencode` installed the output is unchanged, so nothing breaks in CI or on hosts that lack it.
+When [`qrencode`](https://fukuchi.org/works/qrencode/) is on `PATH`, `make login` / `ahoy login` render the one-time login link as a terminal QR code below the link. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Without `qrencode` installed the output is unchanged, so nothing breaks in CI or on hosts that lack it.
 
 ### Step-debugging with XDebug
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Any tool that writes a `TUNNEL_URL` to `.env` (ngrok, tailscale funnel, etc.) is
 
 #### Scannable QR codes
 
-When [`qrencode`](https://fukuchi.org/works/qrencode/) is on `PATH`, `make login` / `ahoy login` render the one-time login link as a terminal QR code below the link. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Without `qrencode` installed the output is unchanged, so nothing breaks in CI or on hosts that lack it.
+QR rendering is opt-in. Set `QRCODE=1` (in your shell environment or `.env`) with [`qrencode`](https://fukuchi.org/works/qrencode/) on `PATH`, and `make login` / `ahoy login` render the one-time login link as a terminal QR code below the link. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Left unset (the default) or without `qrencode` installed, the output is unchanged.
 
 ### Step-debugging with XDebug
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ With `CLOUDFLARE_TUNNEL` set and the [`cloudflared`](https://developers.cloudfla
 
 Any tool that writes a `TUNNEL_URL` to `.env` (ngrok, tailscale funnel, etc.) is picked up the same way - the core scripts are tunnel-agnostic.
 
+#### Scannable QR codes
+
+When [`qrencode`](https://fukuchi.org/works/qrencode/) is on `PATH`, the one-time login link in the `provision` output is also rendered as a terminal QR code, and `make login` / `ahoy login` (and `make drush uli` / `ahoy drush uli`) print one for the link they generate. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Without `qrencode` installed the output is unchanged, so nothing breaks in CI or on hosts that lack it.
+
 ### Step-debugging with XDebug
 
 PHP step-debugging is supported via [XDebug](https://xdebug.org/docs/install). Install the XDebug PHP extension on your host (`php -v` should mention `with Xdebug`), then toggle it on the development server:

--- a/init.php
+++ b/init.php
@@ -108,6 +108,10 @@ function main(array $argv): void {
         default: array_keys($tool_options),
         description: 'All tools are included by default. Uncheck any to remove from your project.',
       ),
+      'cloudflare' => Prompty::confirm(
+        'Keep Cloudflare tunnel support',
+        description: 'Ships opt-in scripts that expose the local site through a public Cloudflare quick tunnel.',
+      ),
       'remove_self' => Prompty::confirm('Remove this script'),
       'proceed' => Prompty::confirm('Proceed with project init'),
     ],
@@ -142,6 +146,9 @@ function main(array $argv): void {
   /** @var array<string> $tools_keep */
   $tools_keep = array_filter((array) $results['tools'], static fn($v): bool => $v !== '');
   $tools_remove = array_values(array_diff(array_keys($tool_options), $tools_keep));
+  // The prompt asks whether to keep the tunnel scripts, so a 'no' answer is
+  // what triggers their removal.
+  $remove_cloudflare = empty($results['cloudflare']) ? 'y' : 'n';
   $remove_self = empty($results['remove_self']) ? 'n' : 'y';
 
   // Derive machine name from extension name if the user accepted placeholder.
@@ -149,7 +156,7 @@ function main(array $argv): void {
     $machine_name = convert_string($name, 'file_name');
   }
 
-  process($name, $machine_name, $type, $ci_provider, $drupal_versions, $command_wrapper, $tools_remove, $remove_self);
+  process($name, $machine_name, $type, $ci_provider, $drupal_versions, $command_wrapper, $tools_remove, $remove_cloudflare, $remove_self);
   // @codeCoverageIgnoreEnd
 }
 
@@ -202,6 +209,7 @@ Environment variables (to pre-fill prompts):
                          One or more of: phpcs, phpstan, rector, twigcs, eslint,
                          stylelint, cspell, jest, phpunit, functional_javascript,
                          renovate.
+  PROMPTY_CLOUDFLARE      Keep Cloudflare tunnel support: true or false.
   PROMPTY_REMOVE_SELF     Remove this script: true or false.
   PROMPTY_PROCEED         Proceed with init: true or false.
 
@@ -226,10 +234,12 @@ EOF;
  *   The selected command wrappers ('ahoy', 'makefile', or both).
  * @param array<string> $tools_remove
  *   The machine names of the development tools to remove.
+ * @param string $remove_cloudflare
+ *   Whether to remove the Cloudflare tunnel scripts ('y' or 'n').
  * @param string $remove_self
  *   Whether to remove this script ('y' or 'n').
  */
-function process(string $extension_name, string $extension_machine_name, string $extension_type, string $ci_provider, array $drupal_versions, array $command_wrapper, array $tools_remove, string $remove_self): void {
+function process(string $extension_name, string $extension_machine_name, string $extension_type, string $ci_provider, array $drupal_versions, array $command_wrapper, array $tools_remove, string $remove_cloudflare, string $remove_self): void {
   // Validate required values.
   if ($extension_name === '') {
     throw new \Exception('Name is required.');
@@ -331,6 +341,15 @@ function process(string $extension_name, string $extension_machine_name, string 
   process_readme($extension_name);
 
   process_internal($extension_name, $extension_machine_name, $extension_type);
+
+  // Remove the opt-in Cloudflare quick-tunnel scripts when the tunnel support
+  // is declined. The tunnel-agnostic TUNNEL_URL handling in the core scripts
+  // stays regardless, so any other tunnel tool still integrates.
+  if ($remove_cloudflare !== 'n') {
+    @unlink('scripts/provision-cloudflared.sh');
+    @unlink('scripts/start-cloudflared.sh');
+    @unlink('scripts/stop-cloudflared.sh');
+  }
 
   if ($remove_self !== 'n') {
     // @codeCoverageIgnoreStart


### PR DESCRIPTION
Closes #432

## Summary

Two related developer-experience improvements to the local environment:

1. **Opt-in QR code for the one-time login link** (#432) - `make login` / `ahoy login` can render the login URL as a terminal QR code below the printed link, so it can be scanned straight from a phone instead of retyped. It is **opt-in and off by default**: nothing is drawn unless `QRCODE` resolves to a truthy value (shell environment or `.env`) and [`qrencode`](https://fukuchi.org/works/qrencode/) is installed, so normal output is unchanged.
2. **Cloudflare tunnel opt-out in `init.php`** (#431) - project initialisation now asks whether to keep Cloudflare tunnel support (just before the "remove this script" prompt); declining removes the opt-in `scripts/*-cloudflared.sh` scripts. The tunnel-agnostic `TUNNEL_URL` handling in the core scripts stays regardless, so any other tunnel tool still integrates.

## Changes

### QR code (#432)

- **Core helper**: `.devtools/helpers.php` gains `print_qrcode(string $url)`, which draws a QR via `qrencode -t ANSIUTF8` only when `QRCODE` resolves truthy (env → `.env`, through `resolve_env_value()`) and `qrencode` is on `PATH`; otherwise it is a silent no-op.
- **Entrypoint**: `.devtools/qrcode` is a small executable (mirroring `.devtools/info`) that renders a URL passed as its first argument through `print_qrcode()`.
- **Login commands**: `make login` and `ahoy login` capture the one-time login link, print it, then render the QR below it via the entrypoint. The `drush` wrappers and the `provision` banner are left untouched.
- **Docs & dictionary**: `README.md` documents the opt-in; `.cspell.json` adds `ansiutf`, `ansiutf8`, `qrcode`, and `qrencode`.
- **Tests**: `HelpersPrintQrcodeTest` covers empty URL, default-off, explicit-off, enabled-but-`qrencode`-absent, enabled-via-env, and enabled-via-`.env`; `QrcodeTest` covers the entrypoint with and without a URL argument.

### Cloudflare tunnel opt-out (#431)

- **`init.php`**: a new "Keep Cloudflare tunnel support" prompt (with a `PROMPTY_CLOUDFLARE` env override) runs just before `remove_self`; declining unlinks `scripts/provision-cloudflared.sh`, `scripts/start-cloudflared.sh`, and `scripts/stop-cloudflared.sh` inside `process()`. No README change is needed - the development README is replaced by `README.dist.md` during init, so the tunnel docs never ship to a generated project.
- **Tests**: `InitProcessTest` gains a `testProcessCloudflare` data provider covering the keep and remove branches; `InitTest` gains a `no_cloudflare` snapshot dataset.

## Before / After

Login-link QR is opt-in (`ahoy login` shown):

```
DEFAULT (QRCODE unset)                    QRCODE=1  (with qrencode installed)
┌────────────────────────────────┐        ┌────────────────────────────────┐
│ $ ahoy login                    │        │ $ QRCODE=1 ahoy login           │
│                                 │        │                                 │
│ http://site.test/user/reset/... │        │ http://site.test/user/reset/... │
│                                 │        │ ██████████████  ▄▄▄▄▄  ████████ │
│ (link only - output unchanged   │        │ ██ ▄▄▄▄▄ ██▄█ █▄  █▄▀▀ ██▄▄▄ ██ │
│  from before this change)       │        │ ██ █   █ ██ ▀▄▀ ▄ █▀▄▀▀ █   █ ██ │
│                                 │        │ ██ █▄▄▄█ ██▀ █▄▄▀██▀▄▀▄ █▄▄▄█ ██ │
│                                 │        │ ██████████████  ▀▀▀▀▀  ████████ │
│                                 │        │ (scan to open, already logged   │
│                                 │        │  in)                            │
└────────────────────────────────┘        └────────────────────────────────┘
```

Cloudflare tunnel support at `init` time:

```
BEFORE                                       AFTER (decline the prompt)
┌───────────────────────────────────┐        ┌───────────────────────────────────┐
│ scripts/                          │        │ scripts/                          │
│   assemble-example.sh             │        │   assemble-example.sh             │
│   provision-cloudflared.sh        │        │   provision-example.sh            │
│   provision-example.sh            │  ──►   │   start-example.sh                │
│   start-cloudflared.sh            │        │   stop-example.sh                 │
│   start-example.sh                │        │                                   │
│   stop-cloudflared.sh             │        │ (*-cloudflared.sh removed;         │
│   stop-example.sh                 │        │  TUNNEL_URL core stays, so ngrok/  │
│                                   │        │  tailscale/etc. still integrate)   │
└───────────────────────────────────┘        └───────────────────────────────────┘
```
