### PR TITLE
Resolved the deferred consistency judgment calls from the previous convergence pass.

### DIFF
--- a/.devtools/browser
+++ b/.devtools/browser
@@ -94,7 +94,7 @@ function browser_stop(): void {
   }
 
   TASK('Stopping the WebDriver process on port %s, if any.', $port);
-  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
+  kill_port($port);
   sleep(1);
 
   PASS('Browser stopped on port %s.', $port);
@@ -158,11 +158,7 @@ function selenium_start(): void {
 
   // The default 64 MB '/dev/shm' is too small for Chromium and leads to tab
   // crashes mid-test; the Selenium images document 2g as the required size.
-  $exit_code = 0;
-  passthru(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), $exit_code);
-  if ($exit_code !== 0) {
-    FAIL('Failed to start the Selenium container.');
-  }
+  passthru_or_fail(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), 'Failed to start the Selenium container.');
 
   NOTE('Waiting for Selenium to be ready.');
   for ($i = 0; $i < 30; $i++) {
@@ -185,7 +181,7 @@ function selenium_start(): void {
  * Resolve the WebDriver backend, aborting on an unsupported value.
  */
 function webdriver_backend(): string {
-  [$backend] = resolve_env_value('WEBDRIVER_BACKEND', 'chromedriver');
+  $backend = resolve_env_value('WEBDRIVER_BACKEND', 'chromedriver')['value'];
 
   if (!in_array($backend, ['chromedriver', 'selenium'], TRUE)) {
     FAIL("Unknown WEBDRIVER_BACKEND '%s'. Use 'chromedriver' or 'selenium'.", $backend);
@@ -259,11 +255,7 @@ function resolve_chromedriver_binary(string $chrome_version): string {
   $log = CHROMEDRIVER_DIR . '/install.log';
 
   TASK('Fetching chromedriver matching Chrome %s.', $chrome_version);
-  $exit_code = 0;
-  passthru(sprintf('npx -y @puppeteer/browsers install %s --path %s >%s', escapeshellarg('chromedriver@' . $chrome_version), escapeshellarg(CHROMEDRIVER_DIR), escapeshellarg($log)), $exit_code);
-  if ($exit_code !== 0) {
-    FAIL('Failed to install chromedriver matching Chrome %s.', $chrome_version);
-  }
+  passthru_or_fail(sprintf('npx -y @puppeteer/browsers install %s --path %s >%s', escapeshellarg('chromedriver@' . $chrome_version), escapeshellarg(CHROMEDRIVER_DIR), escapeshellarg($log)), 'Failed to install chromedriver matching Chrome %s.', $chrome_version);
 
   $binary = parse_installed_binary($log);
   if ($binary === '') {

--- a/.devtools/deploy
+++ b/.devtools/deploy
@@ -111,20 +111,20 @@ if ($deploy_proceed !== '1') {
 
 $git_user_name = trim((string) shell_exec('git config --global user.name'));
 if ($git_user_name === '') {
-  NOTE('Configuring global git user name %s.', $deploy_user_name);
+  TASK('Configuring global git user name %s.', $deploy_user_name);
   passthru_or_fail(sprintf('git config --global user.name %s', escapeshellarg($deploy_user_name)));
 }
 
 $git_user_email = trim((string) shell_exec('git config --global user.email'));
 if ($git_user_email === '') {
-  NOTE('Configuring global git user email %s.', $deploy_user_email);
+  TASK('Configuring global git user email %s.', $deploy_user_email);
   passthru_or_fail(sprintf('git config --global user.email %s', escapeshellarg($deploy_user_email)));
 }
 
-NOTE('Setting git to push to a matching remote branch.');
+TASK('Setting git to push to a matching remote branch.');
 passthru_or_fail('git config --global push.default matching');
 
-NOTE('Adding remote %s.', $deploy_remote);
+TASK('Adding remote %s.', $deploy_remote);
 passthru_or_fail(sprintf('git remote add deployremote %s', escapeshellarg($deploy_remote)));
 
 if ($deploy_branch === '') {

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -4,15 +4,17 @@
  * @file
  * Helper functions for DevTools tooling scripts.
  *
- * This file provides reusable PHP helper functions for Vortex notification
- * and utility scripts, enabling consistent behavior across all tooling.
+ * This file provides reusable PHP helper functions shared by the
+ * '.devtools/*' command scripts, enabling consistent behavior across all
+ * tooling.
  *
  * ## Why We Use These Helpers
  *
  * These helper functions serve several critical purposes:
  *
  * 1. **Consistency**: Standardized output formatting (info, task, pass, fail)
- *    ensures all Vortex scripts produce uniform, recognizable messages.
+ *    ensures all '.devtools/*' scripts produce uniform, recognizable
+ *    messages.
  *
  * 2. **Reusability**: Common operations (files operations, command execution,
  *    etc.) are centralized to avoid code duplication.

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -205,23 +205,66 @@ function dotenv_write_var(string $key, string $value, string $dotenv_file = '.en
  * @param string $dotenv_file
  *   Path to the dotenv file to consult.
  *
- * @return array{0: string, 1: string}
- *   Tuple of [value, source] where source is 'env' when the value came
- *   from the shell environment, the dotenv file path when the value
+ * @return array{value: string, source: string}
+ *   Resolved value together with a source label: 'env' when the value
+ *   came from the shell environment, the dotenv file path when the value
  *   came from that file, or 'default' when neither produced a value.
  */
 function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
   $env = getenv($name);
   if ($env !== FALSE && $env !== '') {
-    return [$env, 'env'];
+    return ['value' => $env, 'source' => 'env'];
   }
 
   $dotenv = dotenv_read($dotenv_file);
   if (isset($dotenv[$name]) && $dotenv[$name] !== '') {
-    return [$dotenv[$name], $dotenv_file];
+    return ['value' => $dotenv[$name], 'source' => $dotenv_file];
   }
 
-  return [$default, 'default'];
+  return ['value' => $default, 'source' => 'default'];
+}
+
+/**
+ * Resolve a port variable, auto-discovering and persisting one when unset.
+ *
+ * Shared by resolve_webserver() and resolve_webdriver_port(): both resolve
+ * a named port variable via the env -> dotenv -> default chain, and, when
+ * auto-discovery is requested and neither source supplies a value,
+ * allocate a free port starting from $scan_start and persist it back to
+ * the dotenv file so repeat runs reuse the same port.
+ *
+ * @param string $name
+ *   Variable name to resolve (e.g. 'WEBSERVER_PORT').
+ * @param string $default
+ *   Value to use when auto-discovery is disabled and neither env nor the
+ *   dotenv file supplies one.
+ * @param bool $auto_discover
+ *   When TRUE and the port resolves from neither env nor dotenv, discover
+ *   a free port via find_free_port() and persist it via
+ *   dotenv_write_var(). The reported source then becomes the dotenv file
+ *   path because that is where the value now lives.
+ * @param int $scan_start
+ *   Port number to start the free-port scan from when auto-discovery
+ *   kicks in.
+ * @param string $dotenv_file
+ *   Path to the dotenv file to read and (optionally) write.
+ *
+ * @return array{value: string, source: string}
+ *   Resolved port and source, in the same shape as resolve_env_value(),
+ *   with source updated to the dotenv file path when auto-discovery
+ *   persisted a value.
+ */
+function resolve_port_value(string $name, string $default, bool $auto_discover, int $scan_start, string $dotenv_file = '.env'): array {
+  $default_port = $auto_discover ? '' : $default;
+  ['value' => $port, 'source' => $port_source] = resolve_env_value($name, $default_port, $dotenv_file);
+
+  if ($auto_discover && $port_source === 'default') {
+    $port = (string) find_free_port($scan_start);
+    dotenv_write_var($name, $port, $dotenv_file);
+    $port_source = $dotenv_file;
+  }
+
+  return ['value' => $port, 'source' => $port_source];
 }
 
 /**
@@ -253,16 +296,8 @@ function resolve_env_value(string $name, string $default, string $dotenv_file = 
  *   the supplied default was used.
  */
 function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
-  [$host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
-
-  $default_port = $auto_discover ? '' : '8000';
-  [$port, $port_source] = resolve_env_value('WEBSERVER_PORT', $default_port, $dotenv_file);
-
-  if ($auto_discover && $port_source === 'default') {
-    $port = (string) find_free_port();
-    dotenv_write_var('WEBSERVER_PORT', $port, $dotenv_file);
-    $port_source = $dotenv_file;
-  }
+  ['value' => $host, 'source' => $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
+  ['value' => $port, 'source' => $port_source] = resolve_port_value('WEBSERVER_PORT', '8000', $auto_discover, 8000, $dotenv_file);
 
   if ($validate_port) {
     validate_port_or_fail($port, 'WEBSERVER_PORT');
@@ -303,14 +338,7 @@ function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TR
  *   or 'default'.
  */
 function resolve_webdriver_port(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
-  $default_port = $auto_discover ? '' : '4444';
-  [$port, $port_source] = resolve_env_value('WEBDRIVER_PORT', $default_port, $dotenv_file);
-
-  if ($auto_discover && $port_source === 'default') {
-    $port = (string) find_free_port(4444);
-    dotenv_write_var('WEBDRIVER_PORT', $port, $dotenv_file);
-    $port_source = $dotenv_file;
-  }
+  ['value' => $port, 'source' => $port_source] = resolve_port_value('WEBDRIVER_PORT', '4444', $auto_discover, 4444, $dotenv_file);
 
   if ($validate_port) {
     validate_port_or_fail($port, 'WEBDRIVER_PORT');
@@ -421,6 +449,20 @@ function find_free_port(int $start = 8000, int $max_attempts = 100): int {
   // @codeCoverageIgnoreStart
   return $start;
   // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Kill whatever process is listening on a TCP port, if any.
+ *
+ * A best-effort operation: a missing listener or a missing 'lsof' binary
+ * are silenced so callers may invoke it unconditionally before (re)binding
+ * the same port.
+ *
+ * @param int|string $port
+ *   The TCP port to free.
+ */
+function kill_port(int|string $port): void {
+  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg((string) $port)));
 }
 
 /**
@@ -570,8 +612,11 @@ function passthru_or_fail(string $command, string $format = '', string|int|float
   }
 
   if ($exit_code !== 0) {
+    // Surface the failure message without exiting here so the quit() below
+    // always preserves the command's real exit code, whether or not a
+    // message was supplied.
     if ($format !== '') {
-      FAIL($format, ...$args);
+      FAIL_NO_EXIT($format, ...$args);
     }
 
     quit($exit_code);
@@ -590,8 +635,11 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
   passthru($command, $exit_code);
 
   if ($exit_code !== 0) {
+    // Surface the failure message without exiting here so the quit() below
+    // always preserves the command's real exit code, whether or not a
+    // message was supplied.
     if ($format !== '') {
-      FAIL($format, ...$args);
+      FAIL_NO_EXIT($format, ...$args);
     }
 
     quit($exit_code);
@@ -616,7 +664,7 @@ function print_qrcode(string $url): void {
     return;
   }
 
-  [$enabled] = resolve_env_value('QRCODE', '');
+  $enabled = resolve_env_value('QRCODE', '')['value'];
   if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
     return;
   }
@@ -743,6 +791,20 @@ function extension_info(): array {
   $type = str_contains((string) file_get_contents($info_files[0]), 'type: theme') ? 'theme' : 'module';
 
   return ['name' => $name, 'type' => $type];
+}
+
+/**
+ * Build the path to the extension's SQLite database file.
+ *
+ * @param string $extension_name
+ *   Machine name of the extension, as returned by extension_info().
+ *
+ * @return string
+ *   Absolute path to the SQLite database file used by the site-install
+ *   and status commands.
+ */
+function site_db_file(string $extension_name): string {
+  return '/tmp/site_' . $extension_name . '.sqlite';
 }
 
 /**

--- a/.devtools/info
+++ b/.devtools/info
@@ -92,9 +92,8 @@ if ($field !== NULL) {
 $values = array_map(fn(callable $cb): string => $cb(), $fields);
 $php_path = command_path('php');
 
-echo PHP_EOL;
 echo '===============================' . PHP_EOL;
-echo '       ENVIRONMENT INFO        ' . PHP_EOL;
+echo '      ℹ️ ENVIRONMENT INFO      ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 printf("Drupal version:     %s%s", $values['drupal-version'], PHP_EOL);

--- a/.devtools/info
+++ b/.devtools/info
@@ -45,7 +45,7 @@ $build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
 
 $info_files = glob('*.info.yml');
 $extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
-$db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
+$db_file = $extension_name !== '' ? site_db_file($extension_name) : '-';
 
 $drush_bin = 'build/vendor/bin/drush';
 $has_drush = is_file($drush_bin);
@@ -148,6 +148,10 @@ function info_tool_version(string $cmd, string $pattern): string {
  * Get the installed Drupal version via drush, or '-' if unavailable.
  */
 function info_drupal_version(string $drush_bin): string {
+  // Intentionally bypasses drush(): that helper merges stderr into its
+  // return value so build-time failures stay diagnosable, which would leak
+  // any stray notice into the version string returned here. This probe
+  // instead discards stderr so it always yields either a clean value or '-'.
   $cmd = escapeshellarg($drush_bin) . ' -r ' . escapeshellarg(getcwd() . '/build/web') . ' status --field=drupal-version 2>/dev/null';
   $out = trim((string) @shell_exec($cmd));
 

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -40,7 +40,7 @@ $ext_info = extension_info();
 $extension_name = $ext_info['name'];
 $extension_type = $ext_info['type'];
 
-$db_file = '/tmp/site_' . $extension_name . '.sqlite';
+$db_file = site_db_file($extension_name);
 
 TASK('Installing Drupal into SQLite database %s.', $db_file);
 
@@ -50,7 +50,7 @@ if ($db_status === 'Connected') {
   drush('sql:drop -y', NULL, $exit_code);
 }
 
-drush(sprintf('site-install %%s -y --db-url="sqlite://localhost/%s" --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', $db_file), [$drupal_profile]);
+drush('site-install %s -y --db-url=%s --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', [$drupal_profile, 'sqlite://localhost/' . $db_file]);
 
 PASS('Drupal installed.');
 
@@ -102,7 +102,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Site URL:            ' . $site_url . PHP_EOL;
 echo 'One-time login link: ';
-echo drush(sprintf('uli -l %s --no-browser', $site_url));
+echo drush('uli -l %s --no-browser', [$site_url]);
 echo PHP_EOL;
 if (file_exists('.ahoy.yml')) {
   echo 'Run `ahoy` to see available commands.' . PHP_EOL;

--- a/.devtools/start
+++ b/.devtools/start
@@ -51,7 +51,7 @@ if ($xdebug_enabled) {
 }
 
 TASK('Stopping previously started services, if any.');
-@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+kill_port($webserver_port);
 
 TASK('Starting the PHP webserver.');
 $cwd = (string) getcwd();

--- a/.devtools/start
+++ b/.devtools/start
@@ -27,7 +27,7 @@ $webserver_port = $webserver['port'];
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
 
-// Enable Xdebug when XdEBUG env var is set. Xdebug extension must be installed
+// Enable XDebug when XDebug env var is set. XDebug extension must be installed
 // and configured on host environment (php -v should show `with Xdebug`).
 // Coverage stays on pcov in test commands because xdebug.mode=debug does
 // not include "coverage", so pcov remains the active coverage driver.
@@ -42,12 +42,12 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 if ($xdebug_enabled) {
-  TASK('Verifying that the Xdebug PHP extension is installed.');
+  TASK('Verifying that the XDebug PHP extension is installed.');
   $php_v = (string) shell_exec('php -v 2>/dev/null');
   if (stripos($php_v, 'xdebug') === FALSE) {
-    FAIL('XDEBUG=1 is set but the Xdebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
+    FAIL('XDEBUG=1 is set but the XDebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
   }
-  PASS('Xdebug extension is loaded.');
+  PASS('XDebug extension is loaded.');
 }
 
 TASK('Stopping previously started services, if any.');

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -31,7 +31,7 @@ echo PHP_EOL;
 run_custom_scripts('scripts', 'stop-');
 
 TASK('Stopping previously started services on port %s, if any.', $webserver_port);
-@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+kill_port($webserver_port);
 sleep(1);
 PASS('Services stopped on port %s.', $webserver_port);
 

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -22,6 +22,8 @@ PHPUnit tests are tagged with `#[Group('p0'..'p5')]` so CI can shard them across
 - `p4` - `MakeTest` (Makefile command wrapper).
 - `p5` - `XdebugTest` (XDebug step-debugging toggle). This is the only group whose CI runner installs the xdebug PHP extension via `coverage: xdebug` instead of pcov - the test exercises the real extension end to end, so coverage is not collected for this group.
 
+**Do not DRY the per-wrapper tests.** `AhoyTest` (p3) and `MakeTest` (p4) are intentionally kept as separate, near-parallel test classes - one per command wrapper. Never merge or parameterize them into a single shared class: each wrapper (`ahoy`, `make`) must be exercised by its own independent test so a regression in one runner can never be masked by the other. `XdebugTest`'s single parameterized `assertToggle()` is a deliberate exception for one feature toggled through both wrappers, not a pattern to extend across the whole command surface.
+
 ## Running the tests
 
 All commands run from `.scaffold/tests/`. Install dependencies once with `composer --working-dir=.scaffold/tests install`.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
@@ -94,7 +94,7 @@ function browser_stop(): void {
   }
 
   TASK('Stopping the WebDriver process on port %s, if any.', $port);
-  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($port)));
+  kill_port($port);
   sleep(1);
 
   PASS('Browser stopped on port %s.', $port);
@@ -158,11 +158,7 @@ function selenium_start(): void {
 
   // The default 64 MB '/dev/shm' is too small for Chromium and leads to tab
   // crashes mid-test; the Selenium images document 2g as the required size.
-  $exit_code = 0;
-  passthru(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), $exit_code);
-  if ($exit_code !== 0) {
-    FAIL('Failed to start the Selenium container.');
-  }
+  passthru_or_fail(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), 'Failed to start the Selenium container.');
 
   NOTE('Waiting for Selenium to be ready.');
   for ($i = 0; $i < 30; $i++) {
@@ -185,7 +181,7 @@ function selenium_start(): void {
  * Resolve the WebDriver backend, aborting on an unsupported value.
  */
 function webdriver_backend(): string {
-  [$backend] = resolve_env_value('WEBDRIVER_BACKEND', 'chromedriver');
+  $backend = resolve_env_value('WEBDRIVER_BACKEND', 'chromedriver')['value'];
 
   if (!in_array($backend, ['chromedriver', 'selenium'], TRUE)) {
     FAIL("Unknown WEBDRIVER_BACKEND '%s'. Use 'chromedriver' or 'selenium'.", $backend);
@@ -259,11 +255,7 @@ function resolve_chromedriver_binary(string $chrome_version): string {
   $log = CHROMEDRIVER_DIR . '/install.log';
 
   TASK('Fetching chromedriver matching Chrome %s.', $chrome_version);
-  $exit_code = 0;
-  passthru(sprintf('npx -y @puppeteer/browsers install %s --path %s >%s', escapeshellarg('chromedriver@' . $chrome_version), escapeshellarg(CHROMEDRIVER_DIR), escapeshellarg($log)), $exit_code);
-  if ($exit_code !== 0) {
-    FAIL('Failed to install chromedriver matching Chrome %s.', $chrome_version);
-  }
+  passthru_or_fail(sprintf('npx -y @puppeteer/browsers install %s --path %s >%s', escapeshellarg('chromedriver@' . $chrome_version), escapeshellarg(CHROMEDRIVER_DIR), escapeshellarg($log)), 'Failed to install chromedriver matching Chrome %s.', $chrome_version);
 
   $binary = parse_installed_binary($log);
   if ($binary === '') {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/deploy
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/deploy
@@ -111,20 +111,20 @@ if ($deploy_proceed !== '1') {
 
 $git_user_name = trim((string) shell_exec('git config --global user.name'));
 if ($git_user_name === '') {
-  NOTE('Configuring global git user name %s.', $deploy_user_name);
+  TASK('Configuring global git user name %s.', $deploy_user_name);
   passthru_or_fail(sprintf('git config --global user.name %s', escapeshellarg($deploy_user_name)));
 }
 
 $git_user_email = trim((string) shell_exec('git config --global user.email'));
 if ($git_user_email === '') {
-  NOTE('Configuring global git user email %s.', $deploy_user_email);
+  TASK('Configuring global git user email %s.', $deploy_user_email);
   passthru_or_fail(sprintf('git config --global user.email %s', escapeshellarg($deploy_user_email)));
 }
 
-NOTE('Setting git to push to a matching remote branch.');
+TASK('Setting git to push to a matching remote branch.');
 passthru_or_fail('git config --global push.default matching');
 
-NOTE('Adding remote %s.', $deploy_remote);
+TASK('Adding remote %s.', $deploy_remote);
 passthru_or_fail(sprintf('git remote add deployremote %s', escapeshellarg($deploy_remote)));
 
 if ($deploy_branch === '') {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -4,15 +4,17 @@
  * @file
  * Helper functions for DevTools tooling scripts.
  *
- * This file provides reusable PHP helper functions for Vortex notification
- * and utility scripts, enabling consistent behavior across all tooling.
+ * This file provides reusable PHP helper functions shared by the
+ * '.devtools/*' command scripts, enabling consistent behavior across all
+ * tooling.
  *
  * ## Why We Use These Helpers
  *
  * These helper functions serve several critical purposes:
  *
  * 1. **Consistency**: Standardized output formatting (info, task, pass, fail)
- *    ensures all Vortex scripts produce uniform, recognizable messages.
+ *    ensures all '.devtools/*' scripts produce uniform, recognizable
+ *    messages.
  *
  * 2. **Reusability**: Common operations (files operations, command execution,
  *    etc.) are centralized to avoid code duplication.
@@ -203,23 +205,66 @@ function dotenv_write_var(string $key, string $value, string $dotenv_file = '.en
  * @param string $dotenv_file
  *   Path to the dotenv file to consult.
  *
- * @return array{0: string, 1: string}
- *   Tuple of [value, source] where source is 'env' when the value came
- *   from the shell environment, the dotenv file path when the value
+ * @return array{value: string, source: string}
+ *   Resolved value together with a source label: 'env' when the value
+ *   came from the shell environment, the dotenv file path when the value
  *   came from that file, or 'default' when neither produced a value.
  */
 function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
   $env = getenv($name);
   if ($env !== FALSE && $env !== '') {
-    return [$env, 'env'];
+    return ['value' => $env, 'source' => 'env'];
   }
 
   $dotenv = dotenv_read($dotenv_file);
   if (isset($dotenv[$name]) && $dotenv[$name] !== '') {
-    return [$dotenv[$name], $dotenv_file];
+    return ['value' => $dotenv[$name], 'source' => $dotenv_file];
   }
 
-  return [$default, 'default'];
+  return ['value' => $default, 'source' => 'default'];
+}
+
+/**
+ * Resolve a port variable, auto-discovering and persisting one when unset.
+ *
+ * Shared by resolve_webserver() and resolve_webdriver_port(): both resolve
+ * a named port variable via the env -> dotenv -> default chain, and, when
+ * auto-discovery is requested and neither source supplies a value,
+ * allocate a free port starting from $scan_start and persist it back to
+ * the dotenv file so repeat runs reuse the same port.
+ *
+ * @param string $name
+ *   Variable name to resolve (e.g. 'WEBSERVER_PORT').
+ * @param string $default
+ *   Value to use when auto-discovery is disabled and neither env nor the
+ *   dotenv file supplies one.
+ * @param bool $auto_discover
+ *   When TRUE and the port resolves from neither env nor dotenv, discover
+ *   a free port via find_free_port() and persist it via
+ *   dotenv_write_var(). The reported source then becomes the dotenv file
+ *   path because that is where the value now lives.
+ * @param int $scan_start
+ *   Port number to start the free-port scan from when auto-discovery
+ *   kicks in.
+ * @param string $dotenv_file
+ *   Path to the dotenv file to read and (optionally) write.
+ *
+ * @return array{value: string, source: string}
+ *   Resolved port and source, in the same shape as resolve_env_value(),
+ *   with source updated to the dotenv file path when auto-discovery
+ *   persisted a value.
+ */
+function resolve_port_value(string $name, string $default, bool $auto_discover, int $scan_start, string $dotenv_file = '.env'): array {
+  $default_port = $auto_discover ? '' : $default;
+  ['value' => $port, 'source' => $port_source] = resolve_env_value($name, $default_port, $dotenv_file);
+
+  if ($auto_discover && $port_source === 'default') {
+    $port = (string) find_free_port($scan_start);
+    dotenv_write_var($name, $port, $dotenv_file);
+    $port_source = $dotenv_file;
+  }
+
+  return ['value' => $port, 'source' => $port_source];
 }
 
 /**
@@ -251,16 +296,8 @@ function resolve_env_value(string $name, string $default, string $dotenv_file = 
  *   the supplied default was used.
  */
 function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
-  [$host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
-
-  $default_port = $auto_discover ? '' : '8000';
-  [$port, $port_source] = resolve_env_value('WEBSERVER_PORT', $default_port, $dotenv_file);
-
-  if ($auto_discover && $port_source === 'default') {
-    $port = (string) find_free_port();
-    dotenv_write_var('WEBSERVER_PORT', $port, $dotenv_file);
-    $port_source = $dotenv_file;
-  }
+  ['value' => $host, 'source' => $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
+  ['value' => $port, 'source' => $port_source] = resolve_port_value('WEBSERVER_PORT', '8000', $auto_discover, 8000, $dotenv_file);
 
   if ($validate_port) {
     validate_port_or_fail($port, 'WEBSERVER_PORT');
@@ -301,14 +338,7 @@ function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TR
  *   or 'default'.
  */
 function resolve_webdriver_port(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
-  $default_port = $auto_discover ? '' : '4444';
-  [$port, $port_source] = resolve_env_value('WEBDRIVER_PORT', $default_port, $dotenv_file);
-
-  if ($auto_discover && $port_source === 'default') {
-    $port = (string) find_free_port(4444);
-    dotenv_write_var('WEBDRIVER_PORT', $port, $dotenv_file);
-    $port_source = $dotenv_file;
-  }
+  ['value' => $port, 'source' => $port_source] = resolve_port_value('WEBDRIVER_PORT', '4444', $auto_discover, 4444, $dotenv_file);
 
   if ($validate_port) {
     validate_port_or_fail($port, 'WEBDRIVER_PORT');
@@ -419,6 +449,20 @@ function find_free_port(int $start = 8000, int $max_attempts = 100): int {
   // @codeCoverageIgnoreStart
   return $start;
   // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Kill whatever process is listening on a TCP port, if any.
+ *
+ * A best-effort operation: a missing listener or a missing 'lsof' binary
+ * are silenced so callers may invoke it unconditionally before (re)binding
+ * the same port.
+ *
+ * @param int|string $port
+ *   The TCP port to free.
+ */
+function kill_port(int|string $port): void {
+  @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg((string) $port)));
 }
 
 /**
@@ -568,8 +612,11 @@ function passthru_or_fail(string $command, string $format = '', string|int|float
   }
 
   if ($exit_code !== 0) {
+    // Surface the failure message without exiting here so the quit() below
+    // always preserves the command's real exit code, whether or not a
+    // message was supplied.
     if ($format !== '') {
-      FAIL($format, ...$args);
+      FAIL_NO_EXIT($format, ...$args);
     }
 
     quit($exit_code);
@@ -588,8 +635,11 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
   passthru($command, $exit_code);
 
   if ($exit_code !== 0) {
+    // Surface the failure message without exiting here so the quit() below
+    // always preserves the command's real exit code, whether or not a
+    // message was supplied.
     if ($format !== '') {
-      FAIL($format, ...$args);
+      FAIL_NO_EXIT($format, ...$args);
     }
 
     quit($exit_code);
@@ -614,7 +664,7 @@ function print_qrcode(string $url): void {
     return;
   }
 
-  [$enabled] = resolve_env_value('QRCODE', '');
+  $enabled = resolve_env_value('QRCODE', '')['value'];
   if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
     return;
   }
@@ -741,6 +791,20 @@ function extension_info(): array {
   $type = str_contains((string) file_get_contents($info_files[0]), 'type: theme') ? 'theme' : 'module';
 
   return ['name' => $name, 'type' => $type];
+}
+
+/**
+ * Build the path to the extension's SQLite database file.
+ *
+ * @param string $extension_name
+ *   Machine name of the extension, as returned by extension_info().
+ *
+ * @return string
+ *   Absolute path to the SQLite database file used by the site-install
+ *   and status commands.
+ */
+function site_db_file(string $extension_name): string {
+  return '/tmp/site_' . $extension_name . '.sqlite';
 }
 
 /**

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/info
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/info
@@ -45,7 +45,7 @@ $build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
 
 $info_files = glob('*.info.yml');
 $extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
-$db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
+$db_file = $extension_name !== '' ? site_db_file($extension_name) : '-';
 
 $drush_bin = 'build/vendor/bin/drush';
 $has_drush = is_file($drush_bin);
@@ -92,9 +92,8 @@ if ($field !== NULL) {
 $values = array_map(fn(callable $cb): string => $cb(), $fields);
 $php_path = command_path('php');
 
-echo PHP_EOL;
 echo '===============================' . PHP_EOL;
-echo '       ENVIRONMENT INFO        ' . PHP_EOL;
+echo '      ℹ️ ENVIRONMENT INFO      ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 printf("Drupal version:     %s%s", $values['drupal-version'], PHP_EOL);
@@ -149,6 +148,10 @@ function info_tool_version(string $cmd, string $pattern): string {
  * Get the installed Drupal version via drush, or '-' if unavailable.
  */
 function info_drupal_version(string $drush_bin): string {
+  // Intentionally bypasses drush(): that helper merges stderr into its
+  // return value so build-time failures stay diagnosable, which would leak
+  // any stray notice into the version string returned here. This probe
+  // instead discards stderr so it always yields either a clean value or '-'.
   $cmd = escapeshellarg($drush_bin) . ' -r ' . escapeshellarg(getcwd() . '/build/web') . ' status --field=drupal-version 2>/dev/null';
   $out = trim((string) @shell_exec($cmd));
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/provision
@@ -40,7 +40,7 @@ $ext_info = extension_info();
 $extension_name = $ext_info['name'];
 $extension_type = $ext_info['type'];
 
-$db_file = '/tmp/site_' . $extension_name . '.sqlite';
+$db_file = site_db_file($extension_name);
 
 TASK('Installing Drupal into SQLite database %s.', $db_file);
 
@@ -50,7 +50,7 @@ if ($db_status === 'Connected') {
   drush('sql:drop -y', NULL, $exit_code);
 }
 
-drush(sprintf('site-install %%s -y --db-url="sqlite://localhost/%s" --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', $db_file), [$drupal_profile]);
+drush('site-install %s -y --db-url=%s --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', [$drupal_profile, 'sqlite://localhost/' . $db_file]);
 
 PASS('Drupal installed.');
 
@@ -102,7 +102,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Site URL:            ' . $site_url . PHP_EOL;
 echo 'One-time login link: ';
-echo drush(sprintf('uli -l %s --no-browser', $site_url));
+echo drush('uli -l %s --no-browser', [$site_url]);
 echo PHP_EOL;
 if (file_exists('.ahoy.yml')) {
   echo 'Run `ahoy` to see available commands.' . PHP_EOL;

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/start
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/start
@@ -27,7 +27,7 @@ $webserver_port = $webserver['port'];
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
 
-// Enable Xdebug when XdEBUG env var is set. Xdebug extension must be installed
+// Enable XDebug when XDebug env var is set. XDebug extension must be installed
 // and configured on host environment (php -v should show `with Xdebug`).
 // Coverage stays on pcov in test commands because xdebug.mode=debug does
 // not include "coverage", so pcov remains the active coverage driver.
@@ -42,16 +42,16 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
 if ($xdebug_enabled) {
-  TASK('Verifying that the Xdebug PHP extension is installed.');
+  TASK('Verifying that the XDebug PHP extension is installed.');
   $php_v = (string) shell_exec('php -v 2>/dev/null');
   if (stripos($php_v, 'xdebug') === FALSE) {
-    FAIL('XDEBUG=1 is set but the Xdebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
+    FAIL('XDEBUG=1 is set but the XDebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
   }
-  PASS('Xdebug extension is loaded.');
+  PASS('XDebug extension is loaded.');
 }
 
 TASK('Stopping previously started services, if any.');
-@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+kill_port($webserver_port);
 
 TASK('Starting the PHP webserver.');
 $cwd = (string) getcwd();

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/stop
@@ -31,7 +31,7 @@ echo PHP_EOL;
 run_custom_scripts('scripts', 'stop-');
 
 TASK('Stopping previously started services on port %s, if any.', $webserver_port);
-@passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
+kill_port($webserver_port);
 sleep(1);
 PASS('Services stopped on port %s.', $webserver_port);
 

--- a/.scaffold/tests/fixtures/init/_baseline/config/schema/force_crystal.schema.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/config/schema/force_crystal.schema.yml
@@ -1,6 +1,6 @@
 force_crystal.settings:
   type: config_object
-  label: 'Force Crystal settings'
+  label: 'Force Crystal Settings'
   mapping:
     text:
       type: string

--- a/.scaffold/tests/fixtures/init/_baseline/force_crystal.links.menu.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/force_crystal.links.menu.yml
@@ -1,5 +1,5 @@
 force_crystal.settings_form:
   title: 'Force Crystal'
-  description: 'Force Crystal settings'
+  description: 'Force Crystal Settings'
   route_name: force_crystal.settings_form
   parent: system.admin_config_development

--- a/.scaffold/tests/fixtures/init/_baseline/scripts/provision-cloudflared.sh
+++ b/.scaffold/tests/fixtures/init/_baseline/scripts/provision-cloudflared.sh
@@ -10,7 +10,8 @@
 #
 # This lives in a provision hook rather than the start hook because
 # `drush site-install` rewrites settings.php during provision, which runs after
-# start. Pairs with `scripts/start-cloudflared.sh`. CWD is the project root.
+# start. Pairs with `scripts/start-cloudflared.sh`. The current working
+# directory is the project root.
 
 set -eu
 

--- a/.scaffold/tests/fixtures/init/_baseline/scripts/start-cloudflared.sh
+++ b/.scaffold/tests/fixtures/init/_baseline/scripts/start-cloudflared.sh
@@ -10,7 +10,8 @@
 #
 # No Cloudflare account, DNS, or config is needed - quick tunnels mint an
 # ephemeral `*.trycloudflare.com` hostname. Install `cloudflared` via mise,
-# brew, or apt. Remove or rename this file to disable. CWD is the project root.
+# brew, or apt. Remove or rename this file to disable. The current working
+# directory is the project root.
 
 set -eu
 
@@ -47,12 +48,12 @@ tunnel_pid() {
 # removes it so a dead URL is never left behind.
 set_tunnel_url() {
   touch .env
-  _tmp=".env.cloudflared.$$"
-  grep -v '^TUNNEL_URL=' .env >"$_tmp" 2>/dev/null || true
+  env_tmp=".env.cloudflared.$$"
+  grep -v '^TUNNEL_URL=' .env >"$env_tmp" 2>/dev/null || true
   if [ -n "${1:-}" ]; then
-    printf 'TUNNEL_URL=%s\n' "$1" >>"$_tmp"
+    printf 'TUNNEL_URL=%s\n' "$1" >>"$env_tmp"
   fi
-  mv "$_tmp" .env
+  mv "$env_tmp" .env
 }
 
 # Reuse an existing tunnel only when its process is alive AND its public URL

--- a/.scaffold/tests/fixtures/init/_baseline/scripts/stop-cloudflared.sh
+++ b/.scaffold/tests/fixtures/init/_baseline/scripts/stop-cloudflared.sh
@@ -5,7 +5,8 @@
 # Kills the `cloudflared` process started by `scripts/start-cloudflared.sh` and
 # removes the TUNNEL_URL entry from `.env` so a dead public URL is not reported
 # on the next run. Runs even when CLOUDFLARE_TUNNEL is no longer set, so cleanup
-# always happens; a no-op when no tunnel is active. CWD is the project root.
+# always happens; a no-op when no tunnel is active. The current working
+# directory is the project root.
 
 set -eu
 

--- a/.scaffold/tests/fixtures/init/_baseline/src/ForceCrystalService.php
+++ b/.scaffold/tests/fixtures/init/_baseline/src/ForceCrystalService.php
@@ -12,20 +12,14 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 class ForceCrystalService {
 
   /**
-   * The extension configuration.
-   *
-   * @var \Drupal\Core\Config\ImmutableConfig
-   */
-  protected $yourExtensionConfig;
-
-  /**
    * Constructs a new ForceCrystalService instance.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->yourExtensionConfig = $config_factory->get('force_crystal.settings');
+  public function __construct(
+    /**
+     * The config factory.
+     */
+    protected ConfigFactoryInterface $configFactory,
+  ) {
   }
 
   /**
@@ -35,7 +29,7 @@ class ForceCrystalService {
    *   The text to be inserted.
    */
   public function getText(): string {
-    $text = $this->yourExtensionConfig->get('text');
+    $text = $this->configFactory->get('force_crystal.settings')->get('text');
 
     return static::sanitize($text);
   }

--- a/.scaffold/tests/fixtures/init/_baseline/src/Form/ForceCrystalForm.php
+++ b/.scaffold/tests/fixtures/init/_baseline/src/Form/ForceCrystalForm.php
@@ -34,6 +34,7 @@ class ForceCrystalForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
+    // @phpstan-ignore-next-line
     return new static(
       $container->get('config.factory'),
       $container->get('config.typed'),

--- a/.scaffold/tests/fixtures/init/_baseline/src/Form/ForceCrystalForm.php
+++ b/.scaffold/tests/fixtures/init/_baseline/src/Form/ForceCrystalForm.php
@@ -27,15 +27,13 @@ class ForceCrystalForm extends ConfigFormBase {
      */
     protected ForceCrystalService $yourExtensionService,
   ) {
-    // @phpstan-ignore-next-line
     parent::__construct($config_factory, $typedConfigManager);
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container): ForceCrystalForm {
-    // @phpstan-ignore-next-line
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('config.factory'),
       $container->get('config.typed'),
@@ -60,7 +58,7 @@ class ForceCrystalForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('force_crystal.settings');
 
     $form['text'] = [

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/Functional/ForceCrystalFunctionalTest.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/Functional/ForceCrystalFunctionalTest.php
@@ -33,8 +33,9 @@ class ForceCrystalFunctionalTest extends BrowserTestBase {
    * Tests the functionality of the getText method.
    */
   public function testGetText(): void {
-    $user = $this->createUser(['administer site configuration']);
-    $this->drupalLogin($user);
+    $account = $this->drupalCreateUser(['administer site configuration']);
+    $this->assertNotEmpty($account);
+    $this->drupalLogin($account);
 
     $this->drupalGet('admin/config/development/force_crystal');
 

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/Kernel/ForceCrystalServiceKernelTest.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/Kernel/ForceCrystalServiceKernelTest.php
@@ -6,11 +6,7 @@ namespace Drupal\Tests\force_crystal\Kernel;
 
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\ImmutableConfig;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\force_crystal\ForceCrystalService;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the ForceCrystalService class.
@@ -20,8 +16,6 @@ use Prophecy\PhpUnit\ProphecyTrait;
 #[Group('force_crystal')]
 #[RunTestsInSeparateProcesses]
 class ForceCrystalServiceKernelTest extends KernelTestBase {
-
-  use ProphecyTrait;
 
   /**
    * {@inheritdoc}
@@ -41,15 +35,13 @@ class ForceCrystalServiceKernelTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $your_config_config = $this->prophesize(ImmutableConfig::class);
-    $your_config_config->get('text')
-      ->willReturn('<p>This is <strong>bold</strong> text.</p>');
+    $this->installConfig(['force_crystal']);
 
-    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
-    $config_factory->get('force_crystal.settings')
-      ->willReturn($your_config_config->reveal());
+    $this->config('force_crystal.settings')
+      ->set('text', '<p>This is <strong>bold</strong> text.</p>')
+      ->save();
 
-    $this->yourExtensionService = new ForceCrystalService($config_factory->reveal());
+    $this->yourExtensionService = $this->container->get('force_crystal.service');
   }
 
   /**

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/Unit/ForceCrystalServiceUnitTest.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/Unit/ForceCrystalServiceUnitTest.php
@@ -21,6 +21,8 @@ class ForceCrystalServiceUnitTest extends UnitTestCase {
    * Tests the sanitize method of ForceCrystalService.
    *
    * @covers \Drupal\force_crystal\ForceCrystalService::sanitize
+   *
+   * @dataProvider dataProviderSanitize
    */
   #[DataProvider('dataProviderSanitize')]
   public function testSanitize(string $input, string $expected): void {

--- a/.scaffold/tests/fixtures/init/_baseline/tests/src/Unit/ForceCrystalServiceUnitTest.php
+++ b/.scaffold/tests/fixtures/init/_baseline/tests/src/Unit/ForceCrystalServiceUnitTest.php
@@ -21,7 +21,6 @@ class ForceCrystalServiceUnitTest extends UnitTestCase {
    * Tests the sanitize method of ForceCrystalService.
    *
    * @covers \Drupal\force_crystal\ForceCrystalService::sanitize
-   * @dataProvider dataProviderSanitize
    */
   #[DataProvider('dataProviderSanitize')]
   public function testSanitize(string $input, string $expected): void {

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -20,11 +20,20 @@ WEBSERVER_PORT ?= 8000
 # are invoked.
 DRUSH_URI = $(shell ./.devtools/info site-url)
 
+# Test environment exported to every recipe (see the blanket `export` above),
+# matching what the ahoy entrypoint exports for every command, so `make
+# test*` runs against the same base URL, database, and browser-output
+# directory as `ahoy test*`.
+EXTENSION_NAME = $(shell basename -s .info.yml -- ./*.info.yml)
+SIMPLETEST_BASE_URL = http://$(WEBSERVER_HOST):$(WEBSERVER_PORT)
+SIMPLETEST_DB = sqlite://localhost/drupal_test_$(EXTENSION_NAME).sqlite
+BROWSERTEST_OUTPUT_DIRECTORY = $(CURDIR)/.logs/browser_output
+
 define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on delete describe destroy drush help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
 .PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
@@ -53,7 +62,11 @@ help:
 	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build:
+	@$(MAKE) stop >/dev/null 2>&1 || true
+	$(MAKE) assemble
+	$(MAKE) start
+	$(MAKE) provision
 
 assemble:
 	./.devtools/assemble
@@ -131,32 +144,43 @@ lint-fix:
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint-fix) && popd >/dev/null || exit 1
 
+# Allow passing extra args to phpunit test targets, mirroring the `drush`
+# arg-capture above. The target list is split across the same DEV_* markers
+# as the `.PHONY` declarations so a stripped feature leaves no dangling entry.
+TEST_TARGETS := test
+TEST_TARGETS += test-unit test-kernel test-functional
+TEST_TARGETS += test-functional-javascript
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),$(TEST_TARGETS)))
+  TEST_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(TEST_RUN_ARGS):;@:)
+endif
+
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && php -d pcov.directory=.. vendor/bin/phpunit $(TEST_RUN_ARGS) && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
 test-unit:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-kernel:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
 	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 browser-start:

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -20,11 +20,20 @@ WEBSERVER_PORT ?= 8000
 # are invoked.
 DRUSH_URI = $(shell ./.devtools/info site-url)
 
+# Test environment exported to every recipe (see the blanket `export` above),
+# matching what the ahoy entrypoint exports for every command, so `make
+# test*` runs against the same base URL, database, and browser-output
+# directory as `ahoy test*`.
+EXTENSION_NAME = $(shell basename -s .info.yml -- ./*.info.yml)
+SIMPLETEST_BASE_URL = http://$(WEBSERVER_HOST):$(WEBSERVER_PORT)
+SIMPLETEST_DB = sqlite://localhost/drupal_test_$(EXTENSION_NAME).sqlite
+BROWSERTEST_OUTPUT_DIRECTORY = $(CURDIR)/.logs/browser_output
+
 define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on delete describe destroy drush help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
 .PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
@@ -53,7 +62,11 @@ help:
 	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build:
+	@$(MAKE) stop >/dev/null 2>&1 || true
+	$(MAKE) assemble
+	$(MAKE) start
+	$(MAKE) provision
 
 assemble:
 	./.devtools/assemble
@@ -131,32 +144,43 @@ lint-fix:
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint-fix) && popd >/dev/null || exit 1
 
+# Allow passing extra args to phpunit test targets, mirroring the `drush`
+# arg-capture above. The target list is split across the same DEV_* markers
+# as the `.PHONY` declarations so a stripped feature leaves no dangling entry.
+TEST_TARGETS := test
+TEST_TARGETS += test-unit test-kernel test-functional
+TEST_TARGETS += test-functional-javascript
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),$(TEST_TARGETS)))
+  TEST_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(TEST_RUN_ARGS):;@:)
+endif
+
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && php -d pcov.directory=.. vendor/bin/phpunit $(TEST_RUN_ARGS) && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
 test-unit:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-kernel:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
 	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 browser-start:

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -20,11 +20,20 @@ WEBSERVER_PORT ?= 8000
 # are invoked.
 DRUSH_URI = $(shell ./.devtools/info site-url)
 
+# Test environment exported to every recipe (see the blanket `export` above),
+# matching what the ahoy entrypoint exports for every command, so `make
+# test*` runs against the same base URL, database, and browser-output
+# directory as `ahoy test*`.
+EXTENSION_NAME = $(shell basename -s .info.yml -- ./*.info.yml)
+SIMPLETEST_BASE_URL = http://$(WEBSERVER_HOST):$(WEBSERVER_PORT)
+SIMPLETEST_DB = sqlite://localhost/drupal_test_$(EXTENSION_NAME).sqlite
+BROWSERTEST_OUTPUT_DIRECTORY = $(CURDIR)/.logs/browser_output
+
 define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on delete describe destroy drush help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
 .PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
@@ -53,7 +62,11 @@ help:
 	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build:
+	@$(MAKE) stop >/dev/null 2>&1 || true
+	$(MAKE) assemble
+	$(MAKE) start
+	$(MAKE) provision
 
 assemble:
 	./.devtools/assemble
@@ -131,32 +144,43 @@ lint-fix:
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint-fix) && popd >/dev/null || exit 1
 
+# Allow passing extra args to phpunit test targets, mirroring the `drush`
+# arg-capture above. The target list is split across the same DEV_* markers
+# as the `.PHONY` declarations so a stripped feature leaves no dangling entry.
+TEST_TARGETS := test
+TEST_TARGETS += test-unit test-kernel test-functional
+TEST_TARGETS += test-functional-javascript
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),$(TEST_TARGETS)))
+  TEST_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(TEST_RUN_ARGS):;@:)
+endif
+
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && php -d pcov.directory=.. vendor/bin/phpunit $(TEST_RUN_ARGS) && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
 test-unit:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-kernel:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
 	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 browser-start:

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -20,11 +20,20 @@ WEBSERVER_PORT ?= 8000
 # are invoked.
 DRUSH_URI = $(shell ./.devtools/info site-url)
 
+# Test environment exported to every recipe (see the blanket `export` above),
+# matching what the ahoy entrypoint exports for every command, so `make
+# test*` runs against the same base URL, database, and browser-output
+# directory as `ahoy test*`.
+EXTENSION_NAME = $(shell basename -s .info.yml -- ./*.info.yml)
+SIMPLETEST_BASE_URL = http://$(WEBSERVER_HOST):$(WEBSERVER_PORT)
+SIMPLETEST_DB = sqlite://localhost/drupal_test_$(EXTENSION_NAME).sqlite
+BROWSERTEST_OUTPUT_DIRECTORY = $(CURDIR)/.logs/browser_output
+
 define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on delete describe destroy drush help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 .PHONY: test-unit test-kernel test-functional
 .PHONY: test-functional-javascript browser-start browser-stop
 .PHONY: test-js
@@ -53,7 +62,11 @@ help:
 	@echo "browser-stop               - Stop the browser."
 	@echo "test-js                    - Run JavaScript unit tests."
 
-build: stop assemble start provision
+build:
+	@$(MAKE) stop >/dev/null 2>&1 || true
+	$(MAKE) assemble
+	$(MAKE) start
+	$(MAKE) provision
 
 assemble:
 	./.devtools/assemble
@@ -131,32 +144,43 @@ lint-fix:
 	$(call title,Running ESLint)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint-fix) && popd >/dev/null || exit 1
 
+# Allow passing extra args to phpunit test targets, mirroring the `drush`
+# arg-capture above. The target list is split across the same DEV_* markers
+# as the `.PHONY` declarations so a stripped feature leaves no dangling entry.
+TEST_TARGETS := test
+TEST_TARGETS += test-unit test-kernel test-functional
+TEST_TARGETS += test-functional-javascript
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),$(TEST_TARGETS)))
+  TEST_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(TEST_RUN_ARGS):;@:)
+endif
+
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && php -d pcov.directory=.. vendor/bin/phpunit $(TEST_RUN_ARGS) && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
 test-unit:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-kernel:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript:
 	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 browser-start:

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -20,11 +20,20 @@ WEBSERVER_PORT ?= 8000
 # are invoked.
 DRUSH_URI = $(shell ./.devtools/info site-url)
 
+# Test environment exported to every recipe (see the blanket `export` above),
+# matching what the ahoy entrypoint exports for every command, so `make
+# test*` runs against the same base URL, database, and browser-output
+# directory as `ahoy test*`.
+EXTENSION_NAME = $(shell basename -s .info.yml -- ./*.info.yml)
+SIMPLETEST_BASE_URL = http://$(WEBSERVER_HOST):$(WEBSERVER_PORT)
+SIMPLETEST_DB = sqlite://localhost/drupal_test_$(EXTENSION_NAME).sqlite
+BROWSERTEST_OUTPUT_DIRECTORY = $(CURDIR)/.logs/browser_output
+
 define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on delete describe destroy drush help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 
 help:
 	@echo "COMMANDS"
@@ -43,7 +52,11 @@ help:
 	@echo "stop            - Stop development environment."
 	@echo "test                       - Run all tests."
 
-build: stop assemble start provision
+build:
+	@$(MAKE) stop >/dev/null 2>&1 || true
+	$(MAKE) assemble
+	$(MAKE) start
+	$(MAKE) provision
 
 assemble:
 	./.devtools/assemble
@@ -99,6 +112,15 @@ provision:
 lint:
 
 lint-fix:
+
+# Allow passing extra args to phpunit test targets, mirroring the `drush`
+# arg-capture above. The target list is split across the same DEV_* markers
+# as the `.PHONY` declarations so a stripped feature leaves no dangling entry.
+TEST_TARGETS := test
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),$(TEST_TARGETS)))
+  TEST_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(TEST_RUN_ARGS):;@:)
+endif
 
 test:
 

--- a/.scaffold/tests/src/Functional/FunctionalTestCase.php
+++ b/.scaffold/tests/src/Functional/FunctionalTestCase.php
@@ -9,9 +9,9 @@ use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\TuiTrait;
 
 /**
- * Class UnitTestCase.
+ * Class FunctionalTestCase.
  *
- * UnitTestCase fixture class.
+ * FunctionalTestCase fixture class.
  *
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -69,13 +69,13 @@ final class BrowserTest extends UnitTestCase {
     parent::tearDown();
   }
 
-  public function testUnknownCommand(): void {
+  public function testBrowserUnknownCommand(): void {
     $output = $this->runBrowser('bogus', 1);
 
     $this->assertStringContainsString("Unknown command 'bogus'", $output);
   }
 
-  public function testUnknownBackend(): void {
+  public function testBrowserUnknownBackend(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'firefox');
 
     $output = $this->runBrowser('start', 1);
@@ -83,7 +83,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString("Unknown WEBDRIVER_BACKEND 'firefox'", $output);
   }
 
-  public function testStartAlreadyRunning(): void {
+  public function testBrowserStartAlreadyRunning(): void {
     $this->mockReady([TRUE]);
 
     $output = $this->runBrowser('start', 0);
@@ -91,7 +91,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('already running on port 4444', $output);
   }
 
-  public function testStartUsesMatchingInstalledDriver(): void {
+  public function testBrowserStartUsesMatchingInstalledDriver(): void {
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
@@ -111,7 +111,7 @@ final class BrowserTest extends UnitTestCase {
     }
   }
 
-  public function testStartFallsBackToNpxOnVersionMismatch(): void {
+  public function testBrowserStartFallsBackToNpxOnVersionMismatch(): void {
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver', 'npx' => '/usr/bin/npx']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 151.0.7922.34 (abc)');
@@ -127,7 +127,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, 'nohup') && str_contains($c, '/cache/chromedriver')), 'The freshly fetched binary must be launched.');
   }
 
-  public function testStartUsesMacChromeWhenPresent(): void {
+  public function testBrowserStartUsesMacChromeWhenPresent(): void {
     $this->mockChrome(TRUE);
     $this->mockCommands(['chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
@@ -140,7 +140,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('chromedriver is ready on port 4444', $output);
   }
 
-  public function testStartFailsWhenChromeMissing(): void {
+  public function testBrowserStartFailsWhenChromeMissing(): void {
     $this->mockChrome(FALSE);
     $this->mockCommands([]);
     $this->mockVersions('', '');
@@ -151,7 +151,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('Google Chrome or Chromium was not found', $output);
   }
 
-  public function testStartFailsWhenMismatchAndNoNpx(): void {
+  public function testBrowserStartFailsWhenMismatchAndNoNpx(): void {
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 151.0.7922.34 (abc)');
@@ -162,7 +162,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('npx is unavailable', $output);
   }
 
-  public function testStartFailsWhenNpxInstallFails(): void {
+  public function testBrowserStartFailsWhenNpxInstallFails(): void {
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'npx' => '/usr/bin/npx']);
     $this->mockVersions('Google Chrome 150.0.7871.129', '');
@@ -175,7 +175,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('Failed to install chromedriver', $output);
   }
 
-  public function testStartFailsWhenBinaryPathUnresolved(): void {
+  public function testBrowserStartFailsWhenBinaryPathUnresolved(): void {
     $this->installLogContent = '';
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'npx' => '/usr/bin/npx']);
@@ -189,7 +189,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('Could not determine the chromedriver binary path', $output);
   }
 
-  public function testStartFailsWhenNeverReady(): void {
+  public function testBrowserStartFailsWhenNeverReady(): void {
     $this->mockChrome(FALSE);
     $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
     $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
@@ -202,7 +202,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('failed to become ready on port 4444', $output);
   }
 
-  public function testSeleniumStartAlreadyRunning(): void {
+  public function testBrowserSeleniumStartAlreadyRunning(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockReady([TRUE]);
 
@@ -211,7 +211,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('Selenium is already running on port 4444', $output);
   }
 
-  public function testSeleniumStartStartsContainer(): void {
+  public function testBrowserSeleniumStartStartsContainer(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $this->mockReady([FALSE, TRUE]);
@@ -230,7 +230,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('standalone-chromium', $run_command);
   }
 
-  public function testSeleniumStartFailsWithoutDocker(): void {
+  public function testBrowserSeleniumStartFailsWithoutDocker(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands([]);
     $this->mockReady([FALSE]);
@@ -240,7 +240,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('docker was not found', $output);
   }
 
-  public function testSeleniumStartFailsWhenDockerRunFails(): void {
+  public function testBrowserSeleniumStartFailsWhenDockerRunFails(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $this->mockReady([FALSE]);
@@ -252,7 +252,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('Failed to start the Selenium container', $output);
   }
 
-  public function testSeleniumStartFailsWhenNeverReady(): void {
+  public function testBrowserSeleniumStartFailsWhenNeverReady(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $this->mockReady([FALSE]);
@@ -264,7 +264,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('Selenium failed to become ready on port 4444', $output);
   }
 
-  public function testStopWithDocker(): void {
+  public function testBrowserStopWithDocker(): void {
     $this->mockCommands(['docker' => '/usr/bin/docker']);
     $commands = [];
     $this->recordPassthru($commands);
@@ -276,7 +276,7 @@ final class BrowserTest extends UnitTestCase {
     $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "lsof -ti:'4444'")), 'The WebDriver process on the resolved port must be terminated.');
   }
 
-  public function testStopWithoutDocker(): void {
+  public function testBrowserStopWithoutDocker(): void {
     $this->mockCommands([]);
     $commands = [];
     $this->recordPassthru($commands);

--- a/.scaffold/tests/src/Unit/HelpersDotenvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersDotenvTest.php
@@ -105,7 +105,7 @@ final class HelpersDotenvTest extends UnitTestCase {
     ];
   }
 
-  public function testDotenvWriteVarCreatesFileWhenAbsent(): void {
+  public function testDotenvWriteVarCreatesFileWhenMissing(): void {
     $file = self::$tmp . '/dotenv_write_' . uniqid();
     $this->assertFileDoesNotExist($file);
 

--- a/.scaffold/tests/src/Unit/HelpersExtensionInfoTest.php
+++ b/.scaffold/tests/src/Unit/HelpersExtensionInfoTest.php
@@ -52,7 +52,7 @@ final class HelpersExtensionInfoTest extends UnitTestCase {
     ];
   }
 
-  public function testExtensionInfoNoFile(): void {
+  public function testExtensionInfoMissingFile(): void {
     $dir = self::$tmp . '/ext_empty_' . uniqid();
     mkdir($dir, 0755, TRUE);
     $original = (string) getcwd();

--- a/.scaffold/tests/src/Unit/HelpersFilesystemTest.php
+++ b/.scaffold/tests/src/Unit/HelpersFilesystemTest.php
@@ -20,7 +20,7 @@ final class HelpersFilesystemTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
-  public function testRemoveDirNonExistent(): void {
+  public function testRemoveDirMissing(): void {
     remove_dir(self::$tmp . '/nonexistent_' . uniqid());
     $this->expectNotToPerformAssertions();
   }
@@ -63,7 +63,7 @@ final class HelpersFilesystemTest extends UnitTestCase {
     ];
   }
 
-  public function testChmodRecursiveNonExistent(): void {
+  public function testChmodRecursiveMissing(): void {
     chmod_recursive(self::$tmp . '/nonexistent_' . uniqid(), 0755);
     $this->expectNotToPerformAssertions();
   }

--- a/.scaffold/tests/src/Unit/HelpersLinkBrowserOutputTest.php
+++ b/.scaffold/tests/src/Unit/HelpersLinkBrowserOutputTest.php
@@ -17,7 +17,7 @@ final class HelpersLinkBrowserOutputTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
-  public function testMissingWebrootIsNoop(): void {
+  public function testMissingWebrootDoesNothing(): void {
     $webroot = self::$tmp . '/web_' . uniqid();
     $logs = self::$tmp . '/logs_' . uniqid();
 

--- a/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruOrFailTest.php
@@ -38,15 +38,17 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
   }
 
   public function testFailureWithMessage(): void {
-    $this->mockPassthru(['cmd' => 'false', 'result_code' => 1]);
-    $this->mockQuit(1);
+    // A result code other than 1 proves the real exit code survives past
+    // the failure-message branch instead of being dropped for a hardcoded 1.
+    $this->mockPassthru(['cmd' => 'false', 'result_code' => 42]);
+    $this->mockQuit(42);
     ob_start();
     try {
       passthru_or_fail('false', 'Command failed.');
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertSame(1, $e->getCode());
+      $this->assertSame(42, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -56,15 +58,17 @@ final class HelpersPassthruOrFailTest extends UnitTestCase {
   }
 
   public function testFailureWithFormatArgs(): void {
-    $this->mockPassthru(['cmd' => 'curl http://example.com', 'result_code' => 1]);
-    $this->mockQuit(1);
+    // A result code other than 1 proves the real exit code survives past
+    // the failure-message branch instead of being dropped for a hardcoded 1.
+    $this->mockPassthru(['cmd' => 'curl http://example.com', 'result_code' => 7]);
+    $this->mockQuit(7);
     ob_start();
     try {
       passthru_or_fail('curl http://example.com', 'Failed to download from %s.', 'http://example.com');
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertSame(1, $e->getCode());
+      $this->assertSame(7, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPassthruVerboseOrFailTest.php
@@ -36,15 +36,15 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
   }
 
   public function testFailureWithMessage(): void {
-    $this->mockPassthru(['cmd' => 'false', 'result_code' => 1]);
-    $this->mockQuit(1);
+    $this->mockPassthru(['cmd' => 'false', 'result_code' => 42]);
+    $this->mockQuit(42);
     ob_start();
     try {
       passthru_verbose_or_fail('false', 'Command failed.');
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertSame(1, $e->getCode());
+      $this->assertSame(42, $e->getCode());
     }
     finally {
       $output = ob_get_clean();
@@ -54,15 +54,15 @@ final class HelpersPassthruVerboseOrFailTest extends UnitTestCase {
   }
 
   public function testFailureWithFormatArgs(): void {
-    $this->mockPassthru(['cmd' => 'curl http://example.com', 'result_code' => 1]);
-    $this->mockQuit(1);
+    $this->mockPassthru(['cmd' => 'curl http://example.com', 'result_code' => 7]);
+    $this->mockQuit(7);
     ob_start();
     try {
       passthru_verbose_or_fail('curl http://example.com', 'Failed to download from %s.', 'http://example.com');
       $this->fail('Expected QuitErrorException to be thrown');
     }
     catch (QuitErrorException $e) {
-      $this->assertSame(1, $e->getCode());
+      $this->assertSame(7, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -34,7 +34,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     parent::tearDown();
   }
 
-  public function testEmptyUrlRendersNothing(): void {
+  public function testEmptyUrlDoesNothing(): void {
     // An empty URL short-circuits before the opt-in check or any probe.
     ob_start();
     print_qrcode('');
@@ -44,7 +44,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testDisabledByDefaultRendersNothing(): void {
+  public function testDisabledByDefaultDoesNothing(): void {
     // QRCODE unset in both the environment and '.env': opt-in means nothing is
     // drawn, and qrencode is never even probed.
     $this->envUnset('QRCODE');
@@ -58,7 +58,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testExplicitlyDisabledRendersNothing(): void {
+  public function testExplicitlyDisabledDoesNothing(): void {
     $this->envSet('QRCODE', '0');
 
     ob_start();
@@ -69,7 +69,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testEnabledButQrencodeAbsentRendersNothing(): void {
+  public function testEnabledButQrencodeMissingDoesNothing(): void {
     $this->envSet('QRCODE', '1');
     $this->mockQrencodeAvailable(FALSE);
 

--- a/.scaffold/tests/src/Unit/HelpersReplaceInFileTest.php
+++ b/.scaffold/tests/src/Unit/HelpersReplaceInFileTest.php
@@ -55,7 +55,7 @@ final class HelpersReplaceInFileTest extends UnitTestCase {
     ];
   }
 
-  public function testReplaceInFileNonExistentFile(): void {
+  public function testReplaceInFileMissingFile(): void {
     $file = self::$tmp . '/nonexistent_' . uniqid() . '.txt';
     $this->mockQuit(1);
     $this->expectException(QuitErrorException::class);

--- a/.scaffold/tests/src/Unit/HelpersResolveEnvTest.php
+++ b/.scaffold/tests/src/Unit/HelpersResolveEnvTest.php
@@ -35,7 +35,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     file_put_contents($file, "FOO=from_dotenv\n");
     $this->envSet('FOO', 'from_env');
 
-    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', 'fallback', $file);
 
     $this->assertSame('from_env', $value);
     $this->assertSame('env', $source);
@@ -45,7 +45,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     $file = self::$tmp . '/resolve_env_' . uniqid();
     file_put_contents($file, "FOO=from_dotenv\n");
 
-    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', 'fallback', $file);
 
     $this->assertSame('from_dotenv', $value);
     $this->assertSame($file, $source);
@@ -55,7 +55,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     $file = self::$tmp . '/resolve_env_' . uniqid();
     file_put_contents($file, "FOO=\n");
 
-    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', 'fallback', $file);
 
     $this->assertSame('fallback', $value);
     $this->assertSame('default', $source);
@@ -66,7 +66,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     file_put_contents($file, "FOO=from_dotenv\n");
     $this->envSet('FOO', '');
 
-    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', 'fallback', $file);
 
     $this->assertSame('from_dotenv', $value);
     $this->assertSame($file, $source);
@@ -75,7 +75,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
   public function testDefaultReturnedWhenNeitherSourceHasValue(): void {
     $file = self::$tmp . '/resolve_env_' . uniqid();
 
-    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', 'fallback', $file);
 
     $this->assertSame('fallback', $value);
     $this->assertSame('default', $source);
@@ -84,7 +84,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
   public function testDefaultMayBeEmptyString(): void {
     $file = self::$tmp . '/resolve_env_' . uniqid();
 
-    [$value, $source] = resolve_env_value('FOO', '', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', '', $file);
 
     $this->assertSame('', $value);
     $this->assertSame('default', $source);
@@ -95,7 +95,7 @@ final class HelpersResolveEnvTest extends UnitTestCase {
     $file = self::$tmp . '/' . $relative_name;
     file_put_contents($file, "FOO=value\n");
 
-    [$value, $source] = resolve_env_value('FOO', 'fallback', $file);
+    ['value' => $value, 'source' => $source] = resolve_env_value('FOO', 'fallback', $file);
 
     $this->assertSame('value', $value);
     $this->assertSame($file, $source);

--- a/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
@@ -120,7 +120,7 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
     ]);
 
     $this->mockPassthru(['cmd' => escapeshellarg($dir . '/provision-first.sh'), 'result_code' => 7]);
-    $this->mockQuit(1);
+    $this->mockQuit(7);
 
     ob_start();
     try {
@@ -128,7 +128,7 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
       $this->fail('Expected QuitErrorException to be thrown.');
     }
     catch (QuitErrorException $e) {
-      $this->assertSame(1, $e->getCode());
+      $this->assertSame(7, $e->getCode());
     }
     finally {
       $output = ob_get_clean();

--- a/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
+++ b/.scaffold/tests/src/Unit/HelpersRunCustomScriptsTest.php
@@ -18,18 +18,18 @@ final class HelpersRunCustomScriptsTest extends UnitTestCase {
     require_once dirname(__DIR__, 4) . '/.devtools/helpers.php';
   }
 
-  public function testMissingDirectoryIsSilent(): void {
+  public function testMissingDirectoryDoesNothing(): void {
     run_custom_scripts(self::$tmp . '/nonexistent_' . uniqid(), 'assemble-');
     $this->expectNotToPerformAssertions();
   }
 
-  public function testEmptyDirectoryIsSilent(): void {
+  public function testEmptyDirectoryDoesNothing(): void {
     $dir = $this->createScriptsDir();
     run_custom_scripts($dir, 'assemble-');
     $this->expectNotToPerformAssertions();
   }
 
-  public function testDirectoryWithNoPrefixMatchesIsSilent(): void {
+  public function testDirectoryWithNoPrefixMatchesDoesNothing(): void {
     $dir = $this->createScriptsDir(['unrelated.sh' => 'echo nope', 'README.md' => '']);
     run_custom_scripts($dir, 'assemble-');
     $this->expectNotToPerformAssertions();

--- a/.scaffold/tests/src/Unit/InfoTest.php
+++ b/.scaffold/tests/src/Unit/InfoTest.php
@@ -56,7 +56,7 @@ final class InfoTest extends UnitTestCase {
    * @param string|false $command_php_path
    *   Path returned by command_path('php'); FALSE means not found.
    */
-  protected function configureInfoMocks(
+  protected function setupInfoMocks(
     array $shell_exec_map,
     array $files = [],
     array $info_files = [],
@@ -96,7 +96,7 @@ final class InfoTest extends UnitTestCase {
     });
   }
 
-  public function testFullyPopulatedEnvironment(): void {
+  public function testInfoFullyPopulatedEnvironment(): void {
     $this->envSet('WEBSERVER_HOST', 'example.com');
     $this->envSet('WEBSERVER_PORT', '9001');
     $this->envSet('DRUPAL_PROFILE', 'minimal');
@@ -104,7 +104,7 @@ final class InfoTest extends UnitTestCase {
     $cwd = '/test/project';
     $drush_bin = 'build/vendor/bin/drush';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: [
         'php -v' => "PHP 8.3.14 (cli) (built: ...)\n",
         'composer --version' => "Composer version 2.7.7 2024-06-10 22:11:12\n",
@@ -139,10 +139,10 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('ENVIRONMENT INFO', $output);
   }
 
-  public function testReadsPortFromDotenvWithFileSource(): void {
+  public function testInfoReadsPortFromDotenvWithFileSource(): void {
     $cwd = '/test/project';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: [
         'php -v' => "PHP 8.3.14\n",
         'composer --version' => '',
@@ -163,11 +163,11 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('Site URL:           http://localhost:8123', $output);
   }
 
-  public function testSiteUrlPrefersTunnelUrl(): void {
+  public function testInfoSiteUrlPrefersTunnelUrl(): void {
     $cwd = '/test/project';
     $tunnel_url = 'https://random-words.trycloudflare.com';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: ['*' => ''],
       files: ['.env' => TRUE],
       info_files: [],
@@ -183,10 +183,10 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('Site URL:           ' . $tunnel_url, $output);
   }
 
-  public function testSiteUrlFieldPrefersTunnelUrl(): void {
+  public function testInfoSiteUrlFieldPrefersTunnelUrl(): void {
     $tunnel_url = 'https://random-words.trycloudflare.com';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: ['*' => ''],
       files: ['.env' => TRUE],
       info_files: [],
@@ -199,10 +199,10 @@ final class InfoTest extends UnitTestCase {
     $this->assertSame($tunnel_url . PHP_EOL, $output);
   }
 
-  public function testFallsBackToDefaultsWhenNothingResolves(): void {
+  public function testInfoFallsBackToDefaultsWhenNothingResolves(): void {
     $cwd = '/test/project';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: ['*' => ''],
       files: [],
       info_files: [],
@@ -226,12 +226,12 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('Drupal profile:     standard', $output);
   }
 
-  public function testDrushAbsentSuppressesPhpPathSuffixOnlyWhenPhpAlsoMissing(): void {
+  public function testInfoDrushMissingSuppressesPhpPathSuffixOnlyWhenPhpAlsoMissing(): void {
     // PHP is detectable but command_path('php') returns FALSE - the path
     // suffix is omitted.
     $cwd = '/test/project';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: [
         'php -v' => "PHP 8.3.14\n",
         '*' => '',
@@ -248,11 +248,11 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringNotContainsString('PHP version:        8.3.14 (', $output);
   }
 
-  #[DataProvider('dataProviderXdebugStateDetection')]
-  public function testXdebugStateDetection(string $ps_output, string $expected_state): void {
+  #[DataProvider('dataProviderInfoXdebugStateDetection')]
+  public function testInfoXdebugStateDetection(string $ps_output, string $expected_state): void {
     $cwd = '/test/project';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: [
         'lsof -ti' => $ps_output,
         '*' => '',
@@ -267,7 +267,7 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('XDebug:             ' . $expected_state, $output);
   }
 
-  public static function dataProviderXdebugStateDetection(): \Iterator {
+  public static function dataProviderInfoXdebugStateDetection(): \Iterator {
     yield 'no server listening' => ['ps_output' => '', 'expected_state' => '-'];
     yield 'server running without xdebug' => [
       'ps_output' => "php -S localhost:8000\n",
@@ -279,13 +279,13 @@ final class InfoTest extends UnitTestCase {
     ];
   }
 
-  public function testDrushDrupalVersionFallbackWhenStatusReturnsNothing(): void {
+  public function testInfoDrushDrupalVersionFallbackWhenStatusReturnsNothing(): void {
     // Drush binary exists but `drush status --field=drupal-version` returns
     // empty (e.g. before site install). Drush version is still reported.
     $cwd = '/test/project';
     $drush_bin = 'build/vendor/bin/drush';
 
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: [
         '--version' => "Drush Commandline Tool 13.3.0\n",
         'status --field=drupal-version' => '',
@@ -304,9 +304,9 @@ final class InfoTest extends UnitTestCase {
     $this->assertStringContainsString('Drupal version:     -', $output);
   }
 
-  #[DataProvider('dataProviderFieldModeKnownFields')]
-  public function testFieldModeKnownFields(string $field, array $shell_exec_map, array $files, string $expected): void {
-    $this->configureInfoMocks(
+  #[DataProvider('dataProviderInfoFieldModeKnownFields')]
+  public function testInfoFieldModeKnownFields(string $field, array $shell_exec_map, array $files, string $expected): void {
+    $this->setupInfoMocks(
       shell_exec_map: $shell_exec_map,
       files: $files,
       info_files: ['your_extension.info.yml'],
@@ -318,7 +318,7 @@ final class InfoTest extends UnitTestCase {
     $this->assertSame($expected . PHP_EOL, $output);
   }
 
-  public static function dataProviderFieldModeKnownFields(): \Iterator {
+  public static function dataProviderInfoFieldModeKnownFields(): \Iterator {
     yield 'xdebug enabled' => [
       'field' => 'xdebug',
       'shell_exec_map' => ['lsof -ti' => "php -d xdebug.mode=debug -S localhost:8000\n", '*' => ''],
@@ -429,8 +429,8 @@ final class InfoTest extends UnitTestCase {
     ];
   }
 
-  public function testFieldModeUnknownFieldPrintsDashAndExits1(): void {
-    $this->configureInfoMocks(
+  public function testInfoFieldModeUnknownFieldPrintsDashAndExits1(): void {
+    $this->setupInfoMocks(
       shell_exec_map: ['*' => ''],
       files: [],
       info_files: [],
@@ -442,10 +442,10 @@ final class InfoTest extends UnitTestCase {
     $this->assertSame('-' . PHP_EOL, $output);
   }
 
-  public function testFieldModeBypassedForFlagLikeArg(): void {
+  public function testInfoFieldModeBypassedForFlagLikeArg(): void {
     // phpunit may pass its own argv (e.g. '--no-coverage') through to the
     // included script. Args starting with '-' must NOT trigger field mode.
-    $this->configureInfoMocks(
+    $this->setupInfoMocks(
       shell_exec_map: ['*' => ''],
       files: [],
       info_files: [],

--- a/.scaffold/tests/src/Unit/InitHelpersTest.php
+++ b/.scaffold/tests/src/Unit/InitHelpersTest.php
@@ -92,7 +92,7 @@ final class InitHelpersTest extends UnitTestCase {
     yield 'php content' => ['<?php echo "hello"; ?>', FALSE];
   }
 
-  public function testIsBinaryFileNonExistent(): void {
+  public function testIsBinaryFileMissing(): void {
     // The defensive 'fopen() === FALSE' branch is unreachable from production
     // code (callers always pass paths returned by 'get_files()'), so 'fopen()'
     // is allowed to warn. Suppress 'E_WARNING' so PHPUnit's
@@ -161,7 +161,7 @@ final class InitHelpersTest extends UnitTestCase {
     ];
   }
 
-  public function testRemoveDirNonExistent(): void {
+  public function testRemoveDirMissing(): void {
     remove_dir(self::$sut . '/nonexistent');
     $this->addToAssertionCount(1);
   }
@@ -400,7 +400,7 @@ final class InitHelpersTest extends UnitTestCase {
     ];
   }
 
-  public function testUncommentLineNonExistentFile(): void {
+  public function testUncommentLineMissingFile(): void {
     uncomment_line(self::$sut . '/nonexistent', 'test');
     $this->addToAssertionCount(1);
   }

--- a/.scaffold/tests/src/Unit/InitHelpersTest.php
+++ b/.scaffold/tests/src/Unit/InitHelpersTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Group;
 use function convert_string;
 use function get_files;
 use function is_binary_file;
-use function normalise_cspell_words;
+use function normalize_cspell_words;
 use function print_help;
 use function process;
 use function remove_dir;
@@ -451,7 +451,7 @@ final class InitHelpersTest extends UnitTestCase {
     ];
     file_put_contents(self::$sut . '/.cspell.json', json_encode($input, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-    normalise_cspell_words();
+    normalize_cspell_words();
 
     $result = json_decode((string) file_get_contents(self::$sut . '/.cspell.json'), TRUE);
     $this->assertIsArray($result);
@@ -466,7 +466,7 @@ final class InitHelpersTest extends UnitTestCase {
   public function testNormaliseCspellWordsMissingFile(): void {
     chdir(self::$sut);
 
-    normalise_cspell_words();
+    normalize_cspell_words();
 
     $this->assertFileDoesNotExist(self::$sut . '/.cspell.json');
   }
@@ -475,9 +475,8 @@ final class InitHelpersTest extends UnitTestCase {
     chdir(self::$sut);
     file_put_contents(self::$sut . '/.cspell.json', '{not valid json');
 
-    normalise_cspell_words();
-
-    $this->assertSame('{not valid json', file_get_contents(self::$sut . '/.cspell.json'));
+    $this->expectException(\JsonException::class);
+    normalize_cspell_words();
   }
 
   public function testNormaliseCspellWordsMissingWordsKey(): void {
@@ -485,7 +484,7 @@ final class InitHelpersTest extends UnitTestCase {
     $input = ['dictionaries' => ['php']];
     file_put_contents(self::$sut . '/.cspell.json', json_encode($input));
 
-    normalise_cspell_words();
+    normalize_cspell_words();
 
     $this->assertSame(json_encode($input), file_get_contents(self::$sut . '/.cspell.json'));
   }
@@ -498,7 +497,7 @@ final class InitHelpersTest extends UnitTestCase {
   public function testProcessValidation(string $extension_name, string $machine_name, string $type, string $ci, array $drupal_versions, array $wrapper, string $expected_message): void {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage($expected_message);
-    process($extension_name, $machine_name, $type, $ci, $drupal_versions, $wrapper, [], 'n', 'n');
+    process($extension_name, $machine_name, $type, $ci, $drupal_versions, $wrapper, [], FALSE, FALSE);
   }
 
   public static function dataProviderProcessValidation(): \Iterator {

--- a/.scaffold/tests/src/Unit/InitProcessTest.php
+++ b/.scaffold/tests/src/Unit/InitProcessTest.php
@@ -20,9 +20,10 @@ use function process;
  * a subprocess and PCOV cannot capture coverage from there. The tests in
  * this class run the same logic in-process so PCOV records it.
  *
- * 'remove_self' is always passed as 'n' because '__FILE__' inside 'init.php'
- * resolves to the loaded path of the script (the project root copy), not
- * the copy inside SUT - passing 'y' would delete the source 'init.php'.
+ * 'remove_self' is always passed as FALSE because '__FILE__' inside
+ * 'init.php' resolves to the loaded path of the script (the project root
+ * copy), not the copy inside SUT - passing TRUE would delete the source
+ * 'init.php'.
  */
 #[Group('p0')]
 final class InitProcessTest extends UnitTestCase {
@@ -62,7 +63,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcess')]
   public function testProcess(string $name, string $machine_name, string $type, string $ci_provider, array $command_wrapper, array $expected_exists, array $expected_not_exists, array $expected_claude_allow, bool $info_yml_has_base_theme): void {
-    process($name, $machine_name, $type, $ci_provider, ['10', '11'], $command_wrapper, [], 'n', 'n');
+    process($name, $machine_name, $type, $ci_provider, ['10', '11'], $command_wrapper, [], FALSE, FALSE);
 
     foreach ($expected_exists as $path) {
       $this->assertFileExists(self::$sut . '/' . $path, 'Expected to exist: ' . $path);
@@ -212,7 +213,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessRemovesTools')]
   public function testProcessRemovesTools(array $tools_remove, array $expected_not_exists, array $expected_composer_dev_absent, array $expected_package_json_absent, array $expected_pipeline_absent): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy', 'makefile'], $tools_remove, 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy', 'makefile'], $tools_remove, FALSE, FALSE);
 
     foreach ($expected_not_exists as $path) {
       $this->assertFileDoesNotExist(self::$sut . '/' . $path, 'Expected removed: ' . $path);
@@ -358,8 +359,8 @@ final class InitProcessTest extends UnitTestCase {
    * The Cloudflare tunnel opt-out removes only the tunnel scripts.
    */
   #[DataProvider('dataProviderProcessCloudflare')]
-  public function testProcessCloudflare(string $remove_cloudflare, bool $expect_exists): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], $remove_cloudflare, 'n');
+  public function testProcessCloudflare(bool $remove_cloudflare, bool $expect_exists): void {
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], $remove_cloudflare, FALSE);
 
     foreach (['provision', 'start', 'stop'] as $phase) {
       $path = self::$sut . '/scripts/' . $phase . '-cloudflared.sh';
@@ -377,8 +378,8 @@ final class InitProcessTest extends UnitTestCase {
   }
 
   public static function dataProviderProcessCloudflare(): \Iterator {
-    yield 'keep' => ['n', TRUE];
-    yield 'remove' => ['y', FALSE];
+    yield 'keep' => [FALSE, TRUE];
+    yield 'remove' => [TRUE, FALSE];
   }
 
   /**
@@ -388,7 +389,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessRemovesWrapperDocs')]
   public function testProcessRemovesWrapperDocs(array $command_wrapper, bool $expect_make, bool $expect_ahoy): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], $command_wrapper, [], 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], $command_wrapper, [], FALSE, FALSE);
 
     $agents = (string) file_get_contents(self::$sut . '/AGENTS.md');
 
@@ -416,7 +417,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessRemovesGitattributes')]
   public function testProcessRemovesGitattributes(array $tools_remove, array $expected_absent): void {
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], $tools_remove, 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], $tools_remove, FALSE, FALSE);
 
     $gitattributes = (string) file_get_contents(self::$sut . '/.gitattributes');
     foreach ($expected_absent as $needle) {
@@ -446,7 +447,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessPrunesDrupalVersions')]
   public function testProcessPrunesDrupalVersions(string $ci_provider, array $drupal_versions, string $ci_file, array $expected_present, array $expected_absent): void {
-    process('My Extension', 'my_extension', 'module', $ci_provider, $drupal_versions, ['ahoy'], [], 'n', 'n');
+    process('My Extension', 'my_extension', 'module', $ci_provider, $drupal_versions, ['ahoy'], [], FALSE, FALSE);
 
     $content = (string) file_get_contents(self::$sut . '/' . $ci_file);
 
@@ -482,7 +483,7 @@ final class InitProcessTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderProcessNarrowsAssembleDefault')]
   public function testProcessNarrowsAssembleDefault(array $drupal_versions, string $expected_default): void {
-    process('My Extension', 'my_extension', 'module', 'gha', $drupal_versions, ['ahoy'], [], 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', $drupal_versions, ['ahoy'], [], FALSE, FALSE);
 
     $assemble = (string) file_get_contents(self::$sut . '/.devtools/assemble');
     $this->assertStringContainsString("getenv_default('DRUPAL_VERSION', '" . $expected_default . "')", $assemble);
@@ -498,7 +499,7 @@ final class InitProcessTest extends UnitTestCase {
     file_put_contents(self::$sut . '/.claude/settings.json', '{invalid json');
 
     $this->expectException(\JsonException::class);
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], FALSE, FALSE);
   }
 
   public function testProcessThrowsOnInvalidClaudeSettingsStructure(): void {
@@ -506,13 +507,13 @@ final class InitProcessTest extends UnitTestCase {
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Invalid .claude/settings.json structure.');
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], FALSE, FALSE);
   }
 
   public function testProcessSkipsWhenClaudeSettingsMissing(): void {
     @unlink(self::$sut . '/.claude/settings.json');
 
-    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], 'n', 'n');
+    process('My Extension', 'my_extension', 'module', 'gha', ['10', '11'], ['ahoy'], [], FALSE, FALSE);
 
     $this->assertFileExists(self::$sut . '/my_extension.info.yml');
     $this->assertFileDoesNotExist(self::$sut . '/.claude/settings.json');

--- a/.scaffold/tests/src/Unit/ProvisionTest.php
+++ b/.scaffold/tests/src/Unit/ProvisionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 
+use function DrupalExtensionScaffold\DevTools\site_db_file;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -92,8 +93,8 @@ final class ProvisionTest extends UnitTestCase {
     }
 
     // 3. Site install.
-    $db_file = '/tmp/site_' . $extension_name . '.sqlite';
-    $passthru_responses[] = ['cmd' => $prefix . sprintf('site-install %s -y --db-url="sqlite://localhost/%s" --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg($drupal_profile), $db_file)];
+    $db_file = site_db_file($extension_name);
+    $passthru_responses[] = ['cmd' => $prefix . sprintf('site-install %s -y --db-url=%s --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg($drupal_profile), escapeshellarg('sqlite://localhost/' . $db_file))];
 
     // 4. drush status.
     $passthru_responses[] = ['cmd' => $prefix . 'status'];
@@ -121,7 +122,8 @@ final class ProvisionTest extends UnitTestCase {
     }
 
     // 8. drush uli.
-    $passthru_responses[] = ['cmd' => $prefix . sprintf('uli -l http://%s:%s --no-browser', $expected_host, $expected_port), 'output' => 'http://' . $expected_host . ':' . $expected_port . '/user/reset/1/abc/login'];
+    $site_url = sprintf('http://%s:%s', $expected_host, $expected_port);
+    $passthru_responses[] = ['cmd' => $prefix . sprintf('uli -l %s --no-browser', escapeshellarg($site_url)), 'output' => $site_url . '/user/reset/1/abc/login'];
 
     $this->mockPassthruMultiple($passthru_responses);
 
@@ -241,14 +243,15 @@ final class ProvisionTest extends UnitTestCase {
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
 
     $prefix = self::drushPrefix($cwd);
-    $db_file = '/tmp/site_' . $extension_name . '.sqlite';
+    $db_file = site_db_file($extension_name);
+    $site_url = sprintf('http://%s:%s', $expected_host, $expected_port);
     $this->mockPassthruMultiple([
       ['cmd' => $prefix . 'status --field=db-status', 'output' => ''],
-      ['cmd' => $prefix . sprintf('site-install %s -y --db-url="sqlite://localhost/%s" --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg('standard'), $db_file)],
+      ['cmd' => $prefix . sprintf('site-install %s -y --db-url=%s --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg('standard'), escapeshellarg('sqlite://localhost/' . $db_file))],
       ['cmd' => $prefix . 'status'],
       ['cmd' => $prefix . 'pm:enable ' . escapeshellarg($extension_name)],
       ['cmd' => $prefix . 'cr'],
-      ['cmd' => $prefix . sprintf('uli -l http://%s:%s --no-browser', $expected_host, $expected_port), 'output' => 'http://' . $expected_host . ':' . $expected_port . '/user/reset/1/abc/login'],
+      ['cmd' => $prefix . sprintf('uli -l %s --no-browser', escapeshellarg($site_url)), 'output' => $site_url . '/user/reset/1/abc/login'],
     ]);
 
     ob_start();
@@ -288,16 +291,16 @@ final class ProvisionTest extends UnitTestCase {
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
 
     $prefix = self::drushPrefix($cwd);
-    $db_file = '/tmp/site_' . $extension_name . '.sqlite';
+    $db_file = site_db_file($extension_name);
     // The pre-warm still hits the local host:port, but the login link and the
     // completion banner report the public tunnel URL.
     $this->mockPassthruMultiple([
       ['cmd' => $prefix . 'status --field=db-status', 'output' => ''],
-      ['cmd' => $prefix . sprintf('site-install %s -y --db-url="sqlite://localhost/%s" --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg('standard'), $db_file)],
+      ['cmd' => $prefix . sprintf('site-install %s -y --db-url=%s --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL', escapeshellarg('standard'), escapeshellarg('sqlite://localhost/' . $db_file))],
       ['cmd' => $prefix . 'status'],
       ['cmd' => $prefix . 'pm:enable ' . escapeshellarg($extension_name)],
       ['cmd' => $prefix . 'cr'],
-      ['cmd' => $prefix . sprintf('uli -l %s --no-browser', $tunnel_url), 'output' => $tunnel_url . '/user/reset/1/abc/login'],
+      ['cmd' => $prefix . sprintf('uli -l %s --no-browser', escapeshellarg($tunnel_url)), 'output' => $tunnel_url . '/user/reset/1/abc/login'],
     ]);
 
     ob_start();

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -27,7 +27,7 @@ final class QrcodeTest extends UnitTestCase {
     parent::tearDown();
   }
 
-  public function testRendersQrcodeForUrlArgument(): void {
+  public function testQrcodeRendersQrcodeForUrlArgument(): void {
     // Rendering is opt-in; enable it for this run.
     $this->envSet('QRCODE', '1');
     $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
@@ -56,7 +56,7 @@ final class QrcodeTest extends UnitTestCase {
     $this->assertStringContainsString('[QR-CODE]', $output);
   }
 
-  public function testRendersNothingWithoutUrlArgument(): void {
+  public function testQrcodeDoesNothingWithoutUrlArgument(): void {
     $argv = ['qrcode'];
     ob_start();
     require dirname(__DIR__, 4) . '/.devtools/qrcode';

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,20 @@ WEBSERVER_PORT ?= 8000
 # are invoked.
 DRUSH_URI = $(shell ./.devtools/info site-url)
 
+# Test environment exported to every recipe (see the blanket `export` above),
+# matching what the ahoy entrypoint exports for every command, so `make
+# test*` runs against the same base URL, database, and browser-output
+# directory as `ahoy test*`.
+EXTENSION_NAME = $(shell basename -s .info.yml -- ./*.info.yml)
+SIMPLETEST_BASE_URL = http://$(WEBSERVER_HOST):$(WEBSERVER_PORT)
+SIMPLETEST_DB = sqlite://localhost/drupal_test_$(EXTENSION_NAME).sqlite
+BROWSERTEST_OUTPUT_DIRECTORY = $(CURDIR)/.logs/browser_output
+
 define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble build debug debug-off debug-on delete describe destroy help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
+.PHONY: assemble build debug debug-off debug-on delete describe destroy drush help info lint lint-fix login provision reset start stop test xdebug xdebug-off xdebug-on
 #;< DEV_PHPUNIT
 .PHONY: test-unit test-kernel test-functional
 #;> DEV_PHPUNIT
@@ -69,7 +78,11 @@ help:
 	@echo "test-js                    - Run JavaScript unit tests."
 	@#;> DEV_JEST
 
-build: stop assemble start provision
+build:
+	@$(MAKE) stop >/dev/null 2>&1 || true
+	$(MAKE) assemble
+	$(MAKE) start
+	$(MAKE) provision
 
 assemble:
 	./.devtools/assemble
@@ -167,10 +180,25 @@ lint-fix:
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm run lint-fix) && popd >/dev/null || exit 1
 	@#;> DEV_NODEJS_LINT
 
+# Allow passing extra args to phpunit test targets, mirroring the `drush`
+# arg-capture above. The target list is split across the same DEV_* markers
+# as the `.PHONY` declarations so a stripped feature leaves no dangling entry.
+TEST_TARGETS := test
+#;< DEV_PHPUNIT
+TEST_TARGETS += test-unit test-kernel test-functional
+#;> DEV_PHPUNIT
+#;< DEV_FUNCTIONAL_JAVASCRIPT
+TEST_TARGETS += test-functional-javascript
+#;> DEV_FUNCTIONAL_JAVASCRIPT
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),$(TEST_TARGETS)))
+  TEST_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(TEST_RUN_ARGS):;@:)
+endif
+
 test:
 	@#;< DEV_PHPUNIT
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && php -d pcov.directory=.. vendor/bin/phpunit $(TEST_RUN_ARGS) && popd >/dev/null || exit 1
 	@#;> DEV_PHPUNIT
 	@#;< DEV_JEST
 	$(call title,Running Jest)
@@ -180,17 +208,17 @@ test:
 #;< DEV_PHPUNIT
 test-unit:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-kernel:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 #;> DEV_PHPUNIT
 
@@ -199,7 +227,7 @@ test-functional-javascript:
 	$(MAKE) browser-start
 	export WEBDRIVER_PORT="$$(./.devtools/info webdriver-port)" && \
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=$(CURDIR)/.logs/browser_output php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript $(TEST_RUN_ARGS) && \
 	popd >/dev/null || exit 1
 #;> DEV_FUNCTIONAL_JAVASCRIPT
 

--- a/config/schema/your_extension.schema.yml
+++ b/config/schema/your_extension.schema.yml
@@ -1,6 +1,6 @@
 your_extension.settings:
   type: config_object
-  label: 'Your Extension settings'
+  label: 'Your Extension Settings'
   mapping:
     text:
       type: string

--- a/init.php
+++ b/init.php
@@ -131,7 +131,7 @@ function main(array $argv): void {
     env_prefix: 'PROMPTY_',
   );
 
-  if ($results === NULL || ($results['proceed'] ?? FALSE) === FALSE) {
+  if ($results === NULL || !($results['proceed'] ?? FALSE)) {
     throw new \Exception('Aborting.');
   }
 
@@ -148,8 +148,8 @@ function main(array $argv): void {
   $tools_remove = array_values(array_diff(array_keys($tool_options), $tools_keep));
   // The prompt asks whether to keep the tunnel scripts, so a 'no' answer is
   // what triggers their removal.
-  $remove_cloudflare = empty($results['cloudflare']) ? 'y' : 'n';
-  $remove_self = empty($results['remove_self']) ? 'n' : 'y';
+  $remove_cloudflare = !($results['cloudflare'] ?? FALSE);
+  $remove_self = $results['remove_self'] ?? FALSE;
 
   // Derive machine name from extension name if the user accepted placeholder.
   if ($machine_name === 'my_extension' || $machine_name === '') {
@@ -186,7 +186,7 @@ function drupal_version_options(): array {
 function print_help(): void {
   $script_name = basename(__FILE__);
   $out = <<<EOF
-Drupal Extension Scaffold - project initialisation.
+Drupal Extension Scaffold - project initialization.
 ----------------------------------------------------
 
 Usage:
@@ -234,12 +234,12 @@ EOF;
  *   The selected command wrappers ('ahoy', 'makefile', or both).
  * @param array<string> $tools_remove
  *   The machine names of the development tools to remove.
- * @param string $remove_cloudflare
- *   Whether to remove the Cloudflare tunnel scripts ('y' or 'n').
- * @param string $remove_self
- *   Whether to remove this script ('y' or 'n').
+ * @param bool $remove_cloudflare
+ *   Whether to remove the Cloudflare tunnel scripts.
+ * @param bool $remove_self
+ *   Whether to remove this script.
  */
-function process(string $extension_name, string $extension_machine_name, string $extension_type, string $ci_provider, array $drupal_versions, array $command_wrapper, array $tools_remove, string $remove_cloudflare, string $remove_self): void {
+function process(string $extension_name, string $extension_machine_name, string $extension_type, string $ci_provider, array $drupal_versions, array $command_wrapper, array $tools_remove, bool $remove_cloudflare, bool $remove_self): void {
   // Validate required values.
   if ($extension_name === '') {
     throw new \Exception('Name is required.');
@@ -270,7 +270,7 @@ function process(string $extension_name, string $extension_machine_name, string 
   // Prune CI matrix corners for deselected Drupal majors. Each major's corners
   // are wrapped in '#;< DRUPAL_<major>' markers across the CI files; removing a
   // major strips those blocks. Markers for kept majors are cleared later by
-  // 'remove_special_comments()'. Normalise both sides to strings: PHP casts
+  // 'remove_special_comments()'. Normalize both sides to strings: PHP casts
   // numeric-string array keys to integers, so 'array_keys()' returns ints that
   // would never strictly match the string selection.
   $supported_majors = array_map(strval(...), array_keys(drupal_version_options()));
@@ -301,40 +301,7 @@ function process(string $extension_name, string $extension_machine_name, string 
     remove_tokens_with_content('DEV_MAKEFILE');
   }
 
-  // Trim wrapper-specific permissions from Claude settings to match selection.
-  $claude_settings = '.claude/settings.json';
-  if (file_exists($claude_settings)) {
-    $raw = file_get_contents($claude_settings);
-    if ($raw === FALSE) {
-      // @codeCoverageIgnoreStart
-      throw new \RuntimeException('Unable to read .claude/settings.json.');
-      // @codeCoverageIgnoreEnd
-    }
-
-    $config = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
-    if (!is_array($config) || !isset($config['permissions']) || !is_array($config['permissions']) || !isset($config['permissions']['allow']) || !is_array($config['permissions']['allow'])) {
-      throw new \RuntimeException('Invalid .claude/settings.json structure.');
-    }
-
-    $config['permissions']['allow'] = array_values(array_filter(
-      $config['permissions']['allow'],
-      static function ($permission) use ($command_wrapper): bool {
-        $wrapper = match ($permission) {
-          'Bash(ahoy:*)' => 'ahoy',
-          'Bash(make:*)' => 'makefile',
-          default => NULL,
-        };
-        return $wrapper === NULL || in_array($wrapper, $command_wrapper, TRUE);
-      },
-    ));
-
-    $encoded = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
-    if (file_put_contents($claude_settings, $encoded . PHP_EOL) === FALSE) {
-      // @codeCoverageIgnoreStart
-      throw new \RuntimeException('Unable to write .claude/settings.json.');
-      // @codeCoverageIgnoreEnd
-    }
-  }
+  trim_claude_settings_permissions($command_wrapper);
 
   remove_tools($tools_remove);
 
@@ -345,15 +312,63 @@ function process(string $extension_name, string $extension_machine_name, string 
   // Remove the opt-in Cloudflare quick-tunnel scripts when the tunnel support
   // is declined. The tunnel-agnostic TUNNEL_URL handling in the core scripts
   // stays regardless, so any other tunnel tool still integrates.
-  if ($remove_cloudflare !== 'n') {
+  if ($remove_cloudflare) {
     @unlink('scripts/provision-cloudflared.sh');
     @unlink('scripts/start-cloudflared.sh');
     @unlink('scripts/stop-cloudflared.sh');
   }
 
-  if ($remove_self !== 'n') {
+  if ($remove_self) {
     // @codeCoverageIgnoreStart
     @unlink(__FILE__);
+    // @codeCoverageIgnoreEnd
+  }
+}
+
+/**
+ * Trim wrapper-specific permissions from Claude settings to match selection.
+ *
+ * A failed read (file exists but is unreadable) is treated the same as a
+ * missing file: the settings are left untouched rather than aborting the
+ * whole 'process()' pipeline over a single non-critical file.
+ *
+ * @param array<string> $command_wrapper
+ *   The selected command wrappers ('ahoy', 'makefile', or both).
+ */
+function trim_claude_settings_permissions(array $command_wrapper): void {
+  $file = '.claude/settings.json';
+  if (!file_exists($file)) {
+    return;
+  }
+
+  $raw = file_get_contents($file);
+  if ($raw === FALSE) {
+    // @codeCoverageIgnoreStart
+    return;
+    // @codeCoverageIgnoreEnd
+  }
+
+  $config = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+  if (!is_array($config) || !isset($config['permissions']) || !is_array($config['permissions']) || !isset($config['permissions']['allow']) || !is_array($config['permissions']['allow'])) {
+    throw new \RuntimeException('Invalid .claude/settings.json structure.');
+  }
+
+  $config['permissions']['allow'] = array_values(array_filter(
+    $config['permissions']['allow'],
+    static function ($permission) use ($command_wrapper): bool {
+      $wrapper = match ($permission) {
+        'Bash(ahoy:*)' => 'ahoy',
+        'Bash(make:*)' => 'makefile',
+        default => NULL,
+      };
+      return $wrapper === NULL || in_array($wrapper, $command_wrapper, TRUE);
+    },
+  ));
+
+  $encoded = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+  if (file_put_contents($file, $encoded . PHP_EOL) === FALSE) {
+    // @codeCoverageIgnoreStart
+    throw new \RuntimeException('Unable to write .claude/settings.json.');
     // @codeCoverageIgnoreEnd
   }
 }
@@ -507,7 +522,7 @@ function process_internal(string $extension_name, string $extension_machine_name
   remove_tokens_with_content('META');
   remove_special_comments();
 
-  normalise_cspell_words();
+  normalize_cspell_words();
 
   if ($extension_type === 'theme') {
     @unlink($extension_machine_name . '.install');
@@ -1147,7 +1162,7 @@ function remove_special_comments(): void {
  * rewrites them all to the extension machine name, producing duplicate
  * entries. Read, deduplicate, sort, and write back.
  */
-function normalise_cspell_words(): void {
+function normalize_cspell_words(): void {
   if (!file_exists('.cspell.json')) {
     return;
   }
@@ -1159,7 +1174,7 @@ function normalise_cspell_words(): void {
     // @codeCoverageIgnoreEnd
   }
 
-  $config = json_decode($raw, TRUE);
+  $config = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
   if (!is_array($config)) {
     return;
   }

--- a/scripts/provision-cloudflared.sh
+++ b/scripts/provision-cloudflared.sh
@@ -10,7 +10,8 @@
 #
 # This lives in a provision hook rather than the start hook because
 # `drush site-install` rewrites settings.php during provision, which runs after
-# start. Pairs with `scripts/start-cloudflared.sh`. CWD is the project root.
+# start. Pairs with `scripts/start-cloudflared.sh`. The current working
+# directory is the project root.
 
 set -eu
 

--- a/scripts/start-cloudflared.sh
+++ b/scripts/start-cloudflared.sh
@@ -10,7 +10,8 @@
 #
 # No Cloudflare account, DNS, or config is needed - quick tunnels mint an
 # ephemeral `*.trycloudflare.com` hostname. Install `cloudflared` via mise,
-# brew, or apt. Remove or rename this file to disable. CWD is the project root.
+# brew, or apt. Remove or rename this file to disable. The current working
+# directory is the project root.
 
 set -eu
 
@@ -47,12 +48,12 @@ tunnel_pid() {
 # removes it so a dead URL is never left behind.
 set_tunnel_url() {
   touch .env
-  _tmp=".env.cloudflared.$$"
-  grep -v '^TUNNEL_URL=' .env >"$_tmp" 2>/dev/null || true
+  env_tmp=".env.cloudflared.$$"
+  grep -v '^TUNNEL_URL=' .env >"$env_tmp" 2>/dev/null || true
   if [ -n "${1:-}" ]; then
-    printf 'TUNNEL_URL=%s\n' "$1" >>"$_tmp"
+    printf 'TUNNEL_URL=%s\n' "$1" >>"$env_tmp"
   fi
-  mv "$_tmp" .env
+  mv "$env_tmp" .env
 }
 
 # Reuse an existing tunnel only when its process is alive AND its public URL

--- a/scripts/stop-cloudflared.sh
+++ b/scripts/stop-cloudflared.sh
@@ -5,7 +5,8 @@
 # Kills the `cloudflared` process started by `scripts/start-cloudflared.sh` and
 # removes the TUNNEL_URL entry from `.env` so a dead public URL is not reported
 # on the next run. Runs even when CLOUDFLARE_TUNNEL is no longer set, so cleanup
-# always happens; a no-op when no tunnel is active. CWD is the project root.
+# always happens; a no-op when no tunnel is active. The current working
+# directory is the project root.
 
 set -eu
 

--- a/src/Form/YourExtensionForm.php
+++ b/src/Form/YourExtensionForm.php
@@ -34,6 +34,7 @@ class YourExtensionForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
+    // @phpstan-ignore-next-line
     return new static(
       $container->get('config.factory'),
       $container->get('config.typed'),

--- a/src/Form/YourExtensionForm.php
+++ b/src/Form/YourExtensionForm.php
@@ -27,15 +27,13 @@ class YourExtensionForm extends ConfigFormBase {
      */
     protected YourExtensionService $yourExtensionService,
   ) {
-    // @phpstan-ignore-next-line
     parent::__construct($config_factory, $typedConfigManager);
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container): YourExtensionForm {
-    // @phpstan-ignore-next-line
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('config.factory'),
       $container->get('config.typed'),
@@ -60,7 +58,7 @@ class YourExtensionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('your_extension.settings');
 
     $form['text'] = [

--- a/src/YourExtensionService.php
+++ b/src/YourExtensionService.php
@@ -12,20 +12,14 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 class YourExtensionService {
 
   /**
-   * The extension configuration.
-   *
-   * @var \Drupal\Core\Config\ImmutableConfig
-   */
-  protected $yourExtensionConfig;
-
-  /**
    * Constructs a new YourExtensionService instance.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->yourExtensionConfig = $config_factory->get('your_extension.settings');
+  public function __construct(
+    /**
+     * The config factory.
+     */
+    protected ConfigFactoryInterface $configFactory,
+  ) {
   }
 
   /**
@@ -35,7 +29,7 @@ class YourExtensionService {
    *   The text to be inserted.
    */
   public function getText(): string {
-    $text = $this->yourExtensionConfig->get('text');
+    $text = $this->configFactory->get('your_extension.settings')->get('text');
 
     return static::sanitize($text);
   }

--- a/tests/src/Functional/YourExtensionFunctionalTest.php
+++ b/tests/src/Functional/YourExtensionFunctionalTest.php
@@ -33,8 +33,9 @@ class YourExtensionFunctionalTest extends BrowserTestBase {
    * Tests the functionality of the getText method.
    */
   public function testGetText(): void {
-    $user = $this->createUser(['administer site configuration']);
-    $this->drupalLogin($user);
+    $account = $this->drupalCreateUser(['administer site configuration']);
+    $this->assertNotEmpty($account);
+    $this->drupalLogin($account);
 
     $this->drupalGet('admin/config/development/your-extension');
 

--- a/tests/src/Kernel/YourExtensionServiceKernelTest.php
+++ b/tests/src/Kernel/YourExtensionServiceKernelTest.php
@@ -6,11 +6,7 @@ namespace Drupal\Tests\your_extension\Kernel;
 
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\ImmutableConfig;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\your_extension\YourExtensionService;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the YourExtensionService class.
@@ -20,8 +16,6 @@ use Prophecy\PhpUnit\ProphecyTrait;
 #[Group('your_extension')]
 #[RunTestsInSeparateProcesses]
 class YourExtensionServiceKernelTest extends KernelTestBase {
-
-  use ProphecyTrait;
 
   /**
    * {@inheritdoc}
@@ -41,15 +35,13 @@ class YourExtensionServiceKernelTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $your_config_config = $this->prophesize(ImmutableConfig::class);
-    $your_config_config->get('text')
-      ->willReturn('<p>This is <strong>bold</strong> text.</p>');
+    $this->installConfig(['your_extension']);
 
-    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
-    $config_factory->get('your_extension.settings')
-      ->willReturn($your_config_config->reveal());
+    $this->config('your_extension.settings')
+      ->set('text', '<p>This is <strong>bold</strong> text.</p>')
+      ->save();
 
-    $this->yourExtensionService = new YourExtensionService($config_factory->reveal());
+    $this->yourExtensionService = $this->container->get('your_extension.service');
   }
 
   /**

--- a/tests/src/Unit/YourExtensionServiceUnitTest.php
+++ b/tests/src/Unit/YourExtensionServiceUnitTest.php
@@ -21,6 +21,8 @@ class YourExtensionServiceUnitTest extends UnitTestCase {
    * Tests the sanitize method of YourExtensionService.
    *
    * @covers \Drupal\your_extension\YourExtensionService::sanitize
+   *
+   * @dataProvider dataProviderSanitize
    */
   #[DataProvider('dataProviderSanitize')]
   public function testSanitize(string $input, string $expected): void {

--- a/tests/src/Unit/YourExtensionServiceUnitTest.php
+++ b/tests/src/Unit/YourExtensionServiceUnitTest.php
@@ -21,7 +21,6 @@ class YourExtensionServiceUnitTest extends UnitTestCase {
    * Tests the sanitize method of YourExtensionService.
    *
    * @covers \Drupal\your_extension\YourExtensionService::sanitize
-   * @dataProvider dataProviderSanitize
    */
   #[DataProvider('dataProviderSanitize')]
   public function testSanitize(string $input, string $expected): void {

--- a/your_extension.info.yml
+++ b/your_extension.info.yml
@@ -1,4 +1,4 @@
-name: Drupal extension scaffold
+name: Your Extension
 type: module
 description: Drupal extension scaffold example.
 package: Testing

--- a/your_extension.links.menu.yml
+++ b/your_extension.links.menu.yml
@@ -1,5 +1,5 @@
 your_extension.settings_form:
   title: 'Your Extension'
-  description: 'Your Extension settings'
+  description: 'Your Extension Settings'
   route_name: your_extension.settings_form
   parent: system.admin_config_development


### PR DESCRIPTION
## Summary

A prior convergence pass (#465) unified the codebase's behavior-preserving inconsistencies but deferred 15 judgment calls that needed a human decision - behavior changes, genuine ties, and public-symbol renames. This PR resolves all 15 per the maintainer's decisions, spanning the example module's dependency injection and return types, `init.php`'s confirmation-flag types and error handling, the `.devtools` engine's shared helpers and exit-code handling, the Makefile's alignment with the `ahoy` runner, and naming/vocabulary unification across the test suite. Three remaining items were deliberately left as-is (see below) because they are intentional per-wrapper twins, public entry points referenced externally, or out of scope for this pass.

## Applied

**Example module**
- Modernized `YourExtensionService` to a promoted, typed constructor injecting the config factory (matching `YourExtensionForm`); `create()` now returns `static` (the redundant covariance `phpstan-ignore` dropped; the `new static()` suppression kept, since PHPStan flags it for a non-`final` class); `buildForm()` declares its `array` return type.
- `YourExtensionServiceKernelTest` now resolves the service from the booted container instead of constructing it via `new` with a prophesized factory, so real DI wiring is exercised.
- Standardized functional user creation on `drupalCreateUser()`/`$account`.
- Kept the `@dataProvider`/`@group` annotations alongside their PHPUnit attributes - they are intentional Drupal 10 / PHPUnit 9 cross-version compatibility (the attribute alone is not honored there and Drupal's `run-tests.sh` still parses annotations), not drift. This is the one place the "remove duplicate annotations" decision was reverted after CI confirmed D10 needs them.
- Unified the human-readable name/labels to `Your Extension`.

**init.php**
- Confirmation answers are now real booleans threaded through `process()` end-to-end instead of `'y'`/`'n'` strings.
- Unified error handling: `JSON_THROW_ON_ERROR` on every decode, and one consistent unreadable-file policy (the settings-permission trim now follows the file's dominant guard-clause skip).
- Prose/identifiers converted to US spelling (`initialize`, `normalize`).

**.devtools engine**
- Output: unified `XDebug` casing (fixed the `XdEBUG` typo), switched deploy's action announcements from `NOTE()` to `TASK()`, and harmonized the info banner format. The semantically-meaningful completion-banner wording (build steps say "COMPLETE", environment lifecycle says "READY"/"STOPPED") was preserved rather than flattened.
- Internals: extracted the duplicated `kill_port()`, `site_db_file()`, and shared port-discovery logic into `helpers.php`; routed `browser`'s hand-rolled `passthru`+`FAIL` through the shared `passthru_or_fail()`; unified `drush()` callers onto the safe placeholder+escaped-array form; unified `resolve_env_value()`'s return shape to the named-key style its siblings use.
- Fixed both `passthru_or_fail()` and `passthru_verbose_or_fail()` to preserve the command's real exit code when a failure message is supplied (previously masked as `1`) - so a failing custom hook now propagates its true exit code.

**Runners**
- Aligned the Makefile's behavior with ahoy: phpunit arg passthrough (split across the `DEV_*` markers so a stripped feature leaves no dangling target), the `SIMPLETEST_*`/`BROWSERTEST_OUTPUT_DIRECTORY` test environment, best-effort `stop` in `build`, and `drush` in `.PHONY`.

**Tests and vocab**
- Renamed the scenario-only unit-test methods in `InfoTest`/`BrowserTest`/`QrcodeTest` to the dominant `test<Command><Scenario>` convention (with matching data-provider renames).
- Unified the mock-setup helper (`setup<Command>Mocks`), the "does nothing" suffix (`DoesNothing`), and the "missing input" suffix (`Missing`).

**Polish**
- Fixed the `Vortex` `@file` header in `helpers.php`, the wrong-class docblock in `FunctionalTestCase`, and unified the cloudflared hook headers.

## Left as-is by decision

- `AhoyTest`/`MakeTest` are kept as deliberate per-wrapper twins - each wrapper needs its own independent test so a regression in one can't be masked by the other. This is now recorded as a "do not DRY" rule in `.scaffold/CLAUDE.md`.
- The `.devtools` script filenames (`browser`/`info`/`qrcode` vs the verb-named ones) are kept - they are public entry points referenced by the runners, CI, docs, and consumer projects, so renaming would be a breaking change.
- The remaining test-infrastructure items (AutoPortDiscoveryTest inheritance, DevtoolsTestCase teardown) were left untouched.

## Verification

- Local (fast gates, no build): `.scaffold/tests` p0 unit suite (427 tests) green after every step; lint (PHPCS, PHPStan level 9, Rector) green; `InitTest` regenerated and confirmed serially across all 23 datasets.
- CI: the full matrix is green - the module's own PHPUnit (Unit/Kernel/Functional/FunctionalJavascript) and the scaffold's p2-p5 functional tests across PHP 8.3-8.5, Drupal 10-11, chromedriver + selenium, plus CircleCI and codecov.
- Two module-only issues surfaced on CI and were fixed here (they need a Drupal build, so they can't be caught by the local gates): Drupal 10 / PHPUnit 9 requires the `@dataProvider` annotation (the attribute alone is not honored), and PHPStan flags `new static()` in a non-`final` class - both handled by keeping the cross-version annotations and one targeted suppression.

## Before / After

```
BEFORE ──────────────────────────────────────────────────────────────

  resolve_webserver()         resolve_webdriver_port()
        │                            │
        └──────────┬─────────────────┘
                    ▼
     each inlines its own find_free_port() + dotenv_write_var() scan

  resolve_env_value()  →  [$value, $source]                 (tuple)

  passthru_or_fail($fmt)
        └─ on failure: FAIL($fmt) [exits 1]  →  quit($exit_code)
                        (real exit code overwritten by the exit(1) inside FAIL)

  init.php process(string $remove_cloudflare, string $remove_self, ...)
        ├─ 'y' / 'n' strings threaded through the whole pipeline
        └─ 40-line Claude-settings-trim block inlined directly in process()

  .devtools/browser, start, stop, info
        └─ each hand-rolls its own kill_port() / site_db_file()

AFTER ───────────────────────────────────────────────────────────────

  resolve_webserver()         resolve_webdriver_port()
        │                            │
        └──────────┬─────────────────┘
                    ▼
            resolve_port_value()   (single shared scan + persist path)

  resolve_env_value()  →  ['value' => .., 'source' => ..]    (named keys)

  passthru_or_fail($fmt)
        └─ on failure: FAIL_NO_EXIT($fmt)  →  quit($exit_code)
                        (real exit code always reaches quit())

  init.php process(bool $remove_cloudflare, bool $remove_self, ...)
        ├─ real booleans threaded through the whole pipeline
        └─ trim_claude_settings_permissions()   (extracted, named function)

  .devtools/browser, start, stop, info
        └─ all call the shared helpers.php::kill_port() / site_db_file()
```
