### PR TITLE
Polished scaffold documentation and added a security policy.

### DIFF
--- a/.scaffold/tests/fixtures/init/_baseline/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/_baseline/CONTRIBUTING.md
@@ -132,7 +132,7 @@ The `make test` or `ahoy test` command runs the tests for this extension.
 
 The tests are located in the `tests/src` directory. The `phpunit.xml` file
 configures PHPUnit to run the tests. It uses Drupal core's bootstrap file
-`core/tests/bootstrap.php` to bootstrap the Drupal environment before running
+`web/core/tests/bootstrap.php` to bootstrap the Drupal environment before running
 the tests.
 
 The `test` command is a wrapper for multiple test commands:

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/Kernel/ForceCrystalServiceKernelTest.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/Kernel/ForceCrystalServiceKernelTest.php
@@ -56,7 +56,6 @@ class ForceCrystalServiceKernelTest extends KernelTestBase {
    * Tests the getText method of ForceCrystalService.
    */
   public function testGetText(): void {
-    // Get the text using the service.
     $text = $this->yourExtensionService->getText();
 
     // Assert that the text is sanitized and contains no HTML tags.

--- a/.scaffold/tests/fixtures/init/no_phpunit/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 -
 -The tests are located in the `tests/src` directory. The `phpunit.xml` file
 -configures PHPUnit to run the tests. It uses Drupal core's bootstrap file
--`core/tests/bootstrap.php` to bootstrap the Drupal environment before running
+-`web/core/tests/bootstrap.php` to bootstrap the Drupal environment before running
 -the tests.
 -
 -The `test` command is a wrapper for multiple test commands:

--- a/.scaffold/tests/fixtures/init/no_tools/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_tools/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 -
 -The tests are located in the `tests/src` directory. The `phpunit.xml` file
 -configures PHPUnit to run the tests. It uses Drupal core's bootstrap file
--`core/tests/bootstrap.php` to bootstrap the Drupal environment before running
+-`web/core/tests/bootstrap.php` to bootstrap the Drupal environment before running
 -the tests.
 -
 -The `test` command is a wrapper for multiple test commands:

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -131,6 +131,7 @@ final class InitProcessTest extends UnitTestCase {
       'README.dist.md',
       'CONTRIBUTING.dist.md',
       'LICENSE.txt',
+      'SECURITY.md',
       '.scaffold',
       '.claude/skills',
       'tests/scaffold',

--- a/CONTRIBUTING.dist.md
+++ b/CONTRIBUTING.dist.md
@@ -145,7 +145,7 @@ The `make test` or `ahoy test` command runs the tests for this extension.
 
 The tests are located in the `tests/src` directory. The `phpunit.xml` file
 configures PHPUnit to run the tests. It uses Drupal core's bootstrap file
-`core/tests/bootstrap.php` to bootstrap the Drupal environment before running
+`web/core/tests/bootstrap.php` to bootstrap the Drupal environment before running
 the tests.
 
 The `test` command is a wrapper for multiple test commands:

--- a/README.md
+++ b/README.md
@@ -44,13 +44,12 @@ and push the code to [Drupal.org](https://drupal.org).
 - [Renovate](#renovate)
 - [Projects using this scaffold](#projects-using-this-scaffold)
 - [Contributing](#contributing)
-- [Maintenance](#maintenance)
 
 ## Features
 
 - Turnkey CI configuration:
   - PHP version matrix: `8.3`, `8.4`, `8.5`.
-  - Drupal version matrix: `stable`, `canary` and `legacy` across Drupal 10 and 11.
+  - Drupal version matrix: `stable` on Drupal 10 and 11, plus `legacy` and `canary` tiers on Drupal 11.
   - CI providers: [GitHub Actions](.github/workflows/test.yml)
     and [CircleCI](.circleci/config.yml)
   - Code coverage with https://github.com/krakjoe/pcov pushed to [codecov.io](https://codecov.io).
@@ -200,6 +199,17 @@ To apply patches to the dependencies, add a patch to the `patches` section of
 To overcome GitHub API rate limits, you may provide a `GITHUB_TOKEN` environment
 variable with a personal access token.
 
+### Debugging command output
+
+The output of the underlying commands (Composer, npm, Drush) is suppressed by
+default and shown only when a command fails. Set `DEBUG=1` to stream the full
+output of every command:
+
+```bash
+DEBUG=1 make build   # stream all command output
+DEBUG=1 ahoy build   # same, with ahoy
+```
+
 ### Optional dependencies
 
 If your extension requires additional dependencies for integration testing
@@ -336,7 +346,7 @@ The `make test` or `ahoy test` command runs the PHPUnit tests for your extension
 
 The tests are located in the `tests/src` directory. The `phpunit.xml` file
 configures PHPUnit to run the tests. It uses Drupal core's bootstrap file
-`core/tests/bootstrap.php` to bootstrap the Drupal environment before running
+`web/core/tests/bootstrap.php` to bootstrap the Drupal environment before running
 the tests.
 
 The `test` command is a wrapper for multiple test commands:
@@ -545,7 +555,7 @@ dependencies up-to-date.
 
 | Source                                   | Dependencies                  | Examples                                                                          |
 |------------------------------------------|-------------------------------|-----------------------------------------------------------------------------------|
-| [`composer.dev.json`](composer.dev.json) | Development Composer packages | `phpstan/phpdoc-parser`, `mglaman/phpstan-drupal`, `vincentlanglet/twig-cs-fixer` |
+| [`composer.dev.json`](composer.dev.json) | Development Composer packages | `drupal/coder`, `mglaman/phpstan-drupal`, `vincentlanglet/twig-cs-fixer`          |
 | [`package.json`](package.json)           | npm packages                  | `eslint`, `stylelint`, `prettier`                                                 |
 | `.github/workflows/*.yml`                | GitHub Actions                | `actions/checkout`, `actions/upload-artifact`, `codecov/codecov-action`           |
 
@@ -587,11 +597,3 @@ for all available options.
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to
 build and test the scaffold, run its self-tests, and regenerate the snapshot
 fixtures.
-
-## Maintenance
-
-This template uses a demo extension code to test itself in a [dedicated GitHub
-Actions CI pipeline](.github/workflows/scaffold-test.yml).
-
-The tests are written in [PHPUnit](https://phpunit.de/) and
-located in the [`.scaffold/tests`](.scaffold/tests) directory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest published version on the `1.x`
+branch.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately - do not open a public issue,
+pull request, or discussion for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting from the repository's **Security**
+tab (**Report a vulnerability**), or email the maintainer at <alex@drevops.com>.
+
+Include the affected file or command, steps to reproduce, and the impact. You
+can expect an initial response within a few days. Once the issue is confirmed
+and a fix is prepared, a new release is published.

--- a/init.php
+++ b/init.php
@@ -493,6 +493,7 @@ function process_internal(string $extension_name, string $extension_machine_name
 
   // Remove scaffold files.
   @unlink('LICENSE.txt');
+  @unlink('SECURITY.md');
   remove_dir('tests/scaffold');
   foreach (glob('.github/workflows/scaffold*.yml') ?: [] as $file) {
     @unlink($file);

--- a/tests/src/Kernel/YourExtensionServiceKernelTest.php
+++ b/tests/src/Kernel/YourExtensionServiceKernelTest.php
@@ -56,7 +56,6 @@ class YourExtensionServiceKernelTest extends KernelTestBase {
    * Tests the getText method of YourExtensionService.
    */
   public function testGetText(): void {
-    // Get the text using the service.
     $text = $this->yourExtensionService->getText();
 
     // Assert that the text is sanitized and contains no HTML tags.


### PR DESCRIPTION
## Summary

This is a documentation/polish pass on the Drupal extension scaffold - reconciled `README.md`/`CONTRIBUTING.dist.md` drift with the code, removed a `## Maintenance` section duplicated by `CONTRIBUTING.md`, documented the `DEBUG=1` output toggle, and added a `SECURITY.md` security policy wired through `init.php` so generated projects do not inherit it. Snapshot fixtures were regenerated to match the template edits.

## Changes

### Documentation
- `README.md`: corrected the Drupal version-matrix summary to `stable` on Drupal 10 and 11, plus `legacy` and `canary` tiers on Drupal 11
- `README.md` and `CONTRIBUTING.dist.md`: fixed the PHPUnit bootstrap path to `web/core/tests/bootstrap.php`
- `README.md`: replaced a stale Renovate example (`phpstan/phpdoc-parser`) with `drupal/coder`
- `README.md`: removed the `## Maintenance` section, which duplicated content already in `CONTRIBUTING.md`
- `README.md`: documented the `DEBUG=1` toggle for streaming full command output from Composer, npm, and Drush

### Security policy
- Added `SECURITY.md` describing supported versions and how to report a vulnerability
- `init.php` now unlinks `SECURITY.md` during setup, mirroring `LICENSE.txt`, so generated projects define their own policy
- `InitProcessTest` asserts that `SECURITY.md` is removed after init

### Test hygiene and fixtures
- Removed a redundant comment (`// Get the text using the service.`) from the template and baseline kernel-test examples
- Regenerated the `.scaffold/tests/fixtures/init` baseline and two variant `CONTRIBUTING.md` fixtures to match the template edits

## Before / After

```
init.php - scaffold file cleanup on generated projects
--------------------------------------------------------
  BEFORE                            AFTER
  @unlink('LICENSE.txt');           @unlink('LICENSE.txt');
                                     @unlink('SECURITY.md');
  remove_dir('tests/scaffold');     remove_dir('tests/scaffold');

  Generated projects inherited      Generated projects define their
  the scaffold's own SECURITY.md.   own SECURITY.md (or none).


README.md - table of contents and sections
--------------------------------------------------------
  BEFORE                            AFTER
  - Contributing                    - Contributing
  - Maintenance                     (removed)

  ## Maintenance                    (section deleted; the same
  This template uses a demo          content already lived in
  extension code to test itself...   CONTRIBUTING.md)
```

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Reconciled scaffold documentation with the current code and Drupal 10/11 version matrix.
- Corrected PHPUnit bootstrap paths to `web/core/tests/bootstrap.php`.
- Documented `DEBUG=1` output and refreshed the Renovate example.
- Removed the duplicate Maintenance section and redundant template comments.
- Added a repository security policy and ensured generated projects remove `SECURITY.md`.
- Extended initialization tests and regenerated snapshots accordingly.

## Possibly related

- No issue reference was available in the provided context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->