### PR TITLE
[#339] Unified 'chromedriver-*' and 'selenium-*' commands into 'browser-start' and 'browser-stop'.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -147,12 +147,8 @@ commands:
   test-functional-javascript:
     usage: Run FunctionalJavascript tests.
     cmd: |
-      if [ "${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then
-        ahoy selenium-start || exit 1
-      else
-        ahoy chromedriver-start || exit 1
-        export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
-      fi
+      ahoy browser-start || exit 1
+      export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
       pushd "build" >/dev/null || exit 1
       php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
       popd >/dev/null || exit 1
@@ -168,33 +164,13 @@ commands:
   #;> DEV_JEST
 
   #;< DEV_FUNCTIONAL_JAVASCRIPT
-  chromedriver-start:
-    usage: Start chromedriver against the locally installed Chrome if not already running.
-    cmd: ./.devtools/chromedriver start
+  browser-start:
+    usage: Start the WebDriver backend for FunctionalJavascript tests if not already running.
+    cmd: ./.devtools/browser start
 
-  chromedriver-stop:
-    usage: Stop chromedriver.
-    cmd: ./.devtools/chromedriver stop
-
-  selenium-start:
-    usage: Start Selenium container if not already running.
-    cmd: |
-      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
-        echo "Selenium container is already running."
-        exit 0
-      fi
-      docker rm -f selenium 2>/dev/null || true
-      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
-      echo "Waiting for Selenium to be ready..."
-      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
-      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
-        echo "ERROR: Selenium failed to become ready after 30 seconds."
-        exit 1
-      fi
-
-  selenium-stop:
-    usage: Stop Selenium container.
-    cmd: docker rm -f selenium 2>/dev/null || true
+  browser-stop:
+    usage: Stop the WebDriver backend.
+    cmd: ./.devtools/browser stop
   #;> DEV_FUNCTIONAL_JAVASCRIPT
 
   reset:

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -165,11 +165,11 @@ commands:
 
   #;< DEV_FUNCTIONAL_JAVASCRIPT
   browser-start:
-    usage: Start the WebDriver backend for FunctionalJavascript tests if not already running.
+    usage: Start the browser for FunctionalJavascript tests if not already running.
     cmd: ./.devtools/browser start
 
   browser-stop:
-    usage: Stop the WebDriver backend.
+    usage: Stop the browser used for FunctionalJavascript tests.
     cmd: ./.devtools/browser stop
   #;> DEV_FUNCTIONAL_JAVASCRIPT
 

--- a/.devtools/browser
+++ b/.devtools/browser
@@ -156,8 +156,10 @@ function selenium_start(): void {
   TASK('Starting the Selenium container on port %s.', $port);
   @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
 
+  // The default 64 MB '/dev/shm' is too small for Chromium and leads to tab
+  // crashes mid-test; the Selenium images document 2g as the required size.
   $exit_code = 0;
-  passthru(sprintf('docker run -d --name %s -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), $exit_code);
+  passthru(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), $exit_code);
   if ($exit_code !== 0) {
     FAIL('Failed to start the Selenium container.');
   }

--- a/.devtools/browser
+++ b/.devtools/browser
@@ -3,18 +3,22 @@
 
 /**
  * @file
- * Start or stop chromedriver against the locally installed Chrome.
+ * Start or stop the WebDriver backend for FunctionalJavascript tests.
  *
- * chromedriver is the small WebDriver server that drives the Chrome already
- * installed on the machine, so FunctionalJavascript tests need no Docker.
- * The endpoint port is resolved per project (env -> '.env' -> auto-discover
- * from 4444) and persisted to '.env' like the webserver port, so several
- * projects can run their own chromedriver simultaneously without contending
- * for a single port.
+ * The backend is selected via WEBDRIVER_BACKEND:
+ * - 'chromedriver' (default): a small WebDriver server that drives the Chrome
+ *   already installed on the machine, so no Docker is required.
+ * - 'selenium': the browser runs inside a Docker container.
+ *
+ * Both backends serve the WebDriver endpoint on the same per-project port
+ * (env -> '.env' -> 4444). The chromedriver backend auto-discovers a free
+ * port from 4444 and persists it to '.env' like the webserver port, so
+ * several projects can run their own endpoint simultaneously without
+ * contending for a single port.
  *
  * Usage:
- * - 'chromedriver start': ensure a matching chromedriver is listening.
- * - 'chromedriver stop': stop the chromedriver bound to this project's port.
+ * - 'browser start': ensure the selected backend is listening.
+ * - 'browser stop': stop whichever backend is running.
  */
 
 declare(strict_types=1);
@@ -27,15 +31,18 @@ require_once __DIR__ . '/helpers.php';
 // by git and safe to delete.
 const CHROMEDRIVER_DIR = '.chromedriver';
 
+const SELENIUM_CONTAINER = 'selenium';
+const SELENIUM_IMAGE = 'selenium/standalone-chromium:latest';
+
 $command = $argv[1] ?? '';
 
 if ($command === 'start') {
-  chromedriver_start();
+  browser_start();
   quit(0);
 }
 
 if ($command === 'stop') {
-  chromedriver_stop();
+  browser_stop();
   quit(0);
 }
 
@@ -46,15 +53,58 @@ FAIL("Unknown command '%s'. Use 'start' or 'stop'.", $command);
 // -----------------------------------------------------------------------------
 
 /**
+ * Ensure the selected WebDriver backend is listening.
+ */
+function browser_start(): void {
+  echo '===============================' . PHP_EOL;
+  echo '       🌐 START BROWSER        ' . PHP_EOL;
+  echo '===============================' . PHP_EOL;
+  echo PHP_EOL;
+
+  if (webdriver_backend() === 'selenium') {
+    selenium_start();
+
+    return;
+  }
+
+  chromedriver_start();
+}
+
+/**
+ * Stop whichever WebDriver backend is running.
+ *
+ * Backend-agnostic on purpose: the Selenium container publishes the same
+ * port the chromedriver process would bind, so dispatching on the selected
+ * backend could kill the container's docker proxy instead of the container
+ * when WEBDRIVER_BACKEND is not set for the stop invocation. The container
+ * is removed first, freeing the port, and any remaining process on the
+ * port is then terminated.
+ */
+function browser_stop(): void {
+  $port = resolve_webdriver_port()['port'];
+
+  echo '===============================' . PHP_EOL;
+  echo '        🌐 STOP BROWSER        ' . PHP_EOL;
+  echo '===============================' . PHP_EOL;
+  echo PHP_EOL;
+
+  if (command_path('docker') !== FALSE) {
+    TASK('Removing the Selenium container, if any.');
+    @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+  }
+
+  TASK('Stopping the WebDriver process on port %s, if any.', $port);
+  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
+  sleep(1);
+
+  PASS('Browser stopped on port %s.', $port);
+}
+
+/**
  * Ensure a chromedriver matching the installed Chrome is listening.
  */
 function chromedriver_start(): void {
   $port = resolve_webdriver_port(auto_discover: TRUE)['port'];
-
-  echo '===============================' . PHP_EOL;
-  echo '     🌐 START CHROMEDRIVER     ' . PHP_EOL;
-  echo '===============================' . PHP_EOL;
-  echo PHP_EOL;
 
   if (webdriver_ready($port)) {
     PASS('chromedriver is already running on port %s.', $port);
@@ -88,20 +138,41 @@ function chromedriver_start(): void {
 }
 
 /**
- * Stop the chromedriver bound to this project's port, if any.
+ * Ensure a Selenium container is serving the WebDriver endpoint.
  */
-function chromedriver_stop(): void {
+function selenium_start(): void {
   $port = resolve_webdriver_port()['port'];
 
-  echo '===============================' . PHP_EOL;
-  echo '      🌐 STOP CHROMEDRIVER     ' . PHP_EOL;
-  echo '===============================' . PHP_EOL;
-  echo PHP_EOL;
+  if (webdriver_ready($port)) {
+    PASS('Selenium is already running on port %s.', $port);
 
-  TASK('Stopping chromedriver on port %s, if any.', $port);
-  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
-  sleep(1);
-  PASS('chromedriver stopped on port %s.', $port);
+    return;
+  }
+
+  if (command_path('docker') === FALSE) {
+    FAIL('docker was not found. Install Docker, or unset WEBDRIVER_BACKEND to use the locally installed Chrome.');
+  }
+
+  TASK('Starting the Selenium container on port %s.', $port);
+  @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+
+  $exit_code = 0;
+  passthru(sprintf('docker run -d --name %s -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), $exit_code);
+  if ($exit_code !== 0) {
+    FAIL('Failed to start the Selenium container.');
+  }
+
+  NOTE('Waiting for Selenium to be ready.');
+  for ($i = 0; $i < 30; $i++) {
+    if (webdriver_ready($port)) {
+      PASS('Selenium is ready on port %s.', $port);
+
+      return;
+    }
+    sleep(1);
+  }
+
+  FAIL('Selenium failed to become ready on port %s after 30 seconds.', $port);
 }
 
 // -----------------------------------------------------------------------------
@@ -109,13 +180,30 @@ function chromedriver_stop(): void {
 // -----------------------------------------------------------------------------
 
 /**
+ * Resolve the WebDriver backend, aborting on an unsupported value.
+ */
+function webdriver_backend(): string {
+  [$backend] = resolve_env_value('WEBDRIVER_BACKEND', 'chromedriver');
+
+  if (!in_array($backend, ['chromedriver', 'selenium'], TRUE)) {
+    FAIL("Unknown WEBDRIVER_BACKEND '%s'. Use 'chromedriver' or 'selenium'.", $backend);
+  }
+
+  return $backend;
+}
+
+/**
  * Check whether a WebDriver server on the given port accepts sessions.
+ *
+ * Both backends report '"ready": true' in the '/status' response body.
+ * Selenium serves HTTP 200 before it can accept sessions, so the body is
+ * inspected rather than the response status.
  */
 function webdriver_ready(string $port): bool {
   $context = stream_context_create(['http' => ['method' => 'GET', 'timeout' => 2, 'ignore_errors' => TRUE]]);
-  $headers = @get_headers(sprintf('http://localhost:%s/status', $port), FALSE, $context);
+  $body = @file_get_contents(sprintf('http://localhost:%s/status', $port), FALSE, $context);
 
-  return is_array($headers) && isset($headers[0]) && str_contains((string) $headers[0], '200');
+  return is_string($body) && preg_match('/"ready":\s*true/', $body) === 1;
 }
 
 /**

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -275,13 +275,13 @@ function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TR
 }
 
 /**
- * Resolve the WebDriver (chromedriver) endpoint port with source tracking.
+ * Resolve the WebDriver endpoint port with source tracking.
  *
  * Mirrors the port half of resolve_webserver() for 'WEBDRIVER_PORT':
  * shell env first, then a matching key in the dotenv file, then the
  * default. With auto_discover and no configured value, a free port is
  * allocated from 4444 and persisted to the dotenv file so that several
- * projects each get their own chromedriver endpoint and never contend
+ * projects each get their own WebDriver endpoint and never contend
  * for a single port.
  *
  * @param bool $auto_discover

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Start chromedriver (chromedriver backend)
         if: matrix.backend == 'chromedriver' && (matrix.group == 'p3' || matrix.group == 'p4')
-        run: ./.devtools/chromedriver start
+        run: ./.devtools/browser start
 
       - name: Install PHP test dependencies
         run: composer install --no-interaction

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -120,12 +120,8 @@ commands:
   test-functional-javascript:
     usage: Run FunctionalJavascript tests.
     cmd: |
-      if [ "${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then
-        ahoy selenium-start || exit 1
-      else
-        ahoy chromedriver-start || exit 1
-        export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
-      fi
+      ahoy browser-start || exit 1
+      export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
       pushd "build" >/dev/null || exit 1
       php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
       popd >/dev/null || exit 1
@@ -137,33 +133,13 @@ commands:
       [ ! -d node_modules ] || npm test
       popd >/dev/null || exit 1
 
-  chromedriver-start:
-    usage: Start chromedriver against the locally installed Chrome if not already running.
-    cmd: ./.devtools/chromedriver start
+  browser-start:
+    usage: Start the browser for FunctionalJavascript tests if not already running.
+    cmd: ./.devtools/browser start
 
-  chromedriver-stop:
-    usage: Stop chromedriver.
-    cmd: ./.devtools/chromedriver stop
-
-  selenium-start:
-    usage: Start Selenium container if not already running.
-    cmd: |
-      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
-        echo "Selenium container is already running."
-        exit 0
-      fi
-      docker rm -f selenium 2>/dev/null || true
-      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
-      echo "Waiting for Selenium to be ready..."
-      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
-      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
-        echo "ERROR: Selenium failed to become ready after 30 seconds."
-        exit 1
-      fi
-
-  selenium-stop:
-    usage: Stop Selenium container.
-    cmd: docker rm -f selenium 2>/dev/null || true
+  browser-stop:
+    usage: Stop the browser used for FunctionalJavascript tests.
+    cmd: ./.devtools/browser stop
 
   reset:
     usage: Reset project to the default state.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
@@ -3,18 +3,22 @@
 
 /**
  * @file
- * Start or stop chromedriver against the locally installed Chrome.
+ * Start or stop the WebDriver backend for FunctionalJavascript tests.
  *
- * chromedriver is the small WebDriver server that drives the Chrome already
- * installed on the machine, so FunctionalJavascript tests need no Docker.
- * The endpoint port is resolved per project (env -> '.env' -> auto-discover
- * from 4444) and persisted to '.env' like the webserver port, so several
- * projects can run their own chromedriver simultaneously without contending
- * for a single port.
+ * The backend is selected via WEBDRIVER_BACKEND:
+ * - 'chromedriver' (default): a small WebDriver server that drives the Chrome
+ *   already installed on the machine, so no Docker is required.
+ * - 'selenium': the browser runs inside a Docker container.
+ *
+ * Both backends serve the WebDriver endpoint on the same per-project port
+ * (env -> '.env' -> 4444). The chromedriver backend auto-discovers a free
+ * port from 4444 and persists it to '.env' like the webserver port, so
+ * several projects can run their own endpoint simultaneously without
+ * contending for a single port.
  *
  * Usage:
- * - 'chromedriver start': ensure a matching chromedriver is listening.
- * - 'chromedriver stop': stop the chromedriver bound to this project's port.
+ * - 'browser start': ensure the selected backend is listening.
+ * - 'browser stop': stop whichever backend is running.
  */
 
 declare(strict_types=1);
@@ -27,15 +31,18 @@ require_once __DIR__ . '/helpers.php';
 // by git and safe to delete.
 const CHROMEDRIVER_DIR = '.chromedriver';
 
+const SELENIUM_CONTAINER = 'selenium';
+const SELENIUM_IMAGE = 'selenium/standalone-chromium:latest';
+
 $command = $argv[1] ?? '';
 
 if ($command === 'start') {
-  chromedriver_start();
+  browser_start();
   quit(0);
 }
 
 if ($command === 'stop') {
-  chromedriver_stop();
+  browser_stop();
   quit(0);
 }
 
@@ -46,15 +53,58 @@ FAIL("Unknown command '%s'. Use 'start' or 'stop'.", $command);
 // -----------------------------------------------------------------------------
 
 /**
+ * Ensure the selected WebDriver backend is listening.
+ */
+function browser_start(): void {
+  echo '===============================' . PHP_EOL;
+  echo '       🌐 START BROWSER        ' . PHP_EOL;
+  echo '===============================' . PHP_EOL;
+  echo PHP_EOL;
+
+  if (webdriver_backend() === 'selenium') {
+    selenium_start();
+
+    return;
+  }
+
+  chromedriver_start();
+}
+
+/**
+ * Stop whichever WebDriver backend is running.
+ *
+ * Backend-agnostic on purpose: the Selenium container publishes the same
+ * port the chromedriver process would bind, so dispatching on the selected
+ * backend could kill the container's docker proxy instead of the container
+ * when WEBDRIVER_BACKEND is not set for the stop invocation. The container
+ * is removed first, freeing the port, and any remaining process on the
+ * port is then terminated.
+ */
+function browser_stop(): void {
+  $port = resolve_webdriver_port()['port'];
+
+  echo '===============================' . PHP_EOL;
+  echo '        🌐 STOP BROWSER        ' . PHP_EOL;
+  echo '===============================' . PHP_EOL;
+  echo PHP_EOL;
+
+  if (command_path('docker') !== FALSE) {
+    TASK('Removing the Selenium container, if any.');
+    @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+  }
+
+  TASK('Stopping the WebDriver process on port %s, if any.', $port);
+  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
+  sleep(1);
+
+  PASS('Browser stopped on port %s.', $port);
+}
+
+/**
  * Ensure a chromedriver matching the installed Chrome is listening.
  */
 function chromedriver_start(): void {
   $port = resolve_webdriver_port(auto_discover: TRUE)['port'];
-
-  echo '===============================' . PHP_EOL;
-  echo '     🌐 START CHROMEDRIVER     ' . PHP_EOL;
-  echo '===============================' . PHP_EOL;
-  echo PHP_EOL;
 
   if (webdriver_ready($port)) {
     PASS('chromedriver is already running on port %s.', $port);
@@ -88,20 +138,43 @@ function chromedriver_start(): void {
 }
 
 /**
- * Stop the chromedriver bound to this project's port, if any.
+ * Ensure a Selenium container is serving the WebDriver endpoint.
  */
-function chromedriver_stop(): void {
+function selenium_start(): void {
   $port = resolve_webdriver_port()['port'];
 
-  echo '===============================' . PHP_EOL;
-  echo '      🌐 STOP CHROMEDRIVER     ' . PHP_EOL;
-  echo '===============================' . PHP_EOL;
-  echo PHP_EOL;
+  if (webdriver_ready($port)) {
+    PASS('Selenium is already running on port %s.', $port);
 
-  TASK('Stopping chromedriver on port %s, if any.', $port);
-  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
-  sleep(1);
-  PASS('chromedriver stopped on port %s.', $port);
+    return;
+  }
+
+  if (command_path('docker') === FALSE) {
+    FAIL('docker was not found. Install Docker, or unset WEBDRIVER_BACKEND to use the locally installed Chrome.');
+  }
+
+  TASK('Starting the Selenium container on port %s.', $port);
+  @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+
+  // The default 64 MB '/dev/shm' is too small for Chromium and leads to tab
+  // crashes mid-test; the Selenium images document 2g as the required size.
+  $exit_code = 0;
+  passthru(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), $exit_code);
+  if ($exit_code !== 0) {
+    FAIL('Failed to start the Selenium container.');
+  }
+
+  NOTE('Waiting for Selenium to be ready.');
+  for ($i = 0; $i < 30; $i++) {
+    if (webdriver_ready($port)) {
+      PASS('Selenium is ready on port %s.', $port);
+
+      return;
+    }
+    sleep(1);
+  }
+
+  FAIL('Selenium failed to become ready on port %s after 30 seconds.', $port);
 }
 
 // -----------------------------------------------------------------------------
@@ -109,13 +182,30 @@ function chromedriver_stop(): void {
 // -----------------------------------------------------------------------------
 
 /**
+ * Resolve the WebDriver backend, aborting on an unsupported value.
+ */
+function webdriver_backend(): string {
+  [$backend] = resolve_env_value('WEBDRIVER_BACKEND', 'chromedriver');
+
+  if (!in_array($backend, ['chromedriver', 'selenium'], TRUE)) {
+    FAIL("Unknown WEBDRIVER_BACKEND '%s'. Use 'chromedriver' or 'selenium'.", $backend);
+  }
+
+  return $backend;
+}
+
+/**
  * Check whether a WebDriver server on the given port accepts sessions.
+ *
+ * Both backends report '"ready": true' in the '/status' response body.
+ * Selenium serves HTTP 200 before it can accept sessions, so the body is
+ * inspected rather than the response status.
  */
 function webdriver_ready(string $port): bool {
   $context = stream_context_create(['http' => ['method' => 'GET', 'timeout' => 2, 'ignore_errors' => TRUE]]);
-  $headers = @get_headers(sprintf('http://localhost:%s/status', $port), FALSE, $context);
+  $body = @file_get_contents(sprintf('http://localhost:%s/status', $port), FALSE, $context);
 
-  return is_array($headers) && isset($headers[0]) && str_contains((string) $headers[0], '200');
+  return is_string($body) && preg_match('/"ready":\s*true/', $body) === 1;
 }
 
 /**

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -275,13 +275,13 @@ function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TR
 }
 
 /**
- * Resolve the WebDriver (chromedriver) endpoint port with source tracking.
+ * Resolve the WebDriver endpoint port with source tracking.
  *
  * Mirrors the port half of resolve_webserver() for 'WEBDRIVER_PORT':
  * shell env first, then a matching key in the dotenv file, then the
  * default. With auto_discover and no configured value, a free port is
  * allocated from 4444 and persisted to the dotenv file so that several
- * projects each get their own chromedriver endpoint and never contend
+ * projects each get their own WebDriver endpoint and never contend
  * for a single port.
  *
  * @param bool $auto_discover

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -45,10 +45,8 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `ahoy test-functional` - Run functional tests only
 - `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 - `ahoy test-js` - Run JavaScript unit tests (Jest)
-- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-- `ahoy chromedriver-stop` - Stop chromedriver
-- `ahoy selenium-start` - Start Selenium container
-- `ahoy selenium-stop` - Stop Selenium container
+- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+- `ahoy browser-stop` - Stop the browser
 
 ### Drupal Commands
 
@@ -86,7 +84,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `WEBSERVER_HOST` - Development server host (default: localhost)
 - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 - `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
-- `WEBDRIVER_PORT` - Port for the `chromedriver` WebDriver endpoint. Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
 - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
 - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
 

--- a/.scaffold/tests/fixtures/init/_baseline/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/_baseline/CONTRIBUTING.md
@@ -159,7 +159,7 @@ Docker is required:
 ahoy start
 ahoy provision
 ahoy test-functional-javascript
-ahoy chromedriver-stop
+ahoy browser-stop
 ```
 
 To run the browser in a Docker Selenium container instead, set
@@ -170,7 +170,7 @@ To run the browser in a Docker Selenium container instead, set
 WEBSERVER_HOST=__VERSION__.0 ahoy start
 ahoy provision
 WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
-ahoy selenium-stop
+ahoy browser-stop
 ```
 
 ### Running specific tests

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/FunctionalJavascript/ForceCrystalJsTestBase.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/FunctionalJavascript/ForceCrystalJsTestBase.php
@@ -64,11 +64,10 @@ abstract class ForceCrystalJsTestBase extends WebDriverTestBase {
     }
 
     // The WebDriver endpoint is always reachable at 'localhost'; only the
-    // port varies. The 'chromedriver' backend uses a per-project port
-    // (WEBDRIVER_PORT, auto-discovered by '.devtools/chromedriver'), while
-    // the 'selenium' container is always published on 4444.
+    // port varies. Both backends serve the endpoint on the per-project
+    // port resolved by '.devtools/browser' (WEBDRIVER_PORT, default 4444).
     $backend = getenv('WEBDRIVER_BACKEND') ?: 'chromedriver';
-    $port = $backend === 'selenium' ? '4444' : (getenv('WEBDRIVER_PORT') ?: '4444');
+    $port = getenv('WEBDRIVER_PORT') ?: '4444';
     $decoded[2] = 'http://localhost:' . $port;
 
     // The 'chromedriver' backend drives the host's Chrome directly, so it must

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/AGENTS.md
@@ -31,7 +31,7 @@
  
  **Using Ahoy (alternative):**
  - `ahoy build` - Complete build process
-@@ -35,10 +53,22 @@
+@@ -35,10 +53,20 @@
  ### Code Quality
  
  **Linting:**
@@ -47,14 +47,12 @@
 +- `make test-functional` - Run functional tests only
 +- `make test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 +- `make test-js` - Run JavaScript unit tests (Jest)
-+- `make chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-+- `make chromedriver-stop` - Stop chromedriver
-+- `make selenium-start` - Start Selenium container
-+- `make selenium-stop` - Stop Selenium container
++- `make browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
++- `make browser-stop` - Stop the browser
  - `ahoy test` - Run all tests
  - `ahoy test-unit` - Run unit tests only
  - `ahoy test-kernel` - Run kernel tests only
-@@ -52,11 +82,14 @@
+@@ -50,11 +78,14 @@
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -26,7 +26,7 @@ endef
 
 .PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
-.PHONY: test-functional-javascript chromedriver-start chromedriver-stop selenium-start selenium-stop
+.PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
 
 help:
@@ -49,10 +49,8 @@ help:
 	@echo "test-functional-javascript - Run FunctionalJavascript tests."
 	@echo "test-kernel                - Run kernel tests."
 	@echo "test-unit                  - Run unit tests."
-	@echo "chromedriver-start         - Start chromedriver against the local Chrome."
-	@echo "chromedriver-stop          - Stop chromedriver."
-	@echo "selenium-start             - Start Selenium container."
-	@echo "selenium-stop              - Stop Selenium container."
+	@echo "browser-start              - Start the browser for FunctionalJavascript tests."
+	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
 build: stop assemble start provision
@@ -155,34 +153,17 @@ test-functional:
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
-	@if [ "$${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then $(MAKE) selenium-start; else $(MAKE) chromedriver-start; fi
+	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
-chromedriver-start:
-	./.devtools/chromedriver start
+browser-start:
+	./.devtools/browser start
 
-chromedriver-stop:
-	./.devtools/chromedriver stop
-
-selenium-start:
-	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-		echo "Selenium container is already running."; \
-	else \
-		docker rm -f selenium 2>/dev/null || true; \
-		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
-		echo "Waiting for Selenium to be ready..."; \
-		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
-		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
-			exit 1; \
-		fi; \
-	fi
-
-selenium-stop:
-	docker rm -f selenium 2>/dev/null || true
+browser-stop:
+	./.devtools/browser stop
 
 test-js:
 	pushd "build" >/dev/null || exit 1 && \

--- a/.scaffold/tests/fixtures/init/circleci_makefile/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -10,54 +10,56 @@
+@@ -10,52 +10,54 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
@@ -56,20 +56,16 @@
 -- `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 -- `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
 +- `make test` - Run all tests
 +- `make test-unit` - Run unit tests only
 +- `make test-kernel` - Run kernel tests only
 +- `make test-functional` - Run functional tests only
 +- `make test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 +- `make test-js` - Run JavaScript unit tests (Jest)
-+- `make chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-+- `make chromedriver-stop` - Stop chromedriver
-+- `make selenium-start` - Start Selenium container
-+- `make selenium-stop` - Stop Selenium container
++- `make browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
++- `make browser-stop` - Stop the browser
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -26,7 +26,7 @@ endef
 
 .PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
-.PHONY: test-functional-javascript chromedriver-start chromedriver-stop selenium-start selenium-stop
+.PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
 
 help:
@@ -49,10 +49,8 @@ help:
 	@echo "test-functional-javascript - Run FunctionalJavascript tests."
 	@echo "test-kernel                - Run kernel tests."
 	@echo "test-unit                  - Run unit tests."
-	@echo "chromedriver-start         - Start chromedriver against the local Chrome."
-	@echo "chromedriver-stop          - Stop chromedriver."
-	@echo "selenium-start             - Start Selenium container."
-	@echo "selenium-stop              - Stop Selenium container."
+	@echo "browser-start              - Start the browser for FunctionalJavascript tests."
+	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
 build: stop assemble start provision
@@ -155,34 +153,17 @@ test-functional:
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
-	@if [ "$${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then $(MAKE) selenium-start; else $(MAKE) chromedriver-start; fi
+	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
-chromedriver-start:
-	./.devtools/chromedriver start
+browser-start:
+	./.devtools/browser start
 
-chromedriver-stop:
-	./.devtools/chromedriver stop
-
-selenium-start:
-	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-		echo "Selenium container is already running."; \
-	else \
-		docker rm -f selenium 2>/dev/null || true; \
-		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
-		echo "Waiting for Selenium to be ready..."; \
-		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
-		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
-			exit 1; \
-		fi; \
-	fi
-
-selenium-stop:
-	docker rm -f selenium 2>/dev/null || true
+browser-stop:
+	./.devtools/browser stop
 
 test-js:
 	pushd "build" >/dev/null || exit 1 && \

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -11,53 +11,22 @@
+@@ -11,51 +11,22 @@
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
  
@@ -36,10 +36,8 @@
 -- `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 -- `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/AGENTS.md
@@ -31,7 +31,7 @@
  
  **Using Ahoy (alternative):**
  - `ahoy build` - Complete build process
-@@ -35,10 +53,22 @@
+@@ -35,10 +53,20 @@
  ### Code Quality
  
  **Linting:**
@@ -47,14 +47,12 @@
 +- `make test-functional` - Run functional tests only
 +- `make test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 +- `make test-js` - Run JavaScript unit tests (Jest)
-+- `make chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-+- `make chromedriver-stop` - Stop chromedriver
-+- `make selenium-start` - Start Selenium container
-+- `make selenium-stop` - Stop Selenium container
++- `make browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
++- `make browser-stop` - Stop the browser
  - `ahoy test` - Run all tests
  - `ahoy test-unit` - Run unit tests only
  - `ahoy test-kernel` - Run kernel tests only
-@@ -52,11 +82,14 @@
+@@ -50,11 +78,14 @@
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -26,7 +26,7 @@ endef
 
 .PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
-.PHONY: test-functional-javascript chromedriver-start chromedriver-stop selenium-start selenium-stop
+.PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
 
 help:
@@ -49,10 +49,8 @@ help:
 	@echo "test-functional-javascript - Run FunctionalJavascript tests."
 	@echo "test-kernel                - Run kernel tests."
 	@echo "test-unit                  - Run unit tests."
-	@echo "chromedriver-start         - Start chromedriver against the local Chrome."
-	@echo "chromedriver-stop          - Stop chromedriver."
-	@echo "selenium-start             - Start Selenium container."
-	@echo "selenium-stop              - Stop Selenium container."
+	@echo "browser-start              - Start the browser for FunctionalJavascript tests."
+	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
 build: stop assemble start provision
@@ -155,34 +153,17 @@ test-functional:
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
-	@if [ "$${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then $(MAKE) selenium-start; else $(MAKE) chromedriver-start; fi
+	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
-chromedriver-start:
-	./.devtools/chromedriver start
+browser-start:
+	./.devtools/browser start
 
-chromedriver-stop:
-	./.devtools/chromedriver stop
-
-selenium-start:
-	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-		echo "Selenium container is already running."; \
-	else \
-		docker rm -f selenium 2>/dev/null || true; \
-		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
-		echo "Waiting for Selenium to be ready..."; \
-		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
-		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
-			exit 1; \
-		fi; \
-	fi
-
-selenium-stop:
-	docker rm -f selenium 2>/dev/null || true
+browser-stop:
+	./.devtools/browser stop
 
 test-js:
 	pushd "build" >/dev/null || exit 1 && \

--- a/.scaffold/tests/fixtures/init/gha_makefile/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_makefile/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -10,54 +10,56 @@
+@@ -10,52 +10,54 @@
  
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
@@ -56,20 +56,16 @@
 -- `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 -- `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
 +- `make test` - Run all tests
 +- `make test-unit` - Run unit tests only
 +- `make test-kernel` - Run kernel tests only
 +- `make test-functional` - Run functional tests only
 +- `make test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 +- `make test-js` - Run JavaScript unit tests (Jest)
-+- `make chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-+- `make chromedriver-stop` - Stop chromedriver
-+- `make selenium-start` - Start Selenium container
-+- `make selenium-stop` - Stop Selenium container
++- `make browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
++- `make browser-stop` - Stop the browser
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -26,7 +26,7 @@ endef
 
 .PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
-.PHONY: test-functional-javascript chromedriver-start chromedriver-stop selenium-start selenium-stop
+.PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
 
 help:
@@ -49,10 +49,8 @@ help:
 	@echo "test-functional-javascript - Run FunctionalJavascript tests."
 	@echo "test-kernel                - Run kernel tests."
 	@echo "test-unit                  - Run unit tests."
-	@echo "chromedriver-start         - Start chromedriver against the local Chrome."
-	@echo "chromedriver-stop          - Stop chromedriver."
-	@echo "selenium-start             - Start Selenium container."
-	@echo "selenium-stop              - Stop Selenium container."
+	@echo "browser-start              - Start the browser for FunctionalJavascript tests."
+	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
 build: stop assemble start provision
@@ -155,34 +153,17 @@ test-functional:
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
-	@if [ "$${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then $(MAKE) selenium-start; else $(MAKE) chromedriver-start; fi
+	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
-chromedriver-start:
-	./.devtools/chromedriver start
+browser-start:
+	./.devtools/browser start
 
-chromedriver-stop:
-	./.devtools/chromedriver stop
-
-selenium-start:
-	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-		echo "Selenium container is already running."; \
-	else \
-		docker rm -f selenium 2>/dev/null || true; \
-		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
-		echo "Waiting for Selenium to be ready..."; \
-		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
-		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
-			exit 1; \
-		fi; \
-	fi
-
-selenium-stop:
-	docker rm -f selenium 2>/dev/null || true
+browser-stop:
+	./.devtools/browser stop
 
 test-js:
 	pushd "build" >/dev/null || exit 1 && \

--- a/.scaffold/tests/fixtures/init/gha_no_command_wrapper/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/gha_no_command_wrapper/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -11,53 +11,22 @@
+@@ -11,51 +11,22 @@
  **HARD RULE - use the provided command wrappers, never the tool binaries directly.** When `make` or `ahoy` exposes a command for a task, use that command; do not call the underlying binary directly. Each wrapper `chdir`s into `build/` and runs the tool with the config, plugins, and environment that CI uses, so a raw invocation from the repository root silently diverges from CI - it can pass locally while CI fails (or vice versa), or crash outright when a relative path resolves against the wrong directory. If no wrapped command covers what you need, extend the `make` / `ahoy` target rather than making a one-off raw call; if that is not feasible, stop and ask.
  
  
@@ -36,10 +36,8 @@
 -- `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 -- `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
  
  ### Drupal Commands
  

--- a/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_cspell/AGENTS.md
@@ -6,7 +6,7 @@
  - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
  - **Jest**: `ahoy test-js` - never `npx jest`.
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
-@@ -101,7 +100,6 @@
+@@ -99,7 +98,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
@@ -1,53 +1,29 @@
-@@ -117,18 +117,6 @@
+@@ -117,14 +117,6 @@
        php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional "$@"
        popd >/dev/null || exit 1
  
 -  test-functional-javascript:
 -    usage: Run FunctionalJavascript tests.
 -    cmd: |
--      if [ "${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then
--        ahoy selenium-start || exit 1
--      else
--        ahoy chromedriver-start || exit 1
--        export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
--      fi
+-      ahoy browser-start || exit 1
+-      export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
 -      pushd "build" >/dev/null || exit 1
 -      php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
 -      popd >/dev/null || exit 1
  
    test-js:
      usage: Run JavaScript unit tests.
-@@ -137,33 +125,6 @@
+@@ -133,13 +125,6 @@
        [ ! -d node_modules ] || npm test
        popd >/dev/null || exit 1
  
--  chromedriver-start:
--    usage: Start chromedriver against the locally installed Chrome if not already running.
--    cmd: ./.devtools/chromedriver start
+-  browser-start:
+-    usage: Start the browser for FunctionalJavascript tests if not already running.
+-    cmd: ./.devtools/browser start
 -
--  chromedriver-stop:
--    usage: Stop chromedriver.
--    cmd: ./.devtools/chromedriver stop
--
--  selenium-start:
--    usage: Start Selenium container if not already running.
--    cmd: |
--      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
--        echo "Selenium container is already running."
--        exit 0
--      fi
--      docker rm -f selenium 2>/dev/null || true
--      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
--      echo "Waiting for Selenium to be ready..."
--      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
--      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
--        echo "ERROR: Selenium failed to become ready after 30 seconds."
--        exit 1
--      fi
--
--  selenium-stop:
--    usage: Stop Selenium container.
--    cmd: docker rm -f selenium 2>/dev/null || true
+-  browser-stop:
+-    usage: Stop the browser used for FunctionalJavascript tests.
+-    cmd: ./.devtools/browser stop
  
    reset:
      usage: Reset project to the default state.

--- a/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_funcjs/AGENTS.md
@@ -1,22 +1,20 @@
-@@ -43,12 +43,7 @@
+@@ -43,10 +43,7 @@
  - `ahoy test-unit` - Run unit tests only
  - `ahoy test-kernel` - Run kernel tests only
  - `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
  - `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
  
  ### Drupal Commands
  
-@@ -85,8 +80,6 @@
+@@ -83,8 +80,6 @@
  - `DRUPAL_VERSION` - Target Drupal version (e.g., `10`, `11`, `11@alpha`)
  - `WEBSERVER_HOST` - Development server host (default: localhost)
  - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 -- `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
--- `WEBDRIVER_PORT` - Port for the `chromedriver` WebDriver endpoint. Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
  - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
  - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
  

--- a/.scaffold/tests/fixtures/init/no_funcjs/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_funcjs/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 -ahoy start
 -ahoy provision
 -ahoy test-functional-javascript
--ahoy chromedriver-stop
+-ahoy browser-stop
 -```
 -
 -To run the browser in a Docker Selenium container instead, set
@@ -32,7 +32,7 @@
 -WEBSERVER_HOST=__VERSION__.0 ahoy start
 -ahoy provision
 -WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
--ahoy selenium-stop
+-ahoy browser-stop
  ```
  
  ### Running specific tests

--- a/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
@@ -6,7 +6,7 @@
        popd >/dev/null || exit 1
  
    test-unit:
-@@ -130,12 +129,6 @@
+@@ -126,12 +125,6 @@
        php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
        popd >/dev/null || exit 1
  
@@ -17,5 +17,5 @@
 -      [ ! -d node_modules ] || npm test
 -      popd >/dev/null || exit 1
  
-   chromedriver-start:
-     usage: Start chromedriver against the locally installed Chrome if not already running.
+   browser-start:
+     usage: Start the browser for FunctionalJavascript tests if not already running.

--- a/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_jest/AGENTS.md
@@ -11,6 +11,6 @@
  - `ahoy test-functional` - Run functional tests only
  - `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 -- `ahoy test-js` - Run JavaScript unit tests (Jest)
- - `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
- - `ahoy chromedriver-stop` - Stop chromedriver
- - `ahoy selenium-start` - Start Selenium container
+ - `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+ - `ahoy browser-stop` - Stop the browser
+ 

--- a/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_php_lint/AGENTS.md
@@ -9,7 +9,7 @@
  - **ESLint / Stylelint**: `ahoy lint` / `ahoy lint-fix` - never `npx eslint` or `npx stylelint`.
  - **CSpell**: `ahoy lint` - never `npx cspell`.
  - **PHPUnit**: `ahoy test` / `ahoy test-unit` / `ahoy test-kernel` / `ahoy test-functional` - never `vendor/bin/phpunit`.
-@@ -102,10 +98,6 @@
+@@ -100,10 +96,6 @@
  ## Code Quality Tools
  
  - **CSpell**: Spell checking across the codebase (config at `.cspell.json`)

--- a/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -91,45 +91,11 @@
+@@ -91,41 +91,11 @@
      usage: Run tests.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -31,12 +31,8 @@
 -  test-functional-javascript:
 -    usage: Run FunctionalJavascript tests.
 -    cmd: |
--      if [ "${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then
--        ahoy selenium-start || exit 1
--      else
--        ahoy chromedriver-start || exit 1
--        export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
--      fi
+-      ahoy browser-start || exit 1
+-      export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
 -      pushd "build" >/dev/null || exit 1
 -      php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
 -      popd >/dev/null || exit 1
@@ -44,37 +40,17 @@
    test-js:
      usage: Run JavaScript unit tests.
      cmd: |
-@@ -137,33 +103,6 @@
+@@ -133,13 +103,6 @@
        [ ! -d node_modules ] || npm test
        popd >/dev/null || exit 1
  
--  chromedriver-start:
--    usage: Start chromedriver against the locally installed Chrome if not already running.
--    cmd: ./.devtools/chromedriver start
+-  browser-start:
+-    usage: Start the browser for FunctionalJavascript tests if not already running.
+-    cmd: ./.devtools/browser start
 -
--  chromedriver-stop:
--    usage: Stop chromedriver.
--    cmd: ./.devtools/chromedriver stop
--
--  selenium-start:
--    usage: Start Selenium container if not already running.
--    cmd: |
--      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
--        echo "Selenium container is already running."
--        exit 0
--      fi
--      docker rm -f selenium 2>/dev/null || true
--      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
--      echo "Waiting for Selenium to be ready..."
--      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
--      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
--        echo "ERROR: Selenium failed to become ready after 30 seconds."
--        exit 1
--      fi
--
--  selenium-stop:
--    usage: Stop Selenium container.
--    cmd: docker rm -f selenium 2>/dev/null || true
+-  browser-stop:
+-    usage: Stop the browser used for FunctionalJavascript tests.
+-    cmd: ./.devtools/browser stop
  
    reset:
      usage: Reset project to the default state.

--- a/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
@@ -6,7 +6,7 @@
  - **Jest**: `ahoy test-js` - never `npx jest`.
  - **Drush**: `ahoy drush <command>` - never `build/vendor/bin/drush` directly.
  
-@@ -40,15 +39,7 @@
+@@ -40,13 +39,7 @@
  
  **Testing:**
  - `ahoy test` - Run all tests
@@ -15,14 +15,12 @@
 -- `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
  - `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
  
  ### Drupal Commands
  
-@@ -63,7 +54,6 @@
+@@ -61,7 +54,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)
@@ -30,12 +28,12 @@
  - `config/schema/` - Configuration schema definitions
  - `build/` - Assembled Drupal codebase (symlinked extension)
  - `.devtools/` - Build and deployment scripts used by CI
-@@ -85,8 +75,6 @@
+@@ -83,8 +75,6 @@
  - `DRUPAL_VERSION` - Target Drupal version (e.g., `10`, `11`, `11@alpha`)
  - `WEBSERVER_HOST` - Development server host (default: localhost)
  - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 -- `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
--- `WEBDRIVER_PORT` - Port for the `chromedriver` WebDriver endpoint. Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
  - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
  - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
  

--- a/.scaffold/tests/fixtures/init/no_phpunit/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/CONTRIBUTING.md
@@ -32,7 +32,7 @@
 -ahoy start
 -ahoy provision
 -ahoy test-functional-javascript
--ahoy chromedriver-stop
+-ahoy browser-stop
 -```
 -
 -To run the browser in a Docker Selenium container instead, set
@@ -43,7 +43,7 @@
 -WEBSERVER_HOST=__VERSION__.0 ahoy start
 -ahoy provision
 -WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
--ahoy selenium-stop
+-ahoy browser-stop
 -```
 -
 -### Running specific tests

--- a/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
@@ -30,7 +30,7 @@
        popd >/dev/null || exit 1
  
    test:
-@@ -91,79 +72,11 @@
+@@ -91,55 +72,11 @@
      usage: Run tests.
      cmd: |
        pushd "build" >/dev/null || exit 1
@@ -63,12 +63,8 @@
 -  test-functional-javascript:
 -    usage: Run FunctionalJavascript tests.
 -    cmd: |
--      if [ "${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then
--        ahoy selenium-start || exit 1
--      else
--        ahoy chromedriver-start || exit 1
--        export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
--      fi
+-      ahoy browser-start || exit 1
+-      export WEBDRIVER_PORT="$(./.devtools/info webdriver-port)"
 -      pushd "build" >/dev/null || exit 1
 -      php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
 -      popd >/dev/null || exit 1
@@ -80,33 +76,13 @@
 -      [ ! -d node_modules ] || npm test
 -      popd >/dev/null || exit 1
 -
--  chromedriver-start:
--    usage: Start chromedriver against the locally installed Chrome if not already running.
--    cmd: ./.devtools/chromedriver start
+-  browser-start:
+-    usage: Start the browser for FunctionalJavascript tests if not already running.
+-    cmd: ./.devtools/browser start
 -
--  chromedriver-stop:
--    usage: Stop chromedriver.
--    cmd: ./.devtools/chromedriver stop
--
--  selenium-start:
--    usage: Start Selenium container if not already running.
--    cmd: |
--      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
--        echo "Selenium container is already running."
--        exit 0
--      fi
--      docker rm -f selenium 2>/dev/null || true
--      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest
--      echo "Waiting for Selenium to be ready..."
--      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
--      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
--        echo "ERROR: Selenium failed to become ready after 30 seconds."
--        exit 1
--      fi
--
--  selenium-stop:
--    usage: Stop Selenium container.
--    cmd: docker rm -f selenium 2>/dev/null || true
+-  browser-stop:
+-    usage: Stop the browser used for FunctionalJavascript tests.
+-    cmd: ./.devtools/browser stop
  
    reset:
      usage: Reset project to the default state.

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -30,7 +30,7 @@
  
  **Using Ahoy (alternative):**
  - `ahoy build` - Complete build process
-@@ -35,28 +37,25 @@
+@@ -35,26 +37,25 @@
  ### Code Quality
  
  **Linting:**
@@ -47,10 +47,8 @@
 -- `ahoy test-functional` - Run functional tests only
 -- `ahoy test-functional-javascript` - Run FunctionalJavascript tests (uses the local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
 -- `ahoy test-js` - Run JavaScript unit tests (Jest)
--- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
--- `ahoy chromedriver-stop` - Stop chromedriver
--- `ahoy selenium-start` - Start Selenium container
--- `ahoy selenium-stop` - Stop Selenium container
+-- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+-- `ahoy browser-stop` - Stop the browser
  
  ### Drupal Commands
  
@@ -65,7 +63,7 @@
  - `ahoy info` - Print a read-only summary of PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source), XDebug state, build directory, database path, and active profile. (alias: `ahoy describe`)
  
  ## Project Structure
-@@ -63,7 +62,6 @@
+@@ -61,7 +62,6 @@
  
  **Key Directories:**
  - `src/` - Extension source code (services, forms, etc.)
@@ -73,16 +71,16 @@
  - `config/schema/` - Configuration schema definitions
  - `build/` - Assembled Drupal codebase (symlinked extension)
  - `.devtools/` - Build and deployment scripts used by CI
-@@ -85,8 +83,6 @@
+@@ -83,8 +83,6 @@
  - `DRUPAL_VERSION` - Target Drupal version (e.g., `10`, `11`, `11@alpha`)
  - `WEBSERVER_HOST` - Development server host (default: localhost)
  - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 -- `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
--- `WEBDRIVER_PORT` - Port for the `chromedriver` WebDriver endpoint. Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
  - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
  - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
  
-@@ -101,11 +97,6 @@
+@@ -99,11 +97,6 @@
  
  ## Code Quality Tools
  

--- a/.scaffold/tests/fixtures/init/no_tools/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_tools/CONTRIBUTING.md
@@ -45,7 +45,7 @@
 -ahoy start
 -ahoy provision
 -ahoy test-functional-javascript
--ahoy chromedriver-stop
+-ahoy browser-stop
 -```
 -
 -To run the browser in a Docker Selenium container instead, set
@@ -56,7 +56,7 @@
 -WEBSERVER_HOST=__VERSION__.0 ahoy start
 -ahoy provision
 -WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
--ahoy selenium-stop
+-ahoy browser-stop
 -```
 -
 -### Running specific tests

--- a/.scaffold/tests/phpunit.xml
+++ b/.scaffold/tests/phpunit.xml
@@ -28,7 +28,7 @@
         <include>
             <file>../../.devtools/helpers.php</file>
             <file>../../.devtools/assemble</file>
-            <file>../../.devtools/chromedriver</file>
+            <file>../../.devtools/browser</file>
             <file>../../.devtools/deploy</file>
             <file>../../.devtools/provision</file>
             <file>../../.devtools/start</file>

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -10,24 +10,56 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
- * Tests for the .devtools/chromedriver script.
+ * Tests for the .devtools/browser script.
  *
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */
 #[RunTestsInSeparateProcesses]
 #[Group('p0')]
-final class ChromedriverTest extends UnitTestCase {
+final class BrowserTest extends UnitTestCase {
+
+  protected string $envFileContent = "WEBDRIVER_PORT=4444\n";
+
+  protected string $installLogContent = "chromedriver@150.0.7871.129 /cache/chromedriver\n";
+
+  /**
+   * @var array<int, bool>
+   */
+  protected array $readySequence = [FALSE];
+
+  protected int $readyIndex = 0;
 
   protected function setUp(): void {
     parent::setUp();
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
     self::envUnset('WEBDRIVER_PORT');
+    self::envUnset('WEBDRIVER_BACKEND');
 
     // The '.env' file exists and supplies port 4444, so the port resolves
-    // without touching the free-port probe. Directory creation and sleeps
-    // are no-ops.
+    // without touching the free-port probe. Readiness probes against the
+    // WebDriver '/status' endpoint are answered from $readySequence, with
+    // the last value repeating for further calls. Directory creation and
+    // sleeps are no-ops.
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $f): bool => $f === '.env');
+    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', function (string $f): string|false {
+      if ($f === '.env') {
+        return $this->envFileContent;
+      }
+
+      if (str_contains($f, 'install.log')) {
+        return $this->installLogContent === '' ? FALSE : $this->installLogContent;
+      }
+
+      if (str_starts_with($f, 'http://localhost:')) {
+        $ready = $this->readySequence[$this->readyIndex] ?? end($this->readySequence);
+        $this->readyIndex++;
+
+        return $ready ? '{"value": {"ready": true, "message": "ready"}}' : FALSE;
+      }
+
+      return FALSE;
+    });
     $this->registerMock('mkdir', 'DrupalExtensionScaffold\\DevTools', fn(): bool => TRUE);
     $this->mockSleep();
   }
@@ -38,24 +70,28 @@ final class ChromedriverTest extends UnitTestCase {
   }
 
   public function testUnknownCommand(): void {
-    $this->mockFiles();
-
-    $output = $this->runChromedriver('bogus', 1);
+    $output = $this->runBrowser('bogus', 1);
 
     $this->assertStringContainsString("Unknown command 'bogus'", $output);
   }
 
+  public function testUnknownBackend(): void {
+    self::envSet('WEBDRIVER_BACKEND', 'firefox');
+
+    $output = $this->runBrowser('start', 1);
+
+    $this->assertStringContainsString("Unknown WEBDRIVER_BACKEND 'firefox'", $output);
+  }
+
   public function testStartAlreadyRunning(): void {
-    $this->mockFiles();
     $this->mockReady([TRUE]);
 
-    $output = $this->runChromedriver('start', 0);
+    $output = $this->runBrowser('start', 0);
 
     $this->assertStringContainsString('already running on port 4444', $output);
   }
 
   public function testStartUsesMatchingInstalledDriver(): void {
-    $this->mockFiles();
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
@@ -63,7 +99,7 @@ final class ChromedriverTest extends UnitTestCase {
     $commands = [];
     $this->recordPassthru($commands);
 
-    $output = $this->runChromedriver('start', 0);
+    $output = $this->runBrowser('start', 0);
 
     $this->assertStringContainsString('Using installed chromedriver at /usr/local/bin/chromedriver', $output);
     $this->assertStringContainsString('chromedriver is ready on port 4444', $output);
@@ -76,7 +112,6 @@ final class ChromedriverTest extends UnitTestCase {
   }
 
   public function testStartFallsBackToNpxOnVersionMismatch(): void {
-    $this->mockFiles(log: "chromedriver@150.0.7871.129 /cache/chromedriver\n");
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver', 'npx' => '/usr/bin/npx']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 151.0.7922.34 (abc)');
@@ -84,7 +119,7 @@ final class ChromedriverTest extends UnitTestCase {
     $commands = [];
     $this->recordPassthru($commands);
 
-    $output = $this->runChromedriver('start', 0);
+    $output = $this->runBrowser('start', 0);
 
     $this->assertStringContainsString('does not match Chrome 150.0.7871.129', $output);
     $this->assertStringContainsString('chromedriver is ready on port 4444', $output);
@@ -93,7 +128,6 @@ final class ChromedriverTest extends UnitTestCase {
   }
 
   public function testStartUsesMacChromeWhenPresent(): void {
-    $this->mockFiles();
     $this->mockChrome(TRUE);
     $this->mockCommands(['chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
@@ -101,37 +135,34 @@ final class ChromedriverTest extends UnitTestCase {
     $commands = [];
     $this->recordPassthru($commands);
 
-    $output = $this->runChromedriver('start', 0);
+    $output = $this->runBrowser('start', 0);
 
     $this->assertStringContainsString('chromedriver is ready on port 4444', $output);
   }
 
   public function testStartFailsWhenChromeMissing(): void {
-    $this->mockFiles();
     $this->mockChrome(FALSE);
     $this->mockCommands([]);
     $this->mockVersions('', '');
     $this->mockReady([FALSE]);
 
-    $output = $this->runChromedriver('start', 1);
+    $output = $this->runBrowser('start', 1);
 
     $this->assertStringContainsString('Google Chrome or Chromium was not found', $output);
   }
 
   public function testStartFailsWhenMismatchAndNoNpx(): void {
-    $this->mockFiles();
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 151.0.7922.34 (abc)');
     $this->mockReady([FALSE]);
 
-    $output = $this->runChromedriver('start', 1);
+    $output = $this->runBrowser('start', 1);
 
     $this->assertStringContainsString('npx is unavailable', $output);
   }
 
   public function testStartFailsWhenNpxInstallFails(): void {
-    $this->mockFiles();
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'npx' => '/usr/bin/npx']);
     $this->mockVersions('Google Chrome 150.0.7871.129', '');
@@ -139,13 +170,13 @@ final class ChromedriverTest extends UnitTestCase {
     $commands = [];
     $this->recordPassthru($commands, npx_exit: 1);
 
-    $output = $this->runChromedriver('start', 1);
+    $output = $this->runBrowser('start', 1);
 
     $this->assertStringContainsString('Failed to install chromedriver', $output);
   }
 
   public function testStartFailsWhenBinaryPathUnresolved(): void {
-    $this->mockFiles(log: '');
+    $this->installLogContent = '';
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'npx' => '/usr/bin/npx']);
     $this->mockVersions('Google Chrome 150.0.7871.129', '');
@@ -153,13 +184,12 @@ final class ChromedriverTest extends UnitTestCase {
     $commands = [];
     $this->recordPassthru($commands);
 
-    $output = $this->runChromedriver('start', 1);
+    $output = $this->runBrowser('start', 1);
 
     $this->assertStringContainsString('Could not determine the chromedriver binary path', $output);
   }
 
   public function testStartFailsWhenNeverReady(): void {
-    $this->mockFiles();
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
@@ -167,37 +197,113 @@ final class ChromedriverTest extends UnitTestCase {
     $commands = [];
     $this->recordPassthru($commands);
 
-    $output = $this->runChromedriver('start', 1);
+    $output = $this->runBrowser('start', 1);
 
     $this->assertStringContainsString('failed to become ready on port 4444', $output);
   }
 
-  public function testStop(): void {
-    $this->mockFiles();
+  public function testSeleniumStartAlreadyRunning(): void {
+    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->mockReady([TRUE]);
+
+    $output = $this->runBrowser('start', 0);
+
+    $this->assertStringContainsString('Selenium is already running on port 4444', $output);
+  }
+
+  public function testSeleniumStartStartsContainer(): void {
+    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->mockCommands(['docker' => '/usr/bin/docker']);
+    $this->mockReady([FALSE, TRUE]);
     $commands = [];
     $this->recordPassthru($commands);
 
-    $output = $this->runChromedriver('stop', 0);
+    $output = $this->runBrowser('start', 0);
 
-    $this->assertStringContainsString('chromedriver stopped on port 4444', $output);
+    $this->assertStringContainsString('Selenium is ready on port 4444', $output);
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, 'docker rm -f')), 'A stale container must be removed before starting a new one.');
+    $run_commands = array_filter($commands, fn(string $c): bool => str_contains($c, 'docker run'));
+    $this->assertNotEmpty($run_commands, 'The Selenium container must be started.');
+    $run_command = (string) reset($run_commands);
+    $this->assertStringContainsString("'4444':4444", $run_command, 'The container must publish the resolved WebDriver port.');
+    $this->assertStringContainsString('standalone-chromium', $run_command);
+  }
+
+  public function testSeleniumStartFailsWithoutDocker(): void {
+    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->mockCommands([]);
+    $this->mockReady([FALSE]);
+
+    $output = $this->runBrowser('start', 1);
+
+    $this->assertStringContainsString('docker was not found', $output);
+  }
+
+  public function testSeleniumStartFailsWhenDockerRunFails(): void {
+    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->mockCommands(['docker' => '/usr/bin/docker']);
+    $this->mockReady([FALSE]);
+    $commands = [];
+    $this->recordPassthru($commands, docker_run_exit: 1);
+
+    $output = $this->runBrowser('start', 1);
+
+    $this->assertStringContainsString('Failed to start the Selenium container', $output);
+  }
+
+  public function testSeleniumStartFailsWhenNeverReady(): void {
+    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->mockCommands(['docker' => '/usr/bin/docker']);
+    $this->mockReady([FALSE]);
+    $commands = [];
+    $this->recordPassthru($commands);
+
+    $output = $this->runBrowser('start', 1);
+
+    $this->assertStringContainsString('Selenium failed to become ready on port 4444', $output);
+  }
+
+  public function testStopWithDocker(): void {
+    $this->mockCommands(['docker' => '/usr/bin/docker']);
+    $commands = [];
+    $this->recordPassthru($commands);
+
+    $output = $this->runBrowser('stop', 0);
+
+    $this->assertStringContainsString('Browser stopped on port 4444', $output);
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, 'docker rm -f')), 'The Selenium container must be removed.');
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "lsof -ti:'4444'")), 'The WebDriver process on the resolved port must be terminated.');
+  }
+
+  public function testStopWithoutDocker(): void {
+    $this->mockCommands([]);
+    $commands = [];
+    $this->recordPassthru($commands);
+
+    $output = $this->runBrowser('stop', 0);
+
+    $this->assertStringContainsString('Browser stopped on port 4444', $output);
     $this->assertNotEmpty($commands);
-    $this->assertStringContainsString("lsof -ti:'4444'", $commands[0]);
+    foreach ($commands as $command) {
+      $this->assertStringNotContainsString('docker', $command, 'Docker must not be invoked when it is not installed.');
+    }
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "lsof -ti:'4444'")), 'The WebDriver process on the resolved port must be terminated.');
   }
 
   // ---------------------------------------------------------------------------
   // Helpers.
   // ---------------------------------------------------------------------------
 
-  protected function runChromedriver(string $subcommand, int $expected_exit): string {
+  protected function runBrowser(string $subcommand, int $expected_exit): string {
     $this->mockQuit($expected_exit);
 
     // The included script inherits this scope, so it reads $argv from here.
-    $argv = ['chromedriver', $subcommand];
+    $argv = ['browser', $subcommand];
 
     ob_start();
     try {
-      require dirname(__DIR__, 4) . '/.devtools/chromedriver';
-      $this->fail('Expected chromedriver to call quit().');
+      require dirname(__DIR__, 4) . '/.devtools/browser';
+      $this->fail('Expected browser to call quit().');
     }
     catch (QuitSuccessException | QuitErrorException $e) {
       $this->assertSame($expected_exit, $e->getCode());
@@ -209,17 +315,13 @@ final class ChromedriverTest extends UnitTestCase {
     return $output;
   }
 
-  protected function mockFiles(string $env = "WEBDRIVER_PORT=4444\n", string $log = "chromedriver@150.0.7871.129 /cache/chromedriver\n"): void {
-    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', function (string $f) use ($env, $log): string|false {
-      if ($f === '.env') {
-        return $env;
-      }
-      if (str_contains($f, 'install.log')) {
-        return $log === '' ? FALSE : $log;
-      }
-
-      return FALSE;
-    });
+  /**
+   * @param array<int, bool> $sequence
+   *   Readiness result per call; the last value repeats for further calls.
+   */
+  protected function mockReady(array $sequence): void {
+    $this->readySequence = $sequence;
+    $this->readyIndex = 0;
   }
 
   protected function mockChrome(bool $mac_present): void {
@@ -257,28 +359,17 @@ final class ChromedriverTest extends UnitTestCase {
   }
 
   /**
-   * @param array<int, bool> $sequence
-   *   Readiness result per call; the last value repeats for further calls.
-   */
-  protected function mockReady(array $sequence): void {
-    $index = 0;
-    $this->registerMock('get_headers', 'DrupalExtensionScaffold\\DevTools', function () use (&$index, $sequence): array|false {
-      $ready = $sequence[$index] ?? end($sequence);
-      $index++;
-
-      return $ready ? ['HTTP/1.1 200 OK'] : FALSE;
-    });
-  }
-
-  /**
    * @param array<int, string> $commands
    *   Populated by reference with every passthru() command line.
    */
-  protected function recordPassthru(array &$commands, int $npx_exit = 0): void {
-    $this->registerMock('passthru', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, &$result_code = NULL) use (&$commands, $npx_exit): void {
+  protected function recordPassthru(array &$commands, int $npx_exit = 0, int $docker_run_exit = 0): void {
+    $this->registerMock('passthru', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, &$result_code = NULL) use (&$commands, $npx_exit, $docker_run_exit): void {
       $commands[] = $cmd;
       if (str_contains($cmd, 'npx')) {
         $result_code = $npx_exit;
+      }
+      if (str_contains($cmd, 'docker run')) {
+        $result_code = $docker_run_exit;
       }
     });
   }

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -226,6 +226,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertNotEmpty($run_commands, 'The Selenium container must be started.');
     $run_command = (string) reset($run_commands);
     $this->assertStringContainsString("'4444':4444", $run_command, 'The container must publish the resolved WebDriver port.');
+    $this->assertStringContainsString('--shm-size=2g', $run_command, 'The container must get the shared memory size Chromium needs.');
     $this->assertStringContainsString('standalone-chromium', $run_command);
   }
 

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -330,7 +330,7 @@ final class InitProcessTest extends UnitTestCase {
     // Selenium deps), per the normalisation in 'remove_tools()'.
     yield 'phpunit' => [
       ['phpunit'],
-      ['phpunit.xml', 'phpunit.d10.xml', 'tests', '.devtools/chromedriver'],
+      ['phpunit.xml', 'phpunit.d10.xml', 'tests', '.devtools/browser'],
       ['phpunit/phpunit', 'phpspec/prophecy-phpunit', 'mikey179/vfsstream', 'lullabot/mink-selenium2-driver', 'behat/mink'],
       [],
       ['vendor/bin/phpunit', 'selenium'],
@@ -338,7 +338,7 @@ final class InitProcessTest extends UnitTestCase {
 
     yield 'functional_javascript' => [
       ['functional_javascript'],
-      ['.devtools/chromedriver', 'tests/src/FunctionalJavascript'],
+      ['.devtools/browser', 'tests/src/FunctionalJavascript'],
       ['behat/mink', 'lullabot/mink-selenium2-driver', 'symfony/browser-kit'],
       [],
       ['selenium', 'functional-javascript'],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,8 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `make test-js` - Run JavaScript unit tests (Jest)
 <!-- #;> DEV_JEST -->
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
-- `make browser-start` - Start the WebDriver backend selected by `WEBDRIVER_BACKEND` (chromedriver against the locally installed Chrome by default, or the Selenium container)
-- `make browser-stop` - Stop the WebDriver backend
+- `make browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+- `make browser-stop` - Stop the browser
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 <!-- #;> DEV_MAKEFILE -->
 <!-- #;< DEV_AHOY -->
@@ -135,8 +135,8 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `ahoy test-js` - Run JavaScript unit tests (Jest)
 <!-- #;> DEV_JEST -->
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
-- `ahoy browser-start` - Start the WebDriver backend selected by `WEBDRIVER_BACKEND` (chromedriver against the locally installed Chrome by default, or the Selenium container)
-- `ahoy browser-stop` - Stop the WebDriver backend
+- `ahoy browser-start` - Start the browser for FunctionalJavascript tests (local Chrome by default; set `WEBDRIVER_BACKEND=selenium` for Docker)
+- `ahoy browser-stop` - Stop the browser
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 <!-- #;> DEV_AHOY -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,10 +117,8 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `make test-js` - Run JavaScript unit tests (Jest)
 <!-- #;> DEV_JEST -->
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
-- `make chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-- `make chromedriver-stop` - Stop chromedriver
-- `make selenium-start` - Start Selenium container
-- `make selenium-stop` - Stop Selenium container
+- `make browser-start` - Start the WebDriver backend selected by `WEBDRIVER_BACKEND` (chromedriver against the locally installed Chrome by default, or the Selenium container)
+- `make browser-stop` - Stop the WebDriver backend
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 <!-- #;> DEV_MAKEFILE -->
 <!-- #;< DEV_AHOY -->
@@ -137,10 +135,8 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `ahoy test-js` - Run JavaScript unit tests (Jest)
 <!-- #;> DEV_JEST -->
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
-- `ahoy chromedriver-start` - Start chromedriver against the locally installed Chrome (default backend)
-- `ahoy chromedriver-stop` - Stop chromedriver
-- `ahoy selenium-start` - Start Selenium container
-- `ahoy selenium-stop` - Stop Selenium container
+- `ahoy browser-start` - Start the WebDriver backend selected by `WEBDRIVER_BACKEND` (chromedriver against the locally installed Chrome by default, or the Selenium container)
+- `ahoy browser-stop` - Stop the WebDriver backend
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 <!-- #;> DEV_AHOY -->
 
@@ -194,7 +190,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
 - `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
-- `WEBDRIVER_PORT` - Port for the `chromedriver` WebDriver endpoint. Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
 - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails

--- a/CONTRIBUTING.dist.md
+++ b/CONTRIBUTING.dist.md
@@ -178,7 +178,7 @@ Docker is required:
 ahoy start
 ahoy provision
 ahoy test-functional-javascript
-ahoy chromedriver-stop
+ahoy browser-stop
 ```
 
 To run the browser in a Docker Selenium container instead, set
@@ -189,7 +189,7 @@ To run the browser in a Docker Selenium container instead, set
 WEBSERVER_HOST=0.0.0.0 ahoy start
 ahoy provision
 WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
-ahoy selenium-stop
+ahoy browser-stop
 ```
 
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endef
 .PHONY: test-unit test-kernel test-functional
 #;> DEV_PHPUNIT
 #;< DEV_FUNCTIONAL_JAVASCRIPT
-.PHONY: test-functional-javascript chromedriver-start chromedriver-stop selenium-start selenium-stop
+.PHONY: test-functional-javascript browser-start browser-stop
 #;> DEV_FUNCTIONAL_JAVASCRIPT
 #;< DEV_JEST
 .PHONY: test-js
@@ -62,10 +62,8 @@ help:
 	@echo "test-unit                  - Run unit tests."
 	@#;> DEV_PHPUNIT
 	@#;< DEV_FUNCTIONAL_JAVASCRIPT
-	@echo "chromedriver-start         - Start chromedriver against the local Chrome."
-	@echo "chromedriver-stop          - Stop chromedriver."
-	@echo "selenium-start             - Start Selenium container."
-	@echo "selenium-stop              - Stop Selenium container."
+	@echo "browser-start              - Start the WebDriver backend for FunctionalJavascript tests."
+	@echo "browser-stop               - Stop the WebDriver backend."
 	@#;> DEV_FUNCTIONAL_JAVASCRIPT
 	@#;< DEV_JEST
 	@echo "test-js                    - Run JavaScript unit tests."
@@ -198,7 +196,7 @@ test-functional:
 
 #;< DEV_FUNCTIONAL_JAVASCRIPT
 test-functional-javascript:
-	@if [ "$${WEBDRIVER_BACKEND:-chromedriver}" = "selenium" ]; then $(MAKE) selenium-start; else $(MAKE) chromedriver-start; fi
+	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
 	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
@@ -206,28 +204,11 @@ test-functional-javascript:
 #;> DEV_FUNCTIONAL_JAVASCRIPT
 
 #;< DEV_FUNCTIONAL_JAVASCRIPT
-chromedriver-start:
-	./.devtools/chromedriver start
+browser-start:
+	./.devtools/browser start
 
-chromedriver-stop:
-	./.devtools/chromedriver stop
-
-selenium-start:
-	@if curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-		echo "Selenium container is already running."; \
-	else \
-		docker rm -f selenium 2>/dev/null || true; \
-		docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:latest; \
-		echo "Waiting for Selenium to be ready..."; \
-		for i in $$(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done; \
-		if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then \
-			echo "ERROR: Selenium failed to become ready after 30 seconds."; \
-			exit 1; \
-		fi; \
-	fi
-
-selenium-stop:
-	docker rm -f selenium 2>/dev/null || true
+browser-stop:
+	./.devtools/browser stop
 #;> DEV_FUNCTIONAL_JAVASCRIPT
 
 #;< DEV_JEST

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ help:
 	@echo "test-unit                  - Run unit tests."
 	@#;> DEV_PHPUNIT
 	@#;< DEV_FUNCTIONAL_JAVASCRIPT
-	@echo "browser-start              - Start the WebDriver backend for FunctionalJavascript tests."
-	@echo "browser-stop               - Stop the WebDriver backend."
+	@echo "browser-start              - Start the browser for FunctionalJavascript tests."
+	@echo "browser-stop               - Stop the browser."
 	@#;> DEV_FUNCTIONAL_JAVASCRIPT
 	@#;< DEV_JEST
 	@echo "test-js                    - Run JavaScript unit tests."

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Docker is required:
 ahoy start
 ahoy provision
 ahoy test-functional-javascript
-ahoy chromedriver-stop
+ahoy browser-stop
 ```
 
 To run the browser in a Docker Selenium container instead, set
@@ -376,7 +376,7 @@ To run the browser in a Docker Selenium container instead, set
 WEBSERVER_HOST=0.0.0.0 ahoy start
 ahoy provision
 WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
-ahoy selenium-stop
+ahoy browser-stop
 ```
 
 ![Test process](.scaffold/assets/test.svg)

--- a/init.php
+++ b/init.php
@@ -673,7 +673,7 @@ function tool_specs(): array {
     ],
     'functional_javascript' => [
       'token' => 'DEV_FUNCTIONAL_JAVASCRIPT',
-      'files' => ['.devtools/chromedriver'],
+      'files' => ['.devtools/browser'],
       'dirs' => ['tests/src/FunctionalJavascript'],
       'composer_dev' => [
         'behat/mink',

--- a/tests/src/FunctionalJavascript/YourExtensionJsTestBase.php
+++ b/tests/src/FunctionalJavascript/YourExtensionJsTestBase.php
@@ -64,11 +64,10 @@ abstract class YourExtensionJsTestBase extends WebDriverTestBase {
     }
 
     // The WebDriver endpoint is always reachable at 'localhost'; only the
-    // port varies. The 'chromedriver' backend uses a per-project port
-    // (WEBDRIVER_PORT, auto-discovered by '.devtools/chromedriver'), while
-    // the 'selenium' container is always published on 4444.
+    // port varies. Both backends serve the endpoint on the per-project
+    // port resolved by '.devtools/browser' (WEBDRIVER_PORT, default 4444).
     $backend = getenv('WEBDRIVER_BACKEND') ?: 'chromedriver';
-    $port = $backend === 'selenium' ? '4444' : (getenv('WEBDRIVER_PORT') ?: '4444');
+    $port = getenv('WEBDRIVER_PORT') ?: '4444';
     $decoded[2] = 'http://localhost:' . $port;
 
     // The 'chromedriver' backend drives the host's Chrome directly, so it must


### PR DESCRIPTION
Follow-up to #339.

## Summary

Consolidates the FunctionalJavascript WebDriver backend commands. Previously there were four public commands (`chromedriver-start`, `chromedriver-stop`, `selenium-start`, `selenium-stop`) with the Selenium docker logic inlined as shell in both `.ahoy.yml` and `Makefile`, and a backend if/else duplicated in `test-functional-javascript` in both runners. `.devtools/chromedriver` is renamed to `.devtools/browser` and now owns backend dispatch itself via `WEBDRIVER_BACKEND`, exposing only `browser-start` and `browser-stop` to both runners. The readiness probe and Selenium container handling are also unified: `/status` is checked for a `"ready": true` body instead of a bare HTTP 200, Selenium now publishes the resolved `WEBDRIVER_PORT` instead of a hardcoded 4444, and the container runs with `--shm-size=2g` to prevent Chromium shared-memory crashes.

## Changes

### WebDriver backend script (`.devtools/browser`)
- Renamed from `.devtools/chromedriver`.
- `browser_start()` dispatches to `chromedriver_start()` or the new `selenium_start()` based on `webdriver_backend()`, which reads `WEBDRIVER_BACKEND` (default `chromedriver`) and calls `FAIL()` on any value other than `chromedriver` or `selenium`.
- `selenium_start()` absorbs the docker logic previously duplicated as inline shell in `.ahoy.yml` and `Makefile`: it removes a stale container, runs `docker run -d --name selenium --shm-size=2g -p <port>:4444 selenium/standalone-chromium:latest` on the resolved `WEBDRIVER_PORT`, and polls `/status` for up to 30 seconds. The `--shm-size=2g` mount is required because the default 64 MB `/dev/shm` is too small for Chromium and leads to tab crashes mid-test.
- `browser_stop()` replaces both `chromedriver_stop()` and `selenium-stop`. It is deliberately backend-agnostic: it always removes the Selenium container first (when `docker` is available), then kills whatever process still holds the resolved WebDriver port, because a bare stop after a Selenium run would otherwise kill the container's docker proxy instead of the container.
- `webdriver_ready()` now reads the `/status` response body via `file_get_contents()` and checks for `"ready": true` with a regex, instead of checking for an HTTP 200 status via `get_headers()`, because Selenium serves 200 before it can accept sessions.

### Command runners (`.ahoy.yml`, `Makefile`)
- `chromedriver-start`, `chromedriver-stop`, `selenium-start`, `selenium-stop` are replaced by `browser-start` and `browser-stop`, both delegating to `./.devtools/browser start` / `stop`.
- `test-functional-javascript` no longer branches on `WEBDRIVER_BACKEND` to pick a start command; it always calls `browser-start`, letting the script itself pick the backend.
- The inline Selenium docker shell block (container removal, `docker run -p 4444:4444`, polling loop) is removed from both runners now that it lives in `.devtools/browser`.
- The `browser-start` / `browser-stop` usage and `make help` strings describe starting and stopping the browser, keeping the WebDriver backend an implementation detail of the script.

### Test base class
- `tests/src/FunctionalJavascript/YourExtensionJsTestBase.php` no longer special-cases Selenium to port 4444; both backends now resolve the port from `WEBDRIVER_PORT` (default 4444).

### Docs
- `README.md`, `CONTRIBUTING.dist.md` (which now carries the consumer FunctionalJavascript walkthrough), and `AGENTS.md` are updated so both the chromedriver and Selenium walkthroughs end with `ahoy browser-stop`, and the environment variable table describes `WEBDRIVER_PORT` as shared by both backends.

### Scaffold tests
- `.scaffold/tests/src/Unit/ChromedriverTest.php` is renamed to `BrowserTest.php` and extended to 18 tests, adding coverage for an unknown `WEBDRIVER_BACKEND` value, Selenium already running, Selenium container start with `--shm-size=2g` and the resolved port, a missing `docker` binary, a failing `docker run`, Selenium never becoming ready, and separate stop assertions with and without `docker` present.
- `.scaffold/tests/src/Unit/InitProcessTest.php` and `init.php` are updated to reference `.devtools/browser` in the tool removal lists.
- `.scaffold/tests/phpunit.xml` coverage `<include>` is updated to `.devtools/browser`.
- `.github/workflows/scaffold-test.yml` pre-start step now calls `./.devtools/browser start`.
- Snapshot fixtures under `.scaffold/tests/fixtures/init/` are regenerated to match, including the `.devtools/chromedriver` to `.devtools/browser` rename and the corresponding `.ahoy.yml`, `Makefile`, `AGENTS.md`, and `README.md` content.

## Before / After

```
BEFORE
┌────────────────────┐      ┌────────────────────┐
│     .ahoy.yml      │      │      Makefile      │
├────────────────────┤      ├────────────────────┤
│ chromedriver-start │      │ chromedriver-start │
│ chromedriver-stop  │      │ chromedriver-stop  │
│ selenium-start     │      │ selenium-start     │
│ selenium-stop      │      │ selenium-stop      │
└────────────────────┘      └────────────────────┘
           ▼                           ▼
Both call .devtools/chromedriver (chromedriver only).

Selenium docker logic (container rm, docker run -p 4444:4444,
30s ready poll) is duplicated inline in BOTH files above.
Port is hardcoded to 4444 regardless of WEBDRIVER_PORT.

test-functional-javascript:
  WEBDRIVER_BACKEND=selenium -> selenium-start     (port fixed 4444)
  otherwise                  -> chromedriver-start (port WEBDRIVER_PORT)


AFTER
┌───────────────┐      ┌───────────────┐
│   .ahoy.yml   │      │   Makefile    │
├───────────────┤      ├───────────────┤
│ browser-start │      │ browser-start │
│ browser-stop  │      │ browser-stop  │
└───────────────┘      └───────────────┘
        ▼                      ▼
Both call .devtools/browser start / stop, which owns dispatch + Selenium logic:

  WEBDRIVER_BACKEND=chromedriver -> chromedriver_start()
  WEBDRIVER_BACKEND=selenium     -> selenium_start()
                                     docker run --shm-size=2g -p WEBDRIVER_PORT:4444
  anything else                  -> FAIL()

test-functional-javascript:
  browser-start -> port always WEBDRIVER_PORT (both backends)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Consolidates backend-specific `chromedriver-*` and `selenium-*` commands into unified `browser-start` and `browser-stop` commands.
- Renames `.devtools/chromedriver` to `.devtools/browser` and centralizes backend selection through `WEBDRIVER_BACKEND`.
- Adds shared Selenium Docker startup, readiness polling via `/status` and `"ready": true`, container cleanup, and resolved `WEBDRIVER_PORT` handling.
- Updates Ahoy, Make, functional JavaScript test setup, scaffolding, workflows, tests, snapshots, initialization references, and documentation for the unified browser lifecycle.

## Possibly related

- Possibly related to issues concerning WebDriver backend selection and functional JavaScript browser test orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
