### PR TITLE
Replaced versioned Drupal Rector sets with a composer-based provider and pinned rector/rector below 2.6.2 on Drupal 10 builds.

### DIFF
--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -117,12 +117,9 @@ $build_json = (array) json_decode((string) file_get_contents($build_composer_jso
 unset($build_json['require-dev']['drupal/core-dev']);
 // Add symfony/phpunit-bridge with a version matching Drupal core's Symfony.
 $build_json['require-dev']['symfony/phpunit-bridge'] = (int) $drupal_version_major >= 11 ? '^7 || ^8' : '~6.4';
-// The Drupal 10 deprecation configs in palantirnet/drupal-rector reference the
-// versioned PHPUnit and Twig set constants that rector/rector 2.6.2 removed in
-// favour of composer-based sets, so loading them on a Drupal 10 build aborts
-// Rector before it analyses anything. Constrain Rector on Drupal 10 only; newer
-// majors resolve it freely. Applied to the build rather than composer.dev.json
-// so the extension itself carries no upper bound.
+// The Drupal 10 configs in palantirnet/drupal-rector reference set constants
+// removed in rector/rector 2.6.2. Constrained per-build so the extension's own
+// dependencies carry no upper bound.
 if ((int) $drupal_version_major < 11) {
   $build_json['require-dev']['rector/rector'] = '^2 <2.6.2';
 }

--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -117,6 +117,15 @@ $build_json = (array) json_decode((string) file_get_contents($build_composer_jso
 unset($build_json['require-dev']['drupal/core-dev']);
 // Add symfony/phpunit-bridge with a version matching Drupal core's Symfony.
 $build_json['require-dev']['symfony/phpunit-bridge'] = (int) $drupal_version_major >= 11 ? '^7 || ^8' : '~6.4';
+// The Drupal 10 deprecation configs in palantirnet/drupal-rector reference the
+// versioned PHPUnit and Twig set constants that rector/rector 2.6.2 removed in
+// favour of composer-based sets, so loading them on a Drupal 10 build aborts
+// Rector before it analyses anything. Constrain Rector on Drupal 10 only; newer
+// majors resolve it freely. Applied to the build rather than composer.dev.json
+// so the extension itself carries no upper bound.
+if ((int) $drupal_version_major < 11) {
+  $build_json['require-dev']['rector/rector'] = '^2 <2.6.2';
+}
 file_put_contents($build_composer_json, json_encode($build_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 PASS('Test dependencies configured.');
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -117,6 +117,15 @@ $build_json = (array) json_decode((string) file_get_contents($build_composer_jso
 unset($build_json['require-dev']['drupal/core-dev']);
 // Add symfony/phpunit-bridge with a version matching Drupal core's Symfony.
 $build_json['require-dev']['symfony/phpunit-bridge'] = (int) $drupal_version_major >= 11 ? '^7 || ^8' : '~6.4';
+// The Drupal 10 deprecation configs in palantirnet/drupal-rector reference the
+// versioned PHPUnit and Twig set constants that rector/rector __VERSION__ removed in
+// favour of composer-based sets, so loading them on a Drupal 10 build aborts
+// Rector before it analyses anything. Constrain Rector on Drupal 10 only; newer
+// majors resolve it freely. Applied to the build rather than composer.dev.json
+// so the extension itself carries no upper bound.
+if ((int) $drupal_version_major < 11) {
+  $build_json['require-dev']['rector/rector'] = '^2 <__VERSION__';
+}
 file_put_contents($build_composer_json, json_encode($build_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 PASS('Test dependencies configured.');
 

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/assemble
@@ -117,12 +117,9 @@ $build_json = (array) json_decode((string) file_get_contents($build_composer_jso
 unset($build_json['require-dev']['drupal/core-dev']);
 // Add symfony/phpunit-bridge with a version matching Drupal core's Symfony.
 $build_json['require-dev']['symfony/phpunit-bridge'] = (int) $drupal_version_major >= 11 ? '^7 || ^8' : '~6.4';
-// The Drupal 10 deprecation configs in palantirnet/drupal-rector reference the
-// versioned PHPUnit and Twig set constants that rector/rector __VERSION__ removed in
-// favour of composer-based sets, so loading them on a Drupal 10 build aborts
-// Rector before it analyses anything. Constrain Rector on Drupal 10 only; newer
-// majors resolve it freely. Applied to the build rather than composer.dev.json
-// so the extension itself carries no upper bound.
+// The Drupal 10 configs in palantirnet/drupal-rector reference set constants
+// removed in rector/rector __VERSION__. Constrained per-build so the extension's own
+// dependencies carry no upper bound.
 if ((int) $drupal_version_major < 11) {
   $build_json['require-dev']['rector/rector'] = '^2 <__VERSION__';
 }

--- a/.scaffold/tests/fixtures/init/_baseline/rector.php
+++ b/.scaffold/tests/fixtures/init/_baseline/rector.php
@@ -17,9 +17,7 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
-use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal11SetList;
-use DrupalRector\Set\Drupal9SetList;
+use DrupalRector\Set\DrupalSetProvider;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
@@ -39,7 +37,6 @@ use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRecto
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 // Rector and its embedded PHPStan cache reflection data that records
@@ -54,12 +51,14 @@ if (!is_dir($cache_dir)) {
 
 return RectorConfig::configure()
   ->withSkip([
-    // Specific rules to skip based on project coding standards.
+    // Specific rules to skip based on project coding standards. Rector only
+    // registers `AddOverrideAttributeToOverriddenMethodsRector` on the version
+    // resolved for Drupal 10 builds and warns that the entry is unused on
+    // newer ones, so it stays listed to cover both.
     AddOverrideAttributeToOverriddenMethodsRector::class,
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
     NewlineBeforeNewAssignSetRector::class,
@@ -89,12 +88,13 @@ return RectorConfig::configure()
     privatization: TRUE,
     naming: TRUE,
   )
-  // Drupal-specific deprecation fixes.
-  ->withSets([
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-    Drupal11SetList::DRUPAL_11,
-  ])
+  // Drupal-specific deprecation fixes. The provider binds each set to a
+  // `drupal/core` version and only the sets the installed core satisfies are
+  // loaded, so the rules follow the version the extension is being built
+  // against. Both calls are required: the provider supplies the sets,
+  // `withComposerBased()` enables the group.
+  ->withSetProviders(DrupalSetProvider::class)
+  ->withComposerBased(drupal: TRUE)
   // Additional rules.
   ->withRules([
     DeclareStrictTypesRector::class,

--- a/rector.php
+++ b/rector.php
@@ -17,9 +17,7 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
-use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal11SetList;
-use DrupalRector\Set\Drupal9SetList;
+use DrupalRector\Set\DrupalSetProvider;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
@@ -39,7 +37,6 @@ use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRecto
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 // Rector and its embedded PHPStan cache reflection data that records
@@ -54,12 +51,14 @@ if (!is_dir($cache_dir)) {
 
 return RectorConfig::configure()
   ->withSkip([
-    // Specific rules to skip based on project coding standards.
+    // Specific rules to skip based on project coding standards. Rector only
+    // registers `AddOverrideAttributeToOverriddenMethodsRector` on the version
+    // resolved for Drupal 10 builds and warns that the entry is unused on
+    // newer ones, so it stays listed to cover both.
     AddOverrideAttributeToOverriddenMethodsRector::class,
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
     NewlineBeforeNewAssignSetRector::class,
@@ -95,12 +94,13 @@ return RectorConfig::configure()
     privatization: TRUE,
     naming: TRUE,
   )
-  // Drupal-specific deprecation fixes.
-  ->withSets([
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-    Drupal11SetList::DRUPAL_11,
-  ])
+  // Drupal-specific deprecation fixes. The provider binds each set to a
+  // `drupal/core` version and only the sets the installed core satisfies are
+  // loaded, so the rules follow the version the extension is being built
+  // against. Both calls are required: the provider supplies the sets,
+  // `withComposerBased()` enables the group.
+  ->withSetProviders(DrupalSetProvider::class)
+  ->withComposerBased(drupal: TRUE)
   // Additional rules.
   ->withRules([
     DeclareStrictTypesRector::class,


### PR DESCRIPTION
## Summary

`rector/rector` 2.6.2 (released 2026-08-12) dropped the versioned `PHPUnitSetList::PHPUNIT_*` and `TwigSetList::TWIG_*` constants in favour of composer-based sets, but `palantirnet/drupal-rector` 1.1.2 still references those constants from its Drupal 8, 9, and 10 deprecation configs - and since this template commits no lock file, CI resolves dependencies fresh on every run, so Rector aborted before it analysed anything. This mirrors an issue upstream in Vortex (drevops/vortex#2975), fixed there in drevops/vortex#2978; this PR carries the equivalent fix here, plus one extra piece Vortex doesn't need (see below).

## Changes

- `rector.php` - swapped the 3 hardcoded versioned set lists (`Drupal9SetList::DRUPAL_9`, `Drupal10SetList::DRUPAL_10`, `Drupal11SetList::DRUPAL_11`) for `->withSetProviders(DrupalSetProvider::class)` plus `->withComposerBased(drupal: TRUE)`. Both calls matter: the provider supplies the sets, and `withComposerBased()` is what turns the group on. The provider binds each set to the installed `drupal/core` version, so only the sets that version actually satisfies get loaded. Also dropped the `DisallowedEmptyRuleFixerRector` skip entry - it's deprecated in 2.6.2 and lives in a prepared set this config doesn't enable, so just naming the class made PHPStan fail on a deprecated-class access. `AddOverrideAttributeToOverriddenMethodsRector` stays in the skip list, now with a comment explaining why: Rector registers it on the version resolved for Drupal 10 builds but not on newer ones, where it prints a harmless "skipped rule is never registered" warning.
- `.devtools/assemble` - constrained `rector/rector` to `^2 <2.6.2` for Drupal 10 builds only. This is the one piece that goes beyond the upstream Vortex fix: Vortex only targets Drupal 11, but this template supports Drupal 10 and 11 (and `init.php` lets a consumer generate a Drupal-10-only project, which makes Drupal 10 the assemble default). On a Drupal 10 build, the composer-based provider loads the Drupal 10 deprecation configs, which still reference the removed constants and abort Rector with `Could not detect twig set.`. The constraint lands in the assembled build's `composer.json`, next to the existing `symfony/phpunit-bridge` per-major branch - not in `composer.dev.json` - so the extension's own dependency declarations carry no upper bound and Drupal 11 builds keep resolving Rector freely.
- `.scaffold/tests/fixtures/init/_baseline/rector.php` and `.scaffold/tests/fixtures/init/_baseline/.devtools/assemble` - regenerated the init snapshot baseline so it matches the 2 files above.

## Verification

- Drupal 11 build (rector 2.6.2, drupal/core 11.4.5) - full `ahoy lint` green: PHPCS, PHPStan, Rector, Twig CS Fixer, ESLint, Stylelint, CSpell.
- Drupal 10 build (rector 2.6.1, drupal/core 10.6.15) - Rector runs to completion and reports no changes.
- Scaffold snapshot suite - `composer test -- --filter=InitTest`: 23 tests, 92 assertions, OK.

## Before / After

```
BEFORE
┌─ rector.php ──────────────────────────────────────────────
│   ->withSets([
│     Drupal9SetList::DRUPAL_9,
│     Drupal10SetList::DRUPAL_10,
│     Drupal11SetList::DRUPAL_11,
│   ])
└───────────────────────────────────────────────────────────

┌─ .devtools/assemble ──────────────────────────────────────
│   rector/rector: no version constraint, any Drupal major
└───────────────────────────────────────────────────────────

        rector/rector 2.6.2 removes the constants above ->
        Rector aborts before analysing anything, every build
                                │
                                v
AFTER
┌─ rector.php ──────────────────────────────────────────────
│   ->withSetProviders(DrupalSetProvider::class)
│   ->withComposerBased(drupal: TRUE)
└───────────────────────────────────────────────────────────

┌─ .devtools/assemble ──────────────────────────────────────
│   Drupal 10 build: rector/rector pinned to "^2 <2.6.2"
│   Drupal 11 build: rector/rector unconstrained
└───────────────────────────────────────────────────────────

        provider resolves sets against the installed
        drupal/core version -> Rector runs cleanly on both
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replace versioned Drupal Rector set lists with composer-based `DrupalSetProvider` configuration.
- Remove the deprecated `DisallowedEmptyRuleFixerRector` skip.
- Retain the documented `AddOverrideAttributeToOverriddenMethodsRector` skip.
- Constrain `rector/rector` to `^2 <2.6.2` for Drupal versions below 11.
- Keep Drupal 11 builds unrestricted.
- Regenerate init snapshot baselines.
- Verify Drupal 11 linting, Drupal 10 Rector execution, and the init snapshot suite.

## Possibly related

The repository issue search was unavailable because GitHub returned HTTP 403.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->