### PR TITLE
Converged the scaffold codebase onto its dominant naming, API, and structure conventions.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -108,7 +108,7 @@ commands:
       popd >/dev/null || exit 1
 
   test:
-    usage: Run tests.
+    usage: Run all tests.
     cmd: |
       pushd "build" >/dev/null || exit 1
       #;< DEV_PHPUNIT
@@ -165,11 +165,11 @@ commands:
 
   #;< DEV_FUNCTIONAL_JAVASCRIPT
   browser-start:
-    usage: Start the browser for FunctionalJavascript tests if not already running.
+    usage: Start the browser for FunctionalJavascript tests.
     cmd: ./.devtools/browser start
 
   browser-stop:
-    usage: Stop the browser used for FunctionalJavascript tests.
+    usage: Stop the browser.
     cmd: ./.devtools/browser stop
   #;> DEV_FUNCTIONAL_JAVASCRIPT
 

--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -169,10 +169,10 @@ PASS('Dependencies installed.');
 // Suggested dependencies allow to install them for testing without requiring
 // them in extension's composer.json.
 TASK("Installing suggested dependencies from extension's composer.json.");
-$composer_data = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+$ext_json = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
 $build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
-if (isset($composer_data['suggest']) && is_array($composer_data['suggest'])) {
-  foreach (array_keys($composer_data['suggest']) as $suggest) {
+if (isset($ext_json['suggest']) && is_array($ext_json['suggest'])) {
+  foreach (array_keys($ext_json['suggest']) as $suggest) {
     if (isset($build_json['require'][$suggest]) || isset($build_json['require-dev'][$suggest])) {
       NOTE('Skipping %s (already in require or require-dev).', $suggest);
       continue;

--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -143,8 +143,8 @@ if (is_dir('patches')) {
   PASS('Patches copied.');
 }
 
-$github_token = getenv('GITHUB_TOKEN');
-if ($github_token !== FALSE && $github_token !== '') {
+$github_token = getenv_default('GITHUB_TOKEN', '');
+if ($github_token !== '') {
   TASK('Adding GitHub authentication token if provided.');
   passthru_or_fail(sprintf('composer config --global github-oauth.github.com %s', escapeshellarg($github_token)));
   PASS('GitHub token added.');

--- a/.devtools/deploy
+++ b/.devtools/deploy
@@ -90,7 +90,7 @@ if ($deploy_ssh_key_fingerprint !== '') {
     FAIL('Unable to find SSH key file %s.', $key_file);
   }
 
-  if (getenv('SSH_AGENT_PID') === FALSE || getenv('SSH_AGENT_PID') === '') {
+  if (getenv_default('SSH_AGENT_PID', '') === '') {
     passthru('eval "$(ssh-agent)"');
   }
 
@@ -106,7 +106,7 @@ echo PHP_EOL;
 
 if ($deploy_proceed !== '1') {
   PASS('Skip deployment because DEPLOY_PROCEED is not set to 1.');
-  quit();
+  quit(0);
 }
 
 $git_user_name = trim((string) shell_exec('git config --global user.name'));

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -57,19 +57,19 @@ function getenv_default(mixed ...$vars): string {
  * '#' (after optional whitespace) are ignored. Surrounding single or double
  * quotes around the value are stripped. Keys and values are trimmed.
  *
- * @param string $file
+ * @param string $dotenv_file
  *   Path to the dotenv file.
  *
  * @return array<string, string>
  *   Associative array of key-value pairs. Empty if the file does not exist
  *   or contains no parseable lines.
  */
-function dotenv_read(string $file = '.env'): array {
-  if (!file_exists($file)) {
+function dotenv_read(string $dotenv_file = '.env'): array {
+  if (!file_exists($dotenv_file)) {
     return [];
   }
 
-  $contents = file_get_contents($file);
+  $contents = file_get_contents($dotenv_file);
   if ($contents === FALSE) {
     return [];
   }
@@ -122,23 +122,23 @@ function dotenv_read(string $file = '.env'): array {
  *   Variable name to write.
  * @param string $value
  *   Variable value to write. Not quoted.
- * @param string $file
+ * @param string $dotenv_file
  *   Path to the dotenv file.
  */
-function dotenv_write_var(string $key, string $value, string $file = '.env'): void {
+function dotenv_write_var(string $key, string $value, string $dotenv_file = '.env'): void {
   $assignment = sprintf('%s=%s', $key, $value);
 
-  if (!file_exists($file)) {
-    if (file_put_contents($file, $assignment . PHP_EOL) === FALSE) {
-      FAIL('Unable to write %s', $file);
+  if (!file_exists($dotenv_file)) {
+    if (file_put_contents($dotenv_file, $assignment . PHP_EOL) === FALSE) {
+      FAIL('Unable to write %s', $dotenv_file);
     }
 
     return;
   }
 
-  $contents = file_get_contents($file);
+  $contents = file_get_contents($dotenv_file);
   if ($contents === FALSE) {
-    FAIL('Unable to read %s', $file);
+    FAIL('Unable to read %s', $dotenv_file);
 
     // @codeCoverageIgnoreStart
     return;
@@ -179,8 +179,8 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
     $lines[$replace_index] = $assignment;
   }
 
-  if (file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
-    FAIL('Unable to write %s', $file);
+  if (file_put_contents($dotenv_file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
+    FAIL('Unable to write %s', $dotenv_file);
   }
 }
 
@@ -354,8 +354,8 @@ function resolve_site_url(string $host, string $port, string $dotenv_file = '.en
  * server is listening, and '-' when no server is bound to the port.
  */
 function xdebug_state(string $port): string {
-  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
-  $out = trim((string) @shell_exec($cmd));
+  $command = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($command));
   if ($out === '') {
     return '-';
   }
@@ -528,7 +528,7 @@ function command_must_exist(string $command): void {
  * The command is wrapped in a brace group so both streams are captured
  * together and the exit status is preserved, even for compound commands.
  *
- * @param string $cmd
+ * @param string $command
  *   The command to run.
  * @param int|null &$exit_code
  *   Populated with the command's exit code.
@@ -538,9 +538,9 @@ function command_must_exist(string $command): void {
  * @return string
  *   The captured combined output.
  */
-function passthru_capture(string $cmd, ?int &$exit_code = NULL): string {
+function passthru_capture(string $command, ?int &$exit_code = NULL): string {
   ob_start();
-  passthru('{ ' . $cmd . '; } 2>&1', $exit_code);
+  passthru('{ ' . $command . '; } 2>&1', $exit_code);
 
   return ob_get_clean() ?: '';
 }
@@ -551,14 +551,14 @@ function passthru_capture(string $cmd, ?int &$exit_code = NULL): string {
  * Command output is suppressed during a normal run and surfaced only when the
  * command fails; set DEBUG=1 to stream it live instead.
  */
-function passthru_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
+function passthru_or_fail(string $command, string $format = '', string|int|float ...$args): void {
   $exit_code = 0;
 
   if (is_debug()) {
-    passthru($cmd, $exit_code);
+    passthru($command, $exit_code);
   }
   else {
-    $output = passthru_capture($cmd, $exit_code);
+    $output = passthru_capture($command, $exit_code);
 
     // Surface the captured output only on failure so the error stays
     // diagnosable while a successful run remains quiet.
@@ -583,9 +583,9 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
  * streamed to the terminal rather than suppressed, for commands whose output
  * is meaningful in its own right rather than dependency-tool noise.
  */
-function passthru_verbose_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
+function passthru_verbose_or_fail(string $command, string $format = '', string|int|float ...$args): void {
   $exit_code = 0;
-  passthru($cmd, $exit_code);
+  passthru($command, $exit_code);
 
   if ($exit_code !== 0) {
     if ($format !== '') {
@@ -783,12 +783,12 @@ function replace_in_file(string $file, string $pattern, string $replacement): st
 /**
  * Recursively remove a directory.
  */
-function remove_dir(string $directory): void {
-  if (!is_dir($directory)) {
+function remove_dir(string $dir): void {
+  if (!is_dir($dir)) {
     return;
   }
   $items = new \RecursiveIteratorIterator(
-    new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
+    new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
     \RecursiveIteratorIterator::CHILD_FIRST
   );
   /** @var \SplFileInfo $item */
@@ -804,7 +804,7 @@ function remove_dir(string $directory): void {
       @unlink($path);
     }
   }
-  @rmdir($directory);
+  @rmdir($dir);
 }
 
 /**
@@ -835,12 +835,12 @@ function copy_dir(string $src, string $dst): void {
 /**
  * Recursively chmod a directory.
  */
-function chmod_recursive(string $path, int $mode): void {
-  if (!is_dir($path)) {
+function chmod_recursive(string $dir, int $mode): void {
+  if (!is_dir($dir)) {
     return;
   }
   $iterator = new \RecursiveIteratorIterator(
-    new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
+    new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
     \RecursiveIteratorIterator::SELF_FIRST
   );
   /** @var \SplFileInfo $item */
@@ -849,7 +849,7 @@ function chmod_recursive(string $path, int $mode): void {
       @chmod($item->getPathname(), $mode);
     }
   }
-  @chmod($path, $mode);
+  @chmod($dir, $mode);
 }
 
 /**

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -37,10 +37,10 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 $ext_info = extension_info();
-$extension = $ext_info['name'];
+$extension_name = $ext_info['name'];
 $extension_type = $ext_info['type'];
 
-$db_file = '/tmp/site_' . $extension . '.sqlite';
+$db_file = '/tmp/site_' . $extension_name . '.sqlite';
 
 TASK('Installing Drupal into SQLite database %s.', $db_file);
 
@@ -56,21 +56,21 @@ PASS('Drupal installed.');
 
 drush('status');
 
-TASK('Enabling extension %s.', $extension);
+TASK('Enabling extension %s.', $extension_name);
 if ($extension_type === 'theme') {
-  drush('theme:enable %s', [$extension]);
+  drush('theme:enable %s', [$extension_name]);
 }
 else {
-  drush('pm:enable %s', [$extension]);
+  drush('pm:enable %s', [$extension_name]);
 }
 
 TASK('Clearing caches.');
 drush('cr');
 
 TASK('Enabling suggested modules, if any.');
-$composer_json = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
-if (isset($composer_json['suggest']) && is_array($composer_json['suggest'])) {
-  foreach (array_keys($composer_json['suggest']) as $suggest) {
+$ext_json = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+if (isset($ext_json['suggest']) && is_array($ext_json['suggest'])) {
+  foreach (array_keys($ext_json['suggest']) as $suggest) {
     if (!str_starts_with((string) $suggest, 'drupal/')) {
       continue;
     }

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -88,7 +88,7 @@ commands:
       popd >/dev/null || exit 1
 
   test:
-    usage: Run tests.
+    usage: Run all tests.
     cmd: |
       pushd "build" >/dev/null || exit 1
       ahoy title "Running PHPUnit"
@@ -134,11 +134,11 @@ commands:
       popd >/dev/null || exit 1
 
   browser-start:
-    usage: Start the browser for FunctionalJavascript tests if not already running.
+    usage: Start the browser for FunctionalJavascript tests.
     cmd: ./.devtools/browser start
 
   browser-stop:
-    usage: Stop the browser used for FunctionalJavascript tests.
+    usage: Stop the browser.
     cmd: ./.devtools/browser stop
 
   reset:

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -143,8 +143,8 @@ if (is_dir('patches')) {
   PASS('Patches copied.');
 }
 
-$github_token = getenv('GITHUB_TOKEN');
-if ($github_token !== FALSE && $github_token !== '') {
+$github_token = getenv_default('GITHUB_TOKEN', '');
+if ($github_token !== '') {
   TASK('Adding GitHub authentication token if provided.');
   passthru_or_fail(sprintf('composer config --global github-oauth.github.com %s', escapeshellarg($github_token)));
   PASS('GitHub token added.');
@@ -169,10 +169,10 @@ PASS('Dependencies installed.');
 // Suggested dependencies allow to install them for testing without requiring
 // them in extension's composer.json.
 TASK("Installing suggested dependencies from extension's composer.json.");
-$composer_data = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+$ext_json = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
 $build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
-if (isset($composer_data['suggest']) && is_array($composer_data['suggest'])) {
-  foreach (array_keys($composer_data['suggest']) as $suggest) {
+if (isset($ext_json['suggest']) && is_array($ext_json['suggest'])) {
+  foreach (array_keys($ext_json['suggest']) as $suggest) {
     if (isset($build_json['require'][$suggest]) || isset($build_json['require-dev'][$suggest])) {
       NOTE('Skipping %s (already in require or require-dev).', $suggest);
       continue;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/deploy
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/deploy
@@ -90,7 +90,7 @@ if ($deploy_ssh_key_fingerprint !== '') {
     FAIL('Unable to find SSH key file %s.', $key_file);
   }
 
-  if (getenv('SSH_AGENT_PID') === FALSE || getenv('SSH_AGENT_PID') === '') {
+  if (getenv_default('SSH_AGENT_PID', '') === '') {
     passthru('eval "$(ssh-agent)"');
   }
 
@@ -106,7 +106,7 @@ echo PHP_EOL;
 
 if ($deploy_proceed !== '1') {
   PASS('Skip deployment because DEPLOY_PROCEED is not set to 1.');
-  quit();
+  quit(0);
 }
 
 $git_user_name = trim((string) shell_exec('git config --global user.name'));

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -57,19 +57,19 @@ function getenv_default(mixed ...$vars): string {
  * '#' (after optional whitespace) are ignored. Surrounding single or double
  * quotes around the value are stripped. Keys and values are trimmed.
  *
- * @param string $file
+ * @param string $dotenv_file
  *   Path to the dotenv file.
  *
  * @return array<string, string>
  *   Associative array of key-value pairs. Empty if the file does not exist
  *   or contains no parseable lines.
  */
-function dotenv_read(string $file = '.env'): array {
-  if (!file_exists($file)) {
+function dotenv_read(string $dotenv_file = '.env'): array {
+  if (!file_exists($dotenv_file)) {
     return [];
   }
 
-  $contents = file_get_contents($file);
+  $contents = file_get_contents($dotenv_file);
   if ($contents === FALSE) {
     return [];
   }
@@ -122,23 +122,23 @@ function dotenv_read(string $file = '.env'): array {
  *   Variable name to write.
  * @param string $value
  *   Variable value to write. Not quoted.
- * @param string $file
+ * @param string $dotenv_file
  *   Path to the dotenv file.
  */
-function dotenv_write_var(string $key, string $value, string $file = '.env'): void {
+function dotenv_write_var(string $key, string $value, string $dotenv_file = '.env'): void {
   $assignment = sprintf('%s=%s', $key, $value);
 
-  if (!file_exists($file)) {
-    if (file_put_contents($file, $assignment . PHP_EOL) === FALSE) {
-      FAIL('Unable to write %s', $file);
+  if (!file_exists($dotenv_file)) {
+    if (file_put_contents($dotenv_file, $assignment . PHP_EOL) === FALSE) {
+      FAIL('Unable to write %s', $dotenv_file);
     }
 
     return;
   }
 
-  $contents = file_get_contents($file);
+  $contents = file_get_contents($dotenv_file);
   if ($contents === FALSE) {
-    FAIL('Unable to read %s', $file);
+    FAIL('Unable to read %s', $dotenv_file);
 
     // @codeCoverageIgnoreStart
     return;
@@ -179,8 +179,8 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
     $lines[$replace_index] = $assignment;
   }
 
-  if (file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
-    FAIL('Unable to write %s', $file);
+  if (file_put_contents($dotenv_file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
+    FAIL('Unable to write %s', $dotenv_file);
   }
 }
 
@@ -354,8 +354,8 @@ function resolve_site_url(string $host, string $port, string $dotenv_file = '.en
  * server is listening, and '-' when no server is bound to the port.
  */
 function xdebug_state(string $port): string {
-  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
-  $out = trim((string) @shell_exec($cmd));
+  $command = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($command));
   if ($out === '') {
     return '-';
   }
@@ -528,7 +528,7 @@ function command_must_exist(string $command): void {
  * The command is wrapped in a brace group so both streams are captured
  * together and the exit status is preserved, even for compound commands.
  *
- * @param string $cmd
+ * @param string $command
  *   The command to run.
  * @param int|null &$exit_code
  *   Populated with the command's exit code.
@@ -538,9 +538,9 @@ function command_must_exist(string $command): void {
  * @return string
  *   The captured combined output.
  */
-function passthru_capture(string $cmd, ?int &$exit_code = NULL): string {
+function passthru_capture(string $command, ?int &$exit_code = NULL): string {
   ob_start();
-  passthru('{ ' . $cmd . '; } 2>&1', $exit_code);
+  passthru('{ ' . $command . '; } 2>&1', $exit_code);
 
   return ob_get_clean() ?: '';
 }
@@ -551,14 +551,14 @@ function passthru_capture(string $cmd, ?int &$exit_code = NULL): string {
  * Command output is suppressed during a normal run and surfaced only when the
  * command fails; set DEBUG=1 to stream it live instead.
  */
-function passthru_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
+function passthru_or_fail(string $command, string $format = '', string|int|float ...$args): void {
   $exit_code = 0;
 
   if (is_debug()) {
-    passthru($cmd, $exit_code);
+    passthru($command, $exit_code);
   }
   else {
-    $output = passthru_capture($cmd, $exit_code);
+    $output = passthru_capture($command, $exit_code);
 
     // Surface the captured output only on failure so the error stays
     // diagnosable while a successful run remains quiet.
@@ -583,9 +583,9 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
  * streamed to the terminal rather than suppressed, for commands whose output
  * is meaningful in its own right rather than dependency-tool noise.
  */
-function passthru_verbose_or_fail(string $cmd, string $format = '', string|int|float ...$args): void {
+function passthru_verbose_or_fail(string $command, string $format = '', string|int|float ...$args): void {
   $exit_code = 0;
-  passthru($cmd, $exit_code);
+  passthru($command, $exit_code);
 
   if ($exit_code !== 0) {
     if ($format !== '') {
@@ -783,12 +783,12 @@ function replace_in_file(string $file, string $pattern, string $replacement): st
 /**
  * Recursively remove a directory.
  */
-function remove_dir(string $directory): void {
-  if (!is_dir($directory)) {
+function remove_dir(string $dir): void {
+  if (!is_dir($dir)) {
     return;
   }
   $items = new \RecursiveIteratorIterator(
-    new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
+    new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
     \RecursiveIteratorIterator::CHILD_FIRST
   );
   /** @var \SplFileInfo $item */
@@ -804,7 +804,7 @@ function remove_dir(string $directory): void {
       @unlink($path);
     }
   }
-  @rmdir($directory);
+  @rmdir($dir);
 }
 
 /**
@@ -835,12 +835,12 @@ function copy_dir(string $src, string $dst): void {
 /**
  * Recursively chmod a directory.
  */
-function chmod_recursive(string $path, int $mode): void {
-  if (!is_dir($path)) {
+function chmod_recursive(string $dir, int $mode): void {
+  if (!is_dir($dir)) {
     return;
   }
   $iterator = new \RecursiveIteratorIterator(
-    new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
+    new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),
     \RecursiveIteratorIterator::SELF_FIRST
   );
   /** @var \SplFileInfo $item */
@@ -849,7 +849,7 @@ function chmod_recursive(string $path, int $mode): void {
       @chmod($item->getPathname(), $mode);
     }
   }
-  @chmod($path, $mode);
+  @chmod($dir, $mode);
 }
 
 /**

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -37,10 +37,10 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 $ext_info = extension_info();
-$extension = $ext_info['name'];
+$extension_name = $ext_info['name'];
 $extension_type = $ext_info['type'];
 
-$db_file = '/tmp/site_' . $extension . '.sqlite';
+$db_file = '/tmp/site_' . $extension_name . '.sqlite';
 
 TASK('Installing Drupal into SQLite database %s.', $db_file);
 
@@ -56,21 +56,21 @@ PASS('Drupal installed.');
 
 drush('status');
 
-TASK('Enabling extension %s.', $extension);
+TASK('Enabling extension %s.', $extension_name);
 if ($extension_type === 'theme') {
-  drush('theme:enable %s', [$extension]);
+  drush('theme:enable %s', [$extension_name]);
 }
 else {
-  drush('pm:enable %s', [$extension]);
+  drush('pm:enable %s', [$extension_name]);
 }
 
 TASK('Clearing caches.');
 drush('cr');
 
 TASK('Enabling suggested modules, if any.');
-$composer_json = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
-if (isset($composer_json['suggest']) && is_array($composer_json['suggest'])) {
-  foreach (array_keys($composer_json['suggest']) as $suggest) {
+$ext_json = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+if (isset($ext_json['suggest']) && is_array($ext_json['suggest'])) {
+  foreach (array_keys($ext_json['suggest']) as $suggest) {
     if (!str_starts_with((string) $suggest, 'drupal/')) {
       continue;
     }

--- a/.scaffold/tests/fixtures/init/_baseline/force_crystal.install
+++ b/.scaffold/tests/fixtures/init/_baseline/force_crystal.install
@@ -12,7 +12,7 @@ declare(strict_types=1);
  */
 function force_crystal_install(): void {
   // Set default configuration values.
-  $config = \Drupal::service('config.factory')->getEditable('force_crystal.settings');
+  $config = \Drupal::configFactory()->getEditable('force_crystal.settings');
   $config->set('text', 'Default content to be displayed if JS is disabled.')->save();
 
   \Drupal::service('router.builder')->rebuild();

--- a/.scaffold/tests/fixtures/init/_baseline/force_crystal.module
+++ b/.scaffold/tests/fixtures/init/_baseline/force_crystal.module
@@ -22,7 +22,7 @@ function force_crystal_page_attachments(array &$attachments): void {
  */
 function force_crystal_page_bottom(array &$page_bottom): void {
   /** @var \Drupal\force_crystal\ForceCrystalService $force_crystal_service */
-  $force_crystal_service = \Drupal::getContainer()->get('force_crystal.service');
+  $force_crystal_service = \Drupal::service('force_crystal.service');
 
   $text = $force_crystal_service->getText();
 

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo "info            - Print a read-only summary of the current environment (alias: describe)."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
-	@echo "login           - Run Drush login command."
+	@echo "login           - Login to a website."
 	@echo "provision       - Provision application within assembled codebase."
 	@echo "reset           - Reset project to the default state (aliases: delete, destroy)."
 	@echo "start           - Start development environment."

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo "info            - Print a read-only summary of the current environment (alias: describe)."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
-	@echo "login           - Run Drush login command."
+	@echo "login           - Login to a website."
 	@echo "provision       - Provision application within assembled codebase."
 	@echo "reset           - Reset project to the default state (aliases: delete, destroy)."
 	@echo "start           - Start development environment."

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo "info            - Print a read-only summary of the current environment (alias: describe)."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
-	@echo "login           - Run Drush login command."
+	@echo "login           - Login to a website."
 	@echo "provision       - Provision application within assembled codebase."
 	@echo "reset           - Reset project to the default state (aliases: delete, destroy)."
 	@echo "start           - Start development environment."

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo "info            - Print a read-only summary of the current environment (alias: describe)."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
-	@echo "login           - Run Drush login command."
+	@echo "login           - Login to a website."
 	@echo "provision       - Provision application within assembled codebase."
 	@echo "reset           - Reset project to the default state (aliases: delete, destroy)."
 	@echo "start           - Start development environment."

--- a/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_funcjs/.ahoy.yml
@@ -18,11 +18,11 @@
        popd >/dev/null || exit 1
  
 -  browser-start:
--    usage: Start the browser for FunctionalJavascript tests if not already running.
+-    usage: Start the browser for FunctionalJavascript tests.
 -    cmd: ./.devtools/browser start
 -
 -  browser-stop:
--    usage: Stop the browser used for FunctionalJavascript tests.
+-    usage: Stop the browser.
 -    cmd: ./.devtools/browser stop
  
    reset:

--- a/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_jest/.ahoy.yml
@@ -18,4 +18,4 @@
 -      popd >/dev/null || exit 1
  
    browser-start:
-     usage: Start the browser for FunctionalJavascript tests if not already running.
+     usage: Start the browser for FunctionalJavascript tests.

--- a/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.ahoy.yml
@@ -1,5 +1,5 @@
 @@ -91,41 +91,11 @@
-     usage: Run tests.
+     usage: Run all tests.
      cmd: |
        pushd "build" >/dev/null || exit 1
 -      ahoy title "Running PHPUnit"
@@ -45,11 +45,11 @@
        popd >/dev/null || exit 1
  
 -  browser-start:
--    usage: Start the browser for FunctionalJavascript tests if not already running.
+-    usage: Start the browser for FunctionalJavascript tests.
 -    cmd: ./.devtools/browser start
 -
 -  browser-stop:
--    usage: Stop the browser used for FunctionalJavascript tests.
+-    usage: Stop the browser.
 -    cmd: ./.devtools/browser stop
  
    reset:

--- a/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.ahoy.yml
@@ -31,7 +31,7 @@
  
    test:
 @@ -91,55 +72,11 @@
-     usage: Run tests.
+     usage: Run all tests.
      cmd: |
        pushd "build" >/dev/null || exit 1
 -      ahoy title "Running PHPUnit"
@@ -77,11 +77,11 @@
 -      popd >/dev/null || exit 1
 -
 -  browser-start:
--    usage: Start the browser for FunctionalJavascript tests if not already running.
+-    usage: Start the browser for FunctionalJavascript tests.
 -    cmd: ./.devtools/browser start
 -
 -  browser-stop:
--    usage: Stop the browser used for FunctionalJavascript tests.
+-    usage: Stop the browser.
 -    cmd: ./.devtools/browser stop
  
    reset:

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo "info            - Print a read-only summary of the current environment (alias: describe)."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
-	@echo "login           - Run Drush login command."
+	@echo "login           - Login to a website."
 	@echo "provision       - Provision application within assembled codebase."
 	@echo "reset           - Reset project to the default state (aliases: delete, destroy)."
 	@echo "start           - Start development environment."

--- a/.scaffold/tests/src/Functional/AutoPortDiscoveryTest.php
+++ b/.scaffold/tests/src/Functional/AutoPortDiscoveryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\Group;
  * file. This verifies the end-to-end resolution + persistence behavior, not
  * just the unit-level helpers.
  *
- * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -613,8 +613,8 @@ final class AssembleTest extends UnitTestCase {
   }
 
   public function testAssembleMissingComposerJson(): void {
-    putenv('GITHUB_TOKEN');
-    putenv('SYMFONY_DEPRECATIONS_HELPER');
+    $this->envUnset('GITHUB_TOKEN');
+    $this->envUnset('SYMFONY_DEPRECATIONS_HELPER');
 
     // Override file_exists to return false for composer.json.
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): false => FALSE);

--- a/.scaffold/tests/src/Unit/AssembleTest.php
+++ b/.scaffold/tests/src/Unit/AssembleTest.php
@@ -627,7 +627,7 @@ final class AssembleTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -33,8 +33,8 @@ final class BrowserTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
-    self::envUnset('WEBDRIVER_PORT');
-    self::envUnset('WEBDRIVER_BACKEND');
+    $this->envUnset('WEBDRIVER_PORT');
+    $this->envUnset('WEBDRIVER_BACKEND');
 
     // The '.env' file exists and supplies port 4444, so the port resolves
     // without touching the free-port probe. Readiness probes against the
@@ -76,7 +76,7 @@ final class BrowserTest extends UnitTestCase {
   }
 
   public function testUnknownBackend(): void {
-    self::envSet('WEBDRIVER_BACKEND', 'firefox');
+    $this->envSet('WEBDRIVER_BACKEND', 'firefox');
 
     $output = $this->runBrowser('start', 1);
 
@@ -203,7 +203,7 @@ final class BrowserTest extends UnitTestCase {
   }
 
   public function testSeleniumStartAlreadyRunning(): void {
-    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockReady([TRUE]);
 
     $output = $this->runBrowser('start', 0);
@@ -212,7 +212,7 @@ final class BrowserTest extends UnitTestCase {
   }
 
   public function testSeleniumStartStartsContainer(): void {
-    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $this->mockReady([FALSE, TRUE]);
     $commands = [];
@@ -231,7 +231,7 @@ final class BrowserTest extends UnitTestCase {
   }
 
   public function testSeleniumStartFailsWithoutDocker(): void {
-    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands([]);
     $this->mockReady([FALSE]);
 
@@ -241,7 +241,7 @@ final class BrowserTest extends UnitTestCase {
   }
 
   public function testSeleniumStartFailsWhenDockerRunFails(): void {
-    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $this->mockReady([FALSE]);
     $commands = [];
@@ -253,7 +253,7 @@ final class BrowserTest extends UnitTestCase {
   }
 
   public function testSeleniumStartFailsWhenNeverReady(): void {
-    self::envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $this->mockReady([FALSE]);
     $commands = [];

--- a/.scaffold/tests/src/Unit/DeployTest.php
+++ b/.scaffold/tests/src/Unit/DeployTest.php
@@ -38,7 +38,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitSuccessException to be thrown');
     }
     catch (QuitSuccessException $e) {
-      $this->assertEquals(0, $e->getCode());
+      $this->assertSame(0, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -62,7 +62,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitSuccessException to be thrown');
     }
     catch (QuitSuccessException $e) {
-      $this->assertEquals(0, $e->getCode());
+      $this->assertSame(0, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -173,7 +173,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -310,7 +310,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -438,7 +438,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -471,7 +471,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -509,7 +509,7 @@ final class DeployTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersCommandExistsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersCommandExistsTest.php
@@ -57,7 +57,7 @@ final class HelpersCommandExistsTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersCopyDirTest.php
+++ b/.scaffold/tests/src/Unit/HelpersCopyDirTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\Group;
 /**
  * Tests for copy_dir() function.
  *
- * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  */
 #[CoversFunction('DrupalExtensionScaffold\DevTools\copy_dir')]
 #[Group('p0')]

--- a/.scaffold/tests/src/Unit/HelpersCopyDirTest.php
+++ b/.scaffold/tests/src/Unit/HelpersCopyDirTest.php
@@ -46,7 +46,7 @@ final class HelpersCopyDirTest extends UnitTestCase {
       }
       else {
         $this->assertFileExists($full_path, sprintf('File %s should exist', $relative_path));
-        $this->assertEquals($expected_content, file_get_contents($full_path), sprintf('File %s should have correct content', $relative_path));
+        $this->assertSame($expected_content, file_get_contents($full_path), sprintf('File %s should have correct content', $relative_path));
       }
     }
   }

--- a/.scaffold/tests/src/Unit/HelpersDotenvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersDotenvTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 /**
  * Tests for dotenv_read() and dotenv_write_var() helpers.
  *
- * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */

--- a/.scaffold/tests/src/Unit/HelpersFilesystemTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFilesystemTest.php
@@ -28,7 +28,7 @@ final class HelpersFilesystemTest extends UnitTestCase {
   #[DataProvider('dataProviderRemoveDir')]
   public function testRemoveDir(array $structure, bool $has_symlink): void {
     $dir = self::$tmp . '/remove_' . uniqid();
-    $this->createStructure($dir, $structure);
+    $this->createDirectoryStructure($dir, $structure);
     if ($has_symlink) {
       file_put_contents($dir . '/target.txt', 'target content');
       symlink($dir . '/target.txt', $dir . '/subdir/link.txt');
@@ -71,7 +71,7 @@ final class HelpersFilesystemTest extends UnitTestCase {
   #[DataProvider('dataProviderChmodRecursive')]
   public function testChmodRecursive(array $structure, int $mode, array $expected_perms): void {
     $dir = self::$tmp . '/chmod_' . uniqid();
-    $this->createStructure($dir, $structure);
+    $this->createDirectoryStructure($dir, $structure);
     chmod_recursive($dir, $mode);
     foreach ($expected_perms as $relative_path => $expected_mode) {
       $path = $relative_path === '.' ? $dir : $dir . '/' . $relative_path;
@@ -120,7 +120,7 @@ final class HelpersFilesystemTest extends UnitTestCase {
     $this->assertSame(0644, fileperms($target_dir . '/target.txt') & 0777);
   }
 
-  protected function createStructure(string $base_path, array $structure): void {
+  protected function createDirectoryStructure(string $base_path, array $structure): void {
     if (!is_dir($base_path)) {
       mkdir($base_path, 0755, TRUE);
     }
@@ -128,7 +128,7 @@ final class HelpersFilesystemTest extends UnitTestCase {
       $path = $base_path . '/' . $name;
       if (is_array($content)) {
         mkdir($path, 0755, TRUE);
-        $this->createStructure($path, $content);
+        $this->createDirectoryStructure($path, $content);
       }
       else {
         file_put_contents($path, $content);

--- a/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFindFreePortTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * so the test mocks stream_socket_client to simulate listeners being
  * present or absent on each candidate port.
  *
- * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */

--- a/.scaffold/tests/src/Unit/HelpersFormatterTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFormatterTest.php
@@ -67,6 +67,7 @@ final class HelpersFormatterTest extends UnitTestCase {
     }
     finally {
       $output = ob_get_clean();
+      $this->assertIsString($output);
       $this->assertSame($expected_output, $output);
     }
   }

--- a/.scaffold/tests/src/Unit/HelpersFormatterTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFormatterTest.php
@@ -42,15 +42,15 @@ final class HelpersFormatterTest extends UnitTestCase {
   }
 
   public static function dataProviderOutputFormatters(): \Iterator {
-    yield 'note' => ['note', NULL, "       Test message arg\n"];
-    yield 'task, no color' => ['task', FALSE, "[TASK] Test message arg\n"];
-    yield 'task, with color' => ['task', TRUE, "\033[34m[TASK] Test message arg\033[0m\n"];
-    yield 'info, no color' => ['info', FALSE, "[INFO] Test message arg\n"];
-    yield 'info, with color' => ['info', TRUE, "\033[36m[INFO] Test message arg\033[0m\n"];
-    yield 'pass, no color' => ['pass', FALSE, "[ OK ] Test message arg\n"];
-    yield 'pass, with color' => ['pass', TRUE, "\033[32m[ OK ] Test message arg\033[0m\n"];
-    yield 'fail_no_exit, no color' => ['fail_no_exit', FALSE, "[FAIL] Test message arg\n"];
-    yield 'fail_no_exit, with color' => ['fail_no_exit', TRUE, "\033[31m[FAIL] Test message arg\033[0m\n"];
+    yield 'note' => ['function' => 'note', 'is_tty' => NULL, 'expected_output' => "       Test message arg\n"];
+    yield 'task, no color' => ['function' => 'task', 'is_tty' => FALSE, 'expected_output' => "[TASK] Test message arg\n"];
+    yield 'task, with color' => ['function' => 'task', 'is_tty' => TRUE, 'expected_output' => "\033[34m[TASK] Test message arg\033[0m\n"];
+    yield 'info, no color' => ['function' => 'info', 'is_tty' => FALSE, 'expected_output' => "[INFO] Test message arg\n"];
+    yield 'info, with color' => ['function' => 'info', 'is_tty' => TRUE, 'expected_output' => "\033[36m[INFO] Test message arg\033[0m\n"];
+    yield 'pass, no color' => ['function' => 'pass', 'is_tty' => FALSE, 'expected_output' => "[ OK ] Test message arg\n"];
+    yield 'pass, with color' => ['function' => 'pass', 'is_tty' => TRUE, 'expected_output' => "\033[32m[ OK ] Test message arg\033[0m\n"];
+    yield 'fail_no_exit, no color' => ['function' => 'fail_no_exit', 'is_tty' => FALSE, 'expected_output' => "[FAIL] Test message arg\n"];
+    yield 'fail_no_exit, with color' => ['function' => 'fail_no_exit', 'is_tty' => TRUE, 'expected_output' => "\033[31m[FAIL] Test message arg\033[0m\n"];
   }
 
   #[DataProvider('dataProviderFail')]
@@ -72,8 +72,8 @@ final class HelpersFormatterTest extends UnitTestCase {
   }
 
   public static function dataProviderFail(): \Iterator {
-    yield 'no color' => [FALSE, "[FAIL] Test failure message\n"];
-    yield 'with color' => [TRUE, "\033[31m[FAIL] Test failure message\033[0m\n"];
+    yield 'no color' => ['is_tty' => FALSE, 'expected_output' => "[FAIL] Test failure message\n"];
+    yield 'with color' => ['is_tty' => TRUE, 'expected_output' => "\033[31m[FAIL] Test failure message\033[0m\n"];
   }
 
   #[DataProvider('dataProviderTermSupportsColor')]

--- a/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
@@ -46,7 +46,7 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -64,7 +64,7 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
@@ -97,7 +97,8 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
       $quit_thrown = TRUE;
     }
     finally {
-      $output = (string) ob_get_clean();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
     }
 
     $this->assertSame($result_code !== 0, $quit_thrown);

--- a/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
@@ -22,7 +22,8 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
     $this->mockPassthru(['cmd' => 'echo hello', 'output' => 'BUILD_OUTPUT', 'result_code' => 0]);
     ob_start();
     passthru_verbose_or_fail('echo hello');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
     $this->assertStringContainsString('BUILD_OUTPUT', $output);
   }
 
@@ -46,7 +47,8 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
       $this->assertSame(1, $e->getCode());
     }
     finally {
-      $output = (string) ob_get_clean();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
       $this->assertStringContainsString('Command failed.', $output);
     }
   }
@@ -63,7 +65,8 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
       $this->assertSame(1, $e->getCode());
     }
     finally {
-      $output = (string) ob_get_clean();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
       $this->assertStringContainsString('Failed to download from http://example.com.', $output);
     }
   }

--- a/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
@@ -43,7 +43,7 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = (string) ob_get_clean();
@@ -60,7 +60,7 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = (string) ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -46,7 +46,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   public function testDisabledByDefaultRendersNothing(): void {
     // QRCODE unset in both the environment and '.env': opt-in means nothing is
     // drawn, and qrencode is never even probed.
-    self::envUnset('QRCODE');
+    $this->envUnset('QRCODE');
     $this->mockDotenvAbsent();
 
     ob_start();
@@ -57,7 +57,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   }
 
   public function testExplicitlyDisabledRendersNothing(): void {
-    self::envSet('QRCODE', '0');
+    $this->envSet('QRCODE', '0');
 
     ob_start();
     print_qrcode('https://example.com');
@@ -67,7 +67,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   }
 
   public function testEnabledButQrencodeAbsentRendersNothing(): void {
-    self::envSet('QRCODE', '1');
+    $this->envSet('QRCODE', '1');
     $this->mockQrencodeAvailable(FALSE);
 
     ob_start();
@@ -78,7 +78,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   }
 
   public function testEnabledViaEnvRendersCode(): void {
-    self::envSet('QRCODE', '1');
+    $this->envSet('QRCODE', '1');
     $this->mockQrencodeAvailable(TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
@@ -93,7 +93,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   }
 
   public function testEnabledViaDotenvRendersCode(): void {
-    self::envUnset('QRCODE');
+    $this->envUnset('QRCODE');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
     $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(string $file): string => $file === '.env' ? "QRCODE=1\n" : '');
     $this->mockQrencodeAvailable(TRUE);

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -38,7 +38,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     // An empty URL short-circuits before the opt-in check or any probe.
     ob_start();
     print_qrcode('');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertSame('', $output);
   }
@@ -51,7 +52,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
     ob_start();
     print_qrcode('https://example.com');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertSame('', $output);
   }
@@ -61,7 +63,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
     ob_start();
     print_qrcode('https://example.com');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertSame('', $output);
   }
@@ -72,7 +75,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
     ob_start();
     print_qrcode('https://example.com');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertSame('', $output);
   }
@@ -87,7 +91,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
     ob_start();
     print_qrcode('https://example.com');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('[QR-CODE]', $output);
   }
@@ -104,7 +109,8 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
     ob_start();
     print_qrcode('https://example.com');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('[QR-CODE]', $output);
   }

--- a/.scaffold/tests/src/Unit/HelpersResolveWebdriverPortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersResolveWebdriverPortTest.php
@@ -28,7 +28,7 @@ final class HelpersResolveWebdriverPortTest extends UnitTestCase {
 
     // CI workflows may preload WEBDRIVER_PORT. Strip it so each test
     // starts from a known baseline.
-    self::envUnset('WEBDRIVER_PORT');
+    $this->envUnset('WEBDRIVER_PORT');
   }
 
   protected function tearDown(): void {
@@ -46,7 +46,7 @@ final class HelpersResolveWebdriverPortTest extends UnitTestCase {
   }
 
   public function testEnvOverridesDotenvAndDefault(): void {
-    self::envSet('WEBDRIVER_PORT', '9515');
+    $this->envSet('WEBDRIVER_PORT', '9515');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => TRUE);
     $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBDRIVER_PORT=1234\n");
 
@@ -113,7 +113,7 @@ final class HelpersResolveWebdriverPortTest extends UnitTestCase {
   }
 
   public function testValidationFailsOnMalformedPort(): void {
-    self::envSet('WEBDRIVER_PORT', 'not-a-port');
+    $this->envSet('WEBDRIVER_PORT', 'not-a-port');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
 
     $this->mockQuit(1);
@@ -134,7 +134,7 @@ final class HelpersResolveWebdriverPortTest extends UnitTestCase {
   }
 
   public function testValidationSkippedWhenDisabled(): void {
-    self::envSet('WEBDRIVER_PORT', 'not-a-port');
+    $this->envSet('WEBDRIVER_PORT', 'not-a-port');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
 
     $resolved = resolve_webdriver_port(validate_port: FALSE);

--- a/.scaffold/tests/src/Unit/HelpersResolveWebserverTest.php
+++ b/.scaffold/tests/src/Unit/HelpersResolveWebserverTest.php
@@ -28,8 +28,8 @@ final class HelpersResolveWebserverTest extends UnitTestCase {
 
     // CI workflows preload WEBSERVER_HOST. Strip it so each test
     // starts from a known baseline.
-    self::envUnset('WEBSERVER_HOST');
-    self::envUnset('WEBSERVER_PORT');
+    $this->envUnset('WEBSERVER_HOST');
+    $this->envUnset('WEBSERVER_PORT');
   }
 
   protected function tearDown(): void {
@@ -49,8 +49,8 @@ final class HelpersResolveWebserverTest extends UnitTestCase {
   }
 
   public function testEnvOverridesDotenvAndDefault(): void {
-    self::envSet('WEBSERVER_HOST', '0.0.0.0');
-    self::envSet('WEBSERVER_PORT', '9001');
+    $this->envSet('WEBSERVER_HOST', '0.0.0.0');
+    $this->envSet('WEBSERVER_PORT', '9001');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => TRUE);
     $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(): string => "WEBSERVER_HOST=ignored\nWEBSERVER_PORT=1234\n");
 
@@ -123,7 +123,7 @@ final class HelpersResolveWebserverTest extends UnitTestCase {
   }
 
   public function testValidationFailsOnMalformedPort(): void {
-    self::envSet('WEBSERVER_PORT', 'not-a-port');
+    $this->envSet('WEBSERVER_PORT', 'not-a-port');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
 
     $this->mockQuit(1);
@@ -144,7 +144,7 @@ final class HelpersResolveWebserverTest extends UnitTestCase {
   }
 
   public function testValidationSkippedWhenDisabled(): void {
-    self::envSet('WEBSERVER_PORT', 'not-a-port');
+    $this->envSet('WEBSERVER_PORT', 'not-a-port');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
 
     $resolved = resolve_webserver(validate_port: FALSE);

--- a/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
@@ -50,7 +50,8 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
 
     ob_start();
     run_custom_scripts($dir, 'assemble-');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('assemble-alpha.sh', $output);
     $this->assertStringContainsString('assemble-beta.sh', $output);
@@ -67,7 +68,8 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
 
     ob_start();
     run_custom_scripts($dir, 'assemble-');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('assemble-run.sh', $output);
     $this->assertStringNotContainsString('provision-skip.sh', $output);
@@ -85,7 +87,8 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
 
     ob_start();
     run_custom_scripts($dir, 'assemble-');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('assemble-real.sh', $output);
     $this->assertStringNotContainsString('assemble-rogue.sh', $output);
@@ -102,7 +105,8 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
 
     ob_start();
     run_custom_scripts($dir, 'assemble-');
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('assemble-real.sh', $output);
     $this->assertStringNotContainsString('assemble-readme.md', $output);
@@ -127,7 +131,8 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
       $this->assertSame(1, $e->getCode());
     }
     finally {
-      $output = (string) ob_get_clean();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
       $this->assertStringContainsString('provision-first.sh', $output);
       $this->assertStringContainsString('Custom script', $output);
       $this->assertStringContainsString('failed', $output);

--- a/.scaffold/tests/src/Unit/HelpersValidatePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersValidatePortTest.php
@@ -35,10 +35,10 @@ final class HelpersValidatePortTest extends UnitTestCase {
   }
 
   public static function dataProviderValidPortDoesNotFail(): \Iterator {
-    yield 'lowest valid' => ['1'];
-    yield 'common default' => ['8000'];
-    yield 'highest valid' => ['65535'];
-    yield 'mid range' => ['12345'];
+    yield 'lowest valid' => ['value' => '1'];
+    yield 'common default' => ['value' => '8000'];
+    yield 'highest valid' => ['value' => '65535'];
+    yield 'mid range' => ['value' => '12345'];
   }
 
   #[DataProvider('dataProviderInvalidPortFails')]
@@ -59,15 +59,15 @@ final class HelpersValidatePortTest extends UnitTestCase {
   }
 
   public static function dataProviderInvalidPortFails(): \Iterator {
-    yield 'empty string' => [''];
-    yield 'zero' => ['0'];
-    yield 'too high' => ['65536'];
-    yield 'negative' => ['-1'];
-    yield 'non-numeric' => ['abc'];
-    yield 'mixed alphanumeric' => ['80a0'];
-    yield 'with shell metacharacter' => ['8000; rm -rf /'];
-    yield 'with whitespace' => ['8000 '];
-    yield 'decimal' => ['80.0'];
+    yield 'empty string' => ['value' => ''];
+    yield 'zero' => ['value' => '0'];
+    yield 'too high' => ['value' => '65536'];
+    yield 'negative' => ['value' => '-1'];
+    yield 'non-numeric' => ['value' => 'abc'];
+    yield 'mixed alphanumeric' => ['value' => '80a0'];
+    yield 'with shell metacharacter' => ['value' => '8000; rm -rf /'];
+    yield 'with whitespace' => ['value' => '8000 '];
+    yield 'decimal' => ['value' => '80.0'];
   }
 
   public function testUsesProvidedSourceNameInErrorMessage(): void {

--- a/.scaffold/tests/src/Unit/HelpersValidatePortTest.php
+++ b/.scaffold/tests/src/Unit/HelpersValidatePortTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 /**
  * Tests for validate_port_or_fail() helper.
  *
- * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ * phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
  */

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -27,9 +27,9 @@ final class InfoTest extends UnitTestCase {
     // CI workflows pre-populate WEBSERVER_HOST and friends in the job
     // environment. Strip them so each test starts from a known state and
     // sees only the values it sets explicitly via envSet().
-    self::envUnset('WEBSERVER_HOST');
-    self::envUnset('WEBSERVER_PORT');
-    self::envUnset('DRUPAL_PROFILE');
+    $this->envUnset('WEBSERVER_HOST');
+    $this->envUnset('WEBSERVER_PORT');
+    $this->envUnset('DRUPAL_PROFILE');
   }
 
   protected function tearDown(): void {

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -455,7 +455,8 @@ final class InfoTest extends UnitTestCase {
     $argv = ['info', '--no-coverage'];
     ob_start();
     require dirname(__DIR__, 4) . '/.devtools/info';
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('ENVIRONMENT INFO', $output);
   }
@@ -489,7 +490,8 @@ final class InfoTest extends UnitTestCase {
       $this->assertSame($expected_exit_code, $e->getCode());
     }
     finally {
-      $output = (string) ob_get_clean();
+      $output = ob_get_clean();
+      $this->assertIsString($output);
     }
 
     return $output;

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -50,7 +50,8 @@ final class QrcodeTest extends UnitTestCase {
     $argv = ['qrcode', 'https://example.com'];
     ob_start();
     require dirname(__DIR__, 4) . '/.devtools/qrcode';
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertStringContainsString('[QR-CODE]', $output);
   }
@@ -59,7 +60,8 @@ final class QrcodeTest extends UnitTestCase {
     $argv = ['qrcode'];
     ob_start();
     require dirname(__DIR__, 4) . '/.devtools/qrcode';
-    $output = (string) ob_get_clean();
+    $output = ob_get_clean();
+    $this->assertIsString($output);
 
     $this->assertSame('', $output);
   }

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -29,7 +29,7 @@ final class QrcodeTest extends UnitTestCase {
 
   public function testRendersQrcodeForUrlArgument(): void {
     // Rendering is opt-in; enable it for this run.
-    self::envSet('QRCODE', '1');
+    $this->envSet('QRCODE', '1');
     $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
       $output ??= [];
       if (str_contains($cmd, 'command -v qrencode')) {

--- a/.scaffold/tests/src/Unit/StartTest.php
+++ b/.scaffold/tests/src/Unit/StartTest.php
@@ -156,7 +156,7 @@ final class StartTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -193,7 +193,7 @@ final class StartTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -234,7 +234,7 @@ final class StartTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -278,7 +278,7 @@ final class StartTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -477,7 +477,7 @@ final class StartTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertEquals(1, $e->getCode());
+      $this->assertSame(1, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "info            - Print a read-only summary of the current environment (alias: describe)."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
-	@echo "login           - Run Drush login command."
+	@echo "login           - Login to a website."
 	@echo "provision       - Provision application within assembled codebase."
 	@echo "reset           - Reset project to the default state (aliases: delete, destroy)."
 	@echo "start           - Start development environment."

--- a/init.php
+++ b/init.php
@@ -304,20 +304,20 @@ function process(string $extension_name, string $extension_machine_name, string 
   // Trim wrapper-specific permissions from Claude settings to match selection.
   $claude_settings = '.claude/settings.json';
   if (file_exists($claude_settings)) {
-    $settings_content = file_get_contents($claude_settings);
-    if ($settings_content === FALSE) {
+    $raw = file_get_contents($claude_settings);
+    if ($raw === FALSE) {
       // @codeCoverageIgnoreStart
       throw new \RuntimeException('Unable to read .claude/settings.json.');
       // @codeCoverageIgnoreEnd
     }
 
-    $settings = json_decode($settings_content, TRUE, 512, JSON_THROW_ON_ERROR);
-    if (!is_array($settings) || !isset($settings['permissions']) || !is_array($settings['permissions']) || !isset($settings['permissions']['allow']) || !is_array($settings['permissions']['allow'])) {
+    $config = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+    if (!is_array($config) || !isset($config['permissions']) || !is_array($config['permissions']) || !isset($config['permissions']['allow']) || !is_array($config['permissions']['allow'])) {
       throw new \RuntimeException('Invalid .claude/settings.json structure.');
     }
 
-    $settings['permissions']['allow'] = array_values(array_filter(
-      $settings['permissions']['allow'],
+    $config['permissions']['allow'] = array_values(array_filter(
+      $config['permissions']['allow'],
       static function ($permission) use ($command_wrapper): bool {
         $wrapper = match ($permission) {
           'Bash(ahoy:*)' => 'ahoy',
@@ -328,7 +328,7 @@ function process(string $extension_name, string $extension_machine_name, string 
       },
     ));
 
-    $encoded = json_encode($settings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    $encoded = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     if (file_put_contents($claude_settings, $encoded . PHP_EOL) === FALSE) {
       // @codeCoverageIgnoreStart
       throw new \RuntimeException('Unable to write .claude/settings.json.');
@@ -1093,16 +1093,16 @@ function remove_tokens_with_content(string $token): void {
 /**
  * Uncomment a line in a file by removing the "# " prefix.
  *
- * @param string $filename
+ * @param string $file
  *   The file to modify.
  * @param string $start_string
  *   The string that follows "# " at the start of the line.
  */
-function uncomment_line(string $filename, string $start_string): void {
-  if (!file_exists($filename)) {
+function uncomment_line(string $file, string $start_string): void {
+  if (!file_exists($file)) {
     return;
   }
-  $content = file_get_contents($filename);
+  $content = file_get_contents($file);
   if ($content === FALSE) {
     // @codeCoverageIgnoreStart
     return;
@@ -1116,7 +1116,7 @@ function uncomment_line(string $filename, string $start_string): void {
     }
   }
   unset($line);
-  file_put_contents($filename, implode("\n", $lines));
+  file_put_contents($file, implode("\n", $lines));
 }
 
 /**
@@ -1216,14 +1216,14 @@ function get_files(): array {
 /**
  * Check if a file is binary by looking for null bytes.
  *
- * @param string $path
+ * @param string $file
  *   The file path to check.
  *
  * @return bool
  *   TRUE if the file is binary, FALSE otherwise.
  */
-function is_binary_file(string $path): bool {
-  $handle = fopen($path, 'rb');
+function is_binary_file(string $file): bool {
+  $handle = fopen($file, 'rb');
   if ($handle === FALSE) {
     return TRUE;
   }
@@ -1241,22 +1241,22 @@ function is_binary_file(string $path): bool {
 /**
  * Remove directory recursively with all files.
  *
- * @param string $directory
+ * @param string $dir
  *   Path to the directory to remove.
  */
-function remove_dir(string $directory): void {
-  if (!is_dir($directory)) {
+function remove_dir(string $dir): void {
+  if (!is_dir($dir)) {
     return;
   }
 
-  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
 
   /** @var \SplFileInfo $item */
   foreach ($items as $item) {
     $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
   }
 
-  rmdir($directory);
+  rmdir($dir);
 }
 
 // Entrypoint.

--- a/your_extension.install
+++ b/your_extension.install
@@ -12,7 +12,7 @@ declare(strict_types=1);
  */
 function your_extension_install(): void {
   // Set default configuration values.
-  $config = \Drupal::service('config.factory')->getEditable('your_extension.settings');
+  $config = \Drupal::configFactory()->getEditable('your_extension.settings');
   $config->set('text', 'Default content to be displayed if JS is disabled.')->save();
 
   \Drupal::service('router.builder')->rebuild();

--- a/your_extension.module
+++ b/your_extension.module
@@ -22,7 +22,7 @@ function your_extension_page_attachments(array &$attachments): void {
  */
 function your_extension_page_bottom(array &$page_bottom): void {
   /** @var \Drupal\your_extension\YourExtensionService $your_extension_service */
-  $your_extension_service = \Drupal::getContainer()->get('your_extension.service');
+  $your_extension_service = \Drupal::service('your_extension.service');
 
   $text = $your_extension_service->getText();
 


### PR DESCRIPTION
## Summary

This PR converges the scaffold codebase onto its own dominant naming, API, and structure conventions, using the committed code itself as the source of truth rather than an external style guide. It is a behavior-preserving pass: every change moves an outlier onto the form the majority of its peers already use, or onto an explicit project rule, spanning `helpers.php`, the `.devtools` PHP command scripts, `init.php`, the twin `Makefile`/`.ahoy.yml` runners, and the Drupal module template. Each inconsistency class lives in its own commit (closely related same-file renames are grouped into one focused commit), with fixture regeneration (`update-snapshots`) kept as a separate generated-artifact commit. A substantial set of judgment calls was deliberately left untouched because it is either behavior-changing, a genuine tie with no dominant form, doc-only polish, or a public symbol that external consumers depend on - all of it is itemized below for a maintainer decision.

## What was applied

**Naming vocabulary**
- Duplicate fixture-tree builder `createStructure` -> `createDirectoryStructure` (the more descriptive existing name; 1v1 duplicate).
- `helpers.php` parameters unified: `$cmd` -> `$command` (matches the `command_*` family), dotenv path `$file` -> `$dotenv_file` (4v2), directory params `$directory`/`$path` -> `$dir` (dominant).
- `init.php` locals unified to the file's own dominant forms: `$filename`/`$path` -> `$file`, `$settings_content` -> `$raw`, `$settings` -> `$config`, `$directory` -> `$dir`.
- `.devtools` script locals: provision `$extension` -> `$extension_name` (matches assemble/info/init), decoded extension `composer.json` -> `$ext_json` in assemble+provision (removes a cross-script clash where the same name held a path string in one and an array in another).

**Structure**
- `@phpcs:disable` -> bare `phpcs:disable` in 5 docblocks (13+ already bare).

**API / interface shape**
- Scalar equality `assertEquals` -> `assertSame` at 19 sites in the scaffold suite (infra slice already uses `assertSame` exclusively; all sites are int `getCode()` or file-guarded strings, so the values are type-stable).
- Static env helpers `self::envSet`/`self::envUnset` -> `$this->` instance form at 29 sites (91v28 dominant); `self::envReset` left uniform.
- `ob_get_clean()` output: `(string)` cast -> assign + `$this->assertIsString($output)` in test bodies (assign+assert is the ~41v19 dominant form; helper-return casts left in place, since they are PHPStan-load-bearing).
- Positional data-provider rows -> rows keyed by the consuming test's parameter names (14v2; matches the already-keyed provider).
- `.devtools`: explicit `quit(0)` on the deploy early-quit (3 explicit vs 1 argless); raw `getenv()`+manual guard -> `getenv_default()` where provably identical (assemble `GITHUB_TOKEN`, deploy `SSH_AGENT_PID`).
- Runner usage/help text aligned between `Makefile` and `.ahoy.yml` for `login`, `test`, `browser-start`, `browser-stop` (16/20 commands were already word-identical; the 4 drifted strings converged).
- Module hooks: `\Drupal::getContainer()->get()` -> `\Drupal::service()`; `\Drupal::service('config.factory')` -> `\Drupal::configFactory()` (matches the same file's `hook_uninstall`).

## Judgment calls deferred to you

Deliberately NOT changed, because this pass is behavior-preserving only, or because there is no dominant form to converge onto. These are surfaced for a maintainer decision.

**Behavior-changing (out of scope for a behavior-preserving pass)**
- Module return types: `create()` returns concrete `YourExtensionForm` (with two `phpstan-ignore`s) instead of `static`; `buildForm()` omits the `array` return type its three siblings declare.
- `YourExtensionServiceKernelTest` builds the service via `new` + a prophesized `ConfigFactory` instead of the booted container, so real service wiring is never exercised.
- Module tests: `createUser()`/`$user` (no result assertion) vs `drupalCreateUser()`/`$account` (+`assertNotEmpty`) - not interchangeable wrappers.
- `init.php` confirm answers: real booleans from Prompty vs `'y'`/`'n'` strings threaded through `process()` and tested with `!== 'n'`.
- `tests/src` legacy `@group`/`@dataProvider`/`@covers` annotations duplicated beside (or missing) PHPUnit attributes - Drupal's `run-tests.sh` still parses annotations, so removing `@group` can change discovery.
- Runner behavioral divergences: ahoy `"$@"` passthrough on the phpunit commands (absent in Make), global `SIMPLETEST_*` exports vs Make per-recipe, `build` stop-failure tolerated in ahoy but aborting in Make, `drush` missing from `.PHONY`, pushd-per-tool vs single pushd.
- `.devtools` output text: completion-banner wording (`COMPLETE` vs `ENVIRONMENT READY/STOPPED`), `NOTE`-vs-`TASK` for deploy's git actions, `Xdebug`/`XDebug` label casing - p2-p5 functional tests assert exact stdout (XdebugTest pins `XDebug    : Disabled` verbatim), so any output convergence changes asserted output.
- `.devtools` call-shape deltas: `drush()` sprintf-preinterpolated vs `%s`-array (escaping differs), browser bare `passthru`+manual `FAIL` vs quiet `passthru_or_fail` (streaming vs suppressed), `XDEBUG` non-empty vs `DEPLOY_PROCEED === '1'` flag semantics, `resolve_*` return shapes, `passthru_or_fail` dropping the command exit code when a message is supplied.
- Scaffold test-infra architecture: `AhoyTest`/`MakeTest` ~260-line copy-paste twins vs `XdebugTest`'s parameterized `assertToggle($tool)`; `AutoPortDiscoveryTest` extending `Unit\UnitTestCase` from `Functional/`; `DevtoolsTestCase::tearDown` killing a hardcoded port 8000.
- `init.php` error handling: bare `json_decode` vs `JSON_THROW_ON_ERROR`; unreadable-file handling split three ways (throw / silent-skip / classify-as-binary); its own `remove_dir` using bare `unlink`/`rmdir`; feature removal implemented three ways.
- Module runtime/style: legacy constructor + `@var` property (Service) vs promoted constructor (Form); Service storing derived `ImmutableConfig` vs the injected factory; `info.yml` name `Drupal extension scaffold` vs `Your Extension` everywhere else; `Your Extension Settings` vs `settings` label casing.

**Genuine ties (no dominant form - coin-flip avoided)**
- Test-method command prefix: `test<Command><Scenario>` (31) vs `test<Scenario>` (31); no-op vocabulary (`IsNoop`/`IsSilent`/`RendersNothing`); missing-input vocabulary (`NonExistent`/`Missing`/`NoFile`/`Absent`); `$this->fail()` message wording; mock-setup helper vocabulary (`setup*`/`configure*`/`mock*`/`record*`); Makefile alias-notes present for `info`/`reset` but not `start`/`debug` (2v2).

**Polish, not consistency (belongs to a docs pass)**
- Comment/doc-only drift: `helpers.php` `@file` header says `Vortex`; `FunctionalTestCase` docblock names `UnitTestCase`; `XdEBUG` typo in `start`; UK/US prose spelling in `init.php`; `scripts/` hook header wording families.
- Dedup that would require inventing new shared APIs: the `lsof`-kill one-liner (3 scripts), the SQLite db-path literal (2 scripts), the dotenv line-filter loop, the port-discovery/persist block, the cloudflared `TUNNEL_URL` `.env` rewrite.

**Public symbol (external consumers)**
- `.devtools` lifecycle script filenames mix imperative verbs (`assemble`/`provision`/`start`/`stop`/`deploy`) with nouns (`browser`/`info`/`qrcode`); they are entry points referenced by `Makefile`, `.ahoy.yml`, CI, docs, and consumer projects, so renaming is not behavior-preserving.

## Verification

- p0 unit suite (427 tests) green after each applied class.
- Lint (PHPCS 46/46, PHPStan level 7 across 51 files, Rector) green on the final tree.
- InitTest regenerated and confirmed serially across all 23 datasets (92 assertions). The one `circleci` failure during regeneration was the known `update-snapshots` parallel:4 race, not a real diff - serial InitTest is green.
- Re-confirmed build-free gates after rebasing onto the base branch: `composer --working-dir=.scaffold/tests lint` and `composer --working-dir=.scaffold/tests test -- --group=p0`.

## Before / After

```
BEFORE (scattered conventions)                 AFTER (converged conventions)
--------------------------------               --------------------------------
helpers.php($cmd, $file, $directory)    ---->   helpers.php($command, $dotenv_file, $dir)
init.php($filename, $settings, $path)   ---->   init.php($file, $config, $dir)
assemble/provision: $extension,                 assemble/provision: $extension_name,
  $composer_data vs $composer_json        ---->   $ext_json (both scripts, one shape)
assertEquals(...)                       ---->   assertSame(...)            [type-stable sites]
self::envSet()/self::envUnset()         ---->   $this->envSet()/$this->envUnset()
(string) ob_get_clean()                 ---->   $output = ob_get_clean(); assertIsString($output)
dataProvider [0 => 'a', 1 => 'b']        ---->   dataProvider ['param' => 'a', ...]
getenv('X') === FALSE || === ''         ---->   getenv_default('X', '') === ''
quit()                                  ---->   quit(0)                    [deploy early-quit]
Makefile/.ahoy.yml usage text drifted    ---->   usage text word-identical (login/test/browser-*)
\Drupal::getContainer()->get('config.factory')  \Drupal::configFactory()
\Drupal::getContainer()->get('svc')     ---->   \Drupal::service('svc')
@phpcs:disable (5 docblocks)            ---->   phpcs:disable              [13+ already bare]
createStructure() (duplicate helper)    ---->   createDirectoryStructure()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Standardizes scaffold naming, APIs, and structural conventions without changing intended behavior.

- Renamed helper parameters and local variables across `init.php` and `.devtools` scripts.
- Unified test conventions, including strict assertions, environment helpers, output type checks, PHPCS pragmas, and keyed data providers.
- Updated Drupal service and configuration access patterns.
- Simplified selected environment handling and made deploy success exits explicit.
- Aligned `.ahoy.yml` and `Makefile` help text.
- Renamed a duplicate filesystem fixture helper.
- Regenerated snapshots separately.

Verification passed for unit tests, PHPCS, PHPStan, Rector, and serialized snapshot tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->