### PR TITLE
[#488] Resolved 'DEPLOY_BRANCH' from a repository variable and the default branch in the deploy workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,16 @@ jobs:
 
       - name: Deploy to Remote
         env:
-          DEPLOY_BRANCH: ${{ env.DEPLOY_BRANCH }}
+          # Optional repository variable. Falls back to the branch that
+          # triggered the build, and then to the default branch.
+          DEPLOY_BRANCH: ${{ vars.DEPLOY_BRANCH }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          DEPLOY_BRANCH="${DEPLOY_BRANCH:-${HEAD_BRANCH}}" .devtools/deploy
+          # A tag push reports the tag name as the head branch, which would
+          # deploy the release to a remote branch named after the tag.
+          if git show-ref --quiet --verify "refs/tags/${HEAD_BRANCH}"; then
+            HEAD_BRANCH=''
+          fi
+
+          DEPLOY_BRANCH="${DEPLOY_BRANCH:-${HEAD_BRANCH:-${DEFAULT_BRANCH}}}" .devtools/deploy

--- a/.scaffold/tests/composer.json
+++ b/.scaffold/tests/composer.json
@@ -32,7 +32,8 @@
         "rector/rector": "^2.4.5",
         "symfony/filesystem": "^7.4.11",
         "symfony/finder": "^7.4.8",
-        "symfony/process": "^7.4.13"
+        "symfony/process": "^7.4.13",
+        "symfony/yaml": "^7.4.15"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/.scaffold/tests/composer.lock
+++ b/.scaffold/tests/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "277e197e6baa9647d6b461fb81025cff",
+    "content-hash": "a4262eef8fee98cd3a7a152a359aa0b5",
     "packages": [
         {
             "name": "alexskrypnyk/file",
@@ -3821,16 +3821,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.13",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
+                "reference": "e101850ded5d2c0d44bf32abb8996404afec2dec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e101850ded5d2c0d44bf32abb8996404afec2dec",
+                "reference": "e101850ded5d2c0d44bf32abb8996404afec2dec",
                 "shasum": ""
             },
             "require": {
@@ -3873,7 +3873,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -3893,7 +3893,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T06:06:12+00:00"
+            "time": "2026-07-21T15:13:06+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml
@@ -42,7 +42,16 @@ jobs:
 
       - name: Deploy to Remote
         env:
-          DEPLOY_BRANCH: ${{ env.DEPLOY_BRANCH }}
+          # Optional repository variable. Falls back to the branch that
+          # triggered the build, and then to the default branch.
+          DEPLOY_BRANCH: ${{ vars.DEPLOY_BRANCH }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          DEPLOY_BRANCH="${DEPLOY_BRANCH:-${HEAD_BRANCH}}" .devtools/deploy
+          # A tag push reports the tag name as the head branch, which would
+          # deploy the release to a remote branch named after the tag.
+          if git show-ref --quiet --verify "refs/tags/${HEAD_BRANCH}"; then
+            HEAD_BRANCH=''
+          fi
+
+          DEPLOY_BRANCH="${DEPLOY_BRANCH:-${HEAD_BRANCH:-${DEFAULT_BRANCH}}}" .devtools/deploy

--- a/.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php
+++ b/.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Yaml;
 #[Group('p0')]
 final class WorkflowsEnvContextTest extends UnitTestCase {
 
-  #[DataProvider('dataProviderWorkflows')]
+  #[DataProvider('dataProviderEnvReferencesAreDefined')]
   public function testEnvReferencesAreDefined(string $path): void {
     $contents = file_get_contents($path);
     $this->assertIsString($contents);
@@ -37,7 +37,7 @@ final class WorkflowsEnvContextTest extends UnitTestCase {
     $this->assertSame([], $undefined, sprintf('%s reads environment variables that it never defines: %s', basename($path), implode(', ', $undefined)));
   }
 
-  public static function dataProviderWorkflows(): \Iterator {
+  public static function dataProviderEnvReferencesAreDefined(): \Iterator {
     $paths = glob(dirname(__DIR__, 4) . '/.github/workflows/*.yml');
 
     foreach ($paths ?: [] as $path) {
@@ -93,7 +93,7 @@ final class WorkflowsEnvContextTest extends UnitTestCase {
     preg_match_all('/\$\{\{(.*?)\}\}/s', $contents, $expressions);
 
     foreach ($expressions[1] as $expression) {
-      preg_match_all('/\benv\.([A-Za-z_][A-Za-z0-9_]*)/', $expression, $matches);
+      preg_match_all('/\benv\.([A-Za-z_]\w*)/', $expression, $matches);
       $referenced = array_merge($referenced, $matches[1]);
     }
 

--- a/.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php
+++ b/.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that workflows define every environment variable they read.
+ *
+ * The `env` context resolves to an empty string for a name that was never
+ * defined, so a typo or a self-reference silently disables the value instead
+ * of failing the run. Neither actionlint nor Zizmor reports it.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class WorkflowsEnvContextTest extends UnitTestCase {
+
+  #[DataProvider('dataProviderWorkflows')]
+  public function testEnvReferencesAreDefined(string $path): void {
+    $contents = file_get_contents($path);
+    $this->assertIsString($contents);
+
+    $parsed = Yaml::parse($contents);
+    $this->assertIsArray($parsed);
+
+    $defined = [];
+    self::collectDefined($parsed, $defined);
+
+    $undefined = array_values(array_unique(array_diff(self::collectReferenced($contents), $defined)));
+
+    $this->assertSame([], $undefined, sprintf('%s reads environment variables that it never defines: %s', basename($path), implode(', ', $undefined)));
+  }
+
+  public static function dataProviderWorkflows(): \Iterator {
+    $paths = glob(dirname(__DIR__, 4) . '/.github/workflows/*.yml');
+
+    foreach ($paths ?: [] as $path) {
+      yield basename($path) => ['path' => $path];
+    }
+  }
+
+  /**
+   * Collect the names a workflow defines, into the passed array.
+   *
+   * @param mixed $node
+   *   A node of the parsed workflow.
+   * @param array<int, string> $defined
+   *   Collected names.
+   */
+  protected static function collectDefined(mixed $node, array &$defined): void {
+    if (!is_array($node)) {
+      return;
+    }
+
+    foreach ($node as $key => $value) {
+      if ($key === 'env' && is_array($value)) {
+        foreach ($value as $name => $expression) {
+          // A name assigned from its own `env` entry defines nothing: the
+          // context does not yet hold the block being evaluated.
+          if (is_string($name) && !self::isSelfReference($name, $expression)) {
+            $defined[] = $name;
+          }
+        }
+      }
+
+      if ($key === 'run' && is_string($value) && str_contains($value, 'GITHUB_ENV')) {
+        preg_match_all('/\b([A-Z_][A-Z0-9_]*)=/', $value, $matches);
+        $defined = array_merge($defined, $matches[1]);
+      }
+
+      self::collectDefined($value, $defined);
+    }
+  }
+
+  /**
+   * Collect the names a workflow reads through the `env` context.
+   *
+   * @param string $contents
+   *   The workflow contents.
+   *
+   * @return array<int, string>
+   *   Collected names.
+   */
+  protected static function collectReferenced(string $contents): array {
+    $referenced = [];
+
+    preg_match_all('/\$\{\{(.*?)\}\}/s', $contents, $expressions);
+
+    foreach ($expressions[1] as $expression) {
+      preg_match_all('/\benv\.([A-Za-z_][A-Za-z0-9_]*)/', $expression, $matches);
+      $referenced = array_merge($referenced, $matches[1]);
+    }
+
+    return $referenced;
+  }
+
+  protected static function isSelfReference(string $name, mixed $expression): bool {
+    if (!is_string($expression)) {
+      return FALSE;
+    }
+
+    return preg_match('/^\s*\$\{\{\s*env\.' . preg_quote($name, '/') . '\s*\}\}\s*$/', $expression) === 1;
+  }
+
+}

--- a/.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php
+++ b/.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php
@@ -38,9 +38,10 @@ final class WorkflowsEnvContextTest extends UnitTestCase {
   }
 
   public static function dataProviderEnvReferencesAreDefined(): \Iterator {
-    $paths = glob(dirname(__DIR__, 4) . '/.github/workflows/*.yml');
+    $directory = dirname(__DIR__, 4) . '/.github/workflows/';
+    $paths = array_merge(glob($directory . '*.yml') ?: [], glob($directory . '*.yaml') ?: []);
 
-    foreach ($paths ?: [] as $path) {
+    foreach ($paths as $path) {
       yield basename($path) => ['path' => $path];
     }
   }

--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ ssh-keygen -m PEM -t rsa -b 4096 -C "your_email+project_name@example.com"
   deploy. Without this variable, the deployment job will run but will not
   push the code. This is useful for testing the deployment job.
 
+5. Optionally, set `DEPLOY_BRANCH` to the branch to push to in the destination repository. It is not a secret: add it as a repository variable in GitHub Actions (**Settings** -> **Secrets and variables** -> **Actions** -> **Variables**) and as a project environment variable in CircleCI. Without it, the code is pushed to the branch that triggered the build, and a tagged release is pushed to the default branch - the repository default branch in GitHub Actions, and the `default_branch` alias in `.circleci/config.yml` in CircleCI.
+
 ### Drupal.org CI (DrupalCI)
 
 Once your extension is mirrored to Drupal.org, its GitLab CI ("DrupalCI") runs


### PR DESCRIPTION
Closes #488

## Summary

The deploy workflow computed `DEPLOY_BRANCH` from `${{ env.DEPLOY_BRANCH }}`, a self-reference to an env variable the workflow never defined anywhere else, so the expression always resolved to an empty string and the shell fallback `${DEPLOY_BRANCH:-${HEAD_BRANCH}}` always picked the branch that triggered the build. A configured deploy branch could never take effect on GitHub Actions, even though the equivalent CircleCI job already resolved it correctly.

This change sources `DEPLOY_BRANCH` from the optional `vars.DEPLOY_BRANCH` repository variable, adds a `DEFAULT_BRANCH` fallback from `github.event.repository.default_branch` to mirror the CircleCI chain, and blanks the head branch when it names a tag so a tagged release falls through to the default branch instead of force-pushing to a remote branch named after the tag. A new regression test asserts that every `${{ env.X }}` reference in `.github/workflows/*.yml` resolves to a definition in the same file, a defect class that neither yamllint, actionlint, nor Zizmor catches.

## Changes

### `.github/workflows/deploy.yml`

- Sourced `DEPLOY_BRANCH` from the optional `vars.DEPLOY_BRANCH` repository variable instead of the self-referencing `env.DEPLOY_BRANCH`, which always resolved to an empty string.
- Added a `DEFAULT_BRANCH` env variable from `github.event.repository.default_branch`, giving the shell fallback a third level, mirroring the CircleCI chain `${DEPLOY_BRANCH:-${CIRCLE_BRANCH:-${DEFAULT_BRANCH}}}`.
- Blanked `HEAD_BRANCH` when it names a tag, checked with `git show-ref --verify refs/tags/...` against the tags the existing `fetch-depth: 0` checkout already fetches, so a tagged release resolves to the default branch instead of a branch named after the tag.
- Used a repository variable rather than a secret because a branch name is not sensitive, and secret masking would otherwise print `Pushing code to branch ***` in the deploy log.

### `.scaffold/tests/src/Unit/WorkflowsEnvContextTest.php`

- New `p0` test that parses every `.github/workflows/*.yml` and `*.yaml` file with `symfony/yaml`, collects the names each file defines through `env:` blocks (excluding self-references, which define nothing) and through `run:` steps that write to `$GITHUB_ENV`, then asserts every `${{ env.X }}` reference resolves to one of those names.
- Fails against the pre-fix `deploy.yml` and passes after it.

### `.scaffold/tests/composer.json` / `composer.lock`

- Added `symfony/yaml` (`^7.4.15`) as a direct dependency for the new test; it was already present transitively.

### `.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml`

- Regenerated the baseline snapshot fixture to match the updated `deploy.yml`.

### `README.md`

- Documented the optional `DEPLOY_BRANCH` variable: how to set it as a repository variable in GitHub Actions and as a project environment variable in CircleCI, and the fallback behavior when it is unset.

## Before / After

```
GitHub Actions — BEFORE
└─ DEPLOY_BRANCH = env.DEPLOY_BRANCH  (self-reference, never defined elsewhere)
   └─▶ always ""
       └─▶ shell fallback always uses HEAD_BRANCH
           ├─ branch push → HEAD_BRANCH = "feature/x" → pushed to "feature/x"  (configured branch ignored)
           └─ tag push    → HEAD_BRANCH = "1.2.3"      → pushed to "1.2.3"      (branch named after the tag)

GitHub Actions — AFTER
└─ DEPLOY_BRANCH = vars.DEPLOY_BRANCH  (repository variable, optional)
   └─▶ empty when unset
       └─▶ HEAD_BRANCH, blanked when it names a tag (refs/tags/<name> exists)
           ├─ branch push → HEAD_BRANCH = "feature/x" → pushed to "feature/x" unless a variable is set
           └─ tag push    → HEAD_BRANCH blanked        → falls through to DEFAULT_BRANCH
               └─▶ DEFAULT_BRANCH = github.event.repository.default_branch → pushed to the repo default branch

CircleCI — unchanged, now mirrored by GitHub Actions
└─ DEPLOY_BRANCH  (project environment variable, optional)
   └─▶ empty when unset
       └─▶ CIRCLE_BRANCH → empty on a tag build
           └─▶ default_branch anchor ("1.x")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Resolve `DEPLOY_BRANCH` from the optional GitHub repository variable.
- Fall back to the workflow head branch, then the repository default branch.
- Handle tag-triggered deployments by clearing the tag name before fallback.
- Document `DEPLOY_BRANCH` configuration and fallback behavior for GitHub Actions and CircleCI.
- Add regression coverage for undefined `${{ env.X }}` references in `.yml` and `.yaml` workflows.
- Add `symfony/yaml` as a direct test dependency and regenerate the baseline fixture.

## Possibly related

- Possibly related to `#488`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->