### PR TITLE
[#493, #494]  Documented missing '.devtools' entries and corrected PHPUnit README paths.

### DIFF
--- a/.devtools/README.md
+++ b/.devtools/README.md
@@ -7,6 +7,9 @@ This directory contains scripts used for development. These can be used locally 
 | `stop`        | Stop the development server.                                                                           |
 | `provision`   | Install Drupal on the assembled site and enable the extension.                                         |
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
+| `browser`     | Start or stop the WebDriver backend used by FunctionalJavascript tests.                                |
+| `info`        | Print a summary of the environment, or a single field such as `site-url`, for the wrappers to consume. |
+| `qrcode`      | Render a URL as a scannable QR code in the terminal.                                                   |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
 ## Verbose output

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/README.md
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/README.md
@@ -7,6 +7,9 @@ This directory contains scripts used for development. These can be used locally 
 | `stop`        | Stop the development server.                                                                           |
 | `provision`   | Install Drupal on the assembled site and enable the extension.                                         |
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
+| `browser`     | Start or stop the WebDriver backend used by FunctionalJavascript tests.                                |
+| `info`        | Print a summary of the environment, or a single field such as `site-url`, for the wrappers to consume. |
+| `qrcode`      | Render a URL as a scannable QR code in the terminal.                                                   |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
 ## Verbose output

--- a/.scaffold/tests/fixtures/init/_baseline/phpunit.d10.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpunit.d10.xml
@@ -3,7 +3,7 @@
 <!-- For how to customize PHPUnit configuration, see web/core/tests/README.md. -->
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
 <!-- PHPUnit expects functional tests to be run with either a privileged user
- or your current system user. See core/tests/README.md and
+ or your current system user. See web/core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/.scaffold/tests/fixtures/init/_baseline/phpunit.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpunit.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Drupal 11 PHPUnit configuration. -->
-<!-- For how to customize PHPUnit configuration, see core/tests/README.md. -->
+<!-- For how to customize PHPUnit configuration, see web/core/tests/README.md. -->
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
 <!-- PHPUnit expects functional tests to be run with either a privileged user
- or your current system user. See core/tests/README.md and
+ or your current system user. See web/core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/.scaffold/tests/src/Unit/DocumentationTest.php
+++ b/.scaffold/tests/src/Unit/DocumentationTest.php
@@ -11,8 +11,9 @@ use PHPUnit\Framework\Attributes\Group;
  * Tests that documentation stays consistent with the files it describes.
  *
  * A script can be added to `.devtools/` without ever reaching its README
- * table: the directory and the table are edited independently, and neither
- * file becomes invalid when they disagree, so no linter reports the drift.
+ * table, and a path can be copied into a PHPUnit config without being rebased
+ * onto the build root. Neither drift is reported by a linter, because each
+ * file stays individually valid while the two disagree.
  *
  * phpcs:disable Drupal.Commenting.FunctionComment.Missing
  * phpcs:disable Drupal.Commenting.DocComment.MissingShort
@@ -43,6 +44,36 @@ final class DocumentationTest extends UnitTestCase {
       }
 
       yield $name => ['name' => $name];
+    }
+  }
+
+  #[DataProvider('dataProviderPhpunitCorePathsUseDocrootPrefix')]
+  public function testPhpunitCorePathsUseDocrootPrefix(string $path): void {
+    $contents = file_get_contents($path);
+    $this->assertIsString($contents);
+
+    // These configs run from the build root rather than from the Drupal root,
+    // so the docroot prefix carried by `bootstrap` applies to every other
+    // core-relative path in the file, comments included.
+    $this->assertSame(1, preg_match('/bootstrap="([^"]+)"/', $contents, $bootstrap), sprintf('%s declares no bootstrap attribute.', basename($path)));
+
+    $position = strpos($bootstrap[1], 'core/');
+    $this->assertIsInt($position, sprintf('%s bootstraps outside core: %s', basename($path), $bootstrap[1]));
+
+    $prefix = substr($bootstrap[1], 0, $position);
+
+    preg_match_all('/^.*(?<!' . preg_quote($prefix, '/') . ')\bcore\/.*$/m', $contents, $unprefixed);
+
+    $this->assertSame([], $unprefixed[0], sprintf('%s references core paths without the `%s` docroot prefix.', basename($path), $prefix));
+  }
+
+  public static function dataProviderPhpunitCorePathsUseDocrootPrefix(): \Iterator {
+    $paths = glob(self::rootDir() . '/phpunit*.xml') ?: [];
+
+    self::assertNotSame([], $paths, 'No PHPUnit configuration files found in the project root.');
+
+    foreach ($paths as $path) {
+      yield basename($path) => ['path' => $path];
     }
   }
 

--- a/.scaffold/tests/src/Unit/DocumentationTest.php
+++ b/.scaffold/tests/src/Unit/DocumentationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that documentation stays consistent with the files it describes.
+ *
+ * A script can be added to `.devtools/` without ever reaching its README
+ * table: the directory and the table are edited independently, and neither
+ * file becomes invalid when they disagree, so no linter reports the drift.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class DocumentationTest extends UnitTestCase {
+
+  #[DataProvider('dataProviderDevtoolsScriptsAreDocumented')]
+  public function testDevtoolsScriptsAreDocumented(string $name): void {
+    $readme = file_get_contents(self::rootDir() . '/.devtools/README.md');
+    $this->assertIsString($readme);
+
+    $documented = preg_match('/^\|.*`' . preg_quote($name, '/') . '`.*\|/m', $readme) === 1;
+
+    $this->assertTrue($documented, sprintf('.devtools/README.md has no table row for `%s`.', $name));
+  }
+
+  public static function dataProviderDevtoolsScriptsAreDocumented(): \Iterator {
+    $paths = glob(self::rootDir() . '/.devtools/*') ?: [];
+
+    self::assertNotSame([], $paths, 'No entries found in .devtools/.');
+
+    foreach ($paths as $path) {
+      $name = basename($path);
+
+      if ($name === 'README.md') {
+        continue;
+      }
+
+      yield $name => ['name' => $name];
+    }
+  }
+
+  /**
+   * Get the project root directory.
+   *
+   * @return string
+   *   The absolute path to the project root.
+   */
+  protected static function rootDir(): string {
+    return dirname(__DIR__, 4);
+  }
+
+}

--- a/.scaffold/tests/src/Unit/DocumentationTest.php
+++ b/.scaffold/tests/src/Unit/DocumentationTest.php
@@ -55,16 +55,32 @@ final class DocumentationTest extends UnitTestCase {
     // These configs run from the build root rather than from the Drupal root,
     // so the docroot prefix carried by `bootstrap` applies to every other
     // core-relative path in the file, comments included.
-    $this->assertSame(1, preg_match('/bootstrap="([^"]+)"/', $contents, $bootstrap), sprintf('%s declares no bootstrap attribute.', basename($path)));
+    preg_match('/bootstrap="([^"]+)"/', $contents, $bootstrap);
+    $bootstrap_path = $bootstrap[1] ?? '';
 
-    $position = strpos($bootstrap[1], 'core/');
-    $this->assertIsInt($position, sprintf('%s bootstraps outside core: %s', basename($path), $bootstrap[1]));
+    $this->assertNotSame('', $bootstrap_path, sprintf('%s declares no bootstrap attribute.', basename($path)));
 
-    $prefix = substr($bootstrap[1], 0, $position);
+    $position = strpos($bootstrap_path, 'core/');
+    $this->assertIsInt($position, sprintf('%s bootstraps outside core: %s', basename($path), $bootstrap_path));
 
-    preg_match_all('/^.*(?<!' . preg_quote($prefix, '/') . ')\bcore\/.*$/m', $contents, $unprefixed);
+    $prefix = substr($bootstrap_path, 0, $position);
 
-    $this->assertSame([], $unprefixed[0], sprintf('%s references core paths without the `%s` docroot prefix.', basename($path), $prefix));
+    $unprefixed = [];
+
+    foreach (explode("\n", $contents) as $index => $line) {
+      // Match each reference together with the path segments leading into it,
+      // so the prefix can be compared by value. A lookbehind cannot serve
+      // here: PCRE requires a fixed-length one, and the prefix is derived.
+      preg_match_all('/[A-Za-z0-9_.\/-]*\bcore\//', $line, $references);
+
+      $offenders = array_filter($references[0], static fn(string $reference): bool => !str_starts_with($reference, $prefix));
+
+      foreach ($offenders as $offender) {
+        $unprefixed[] = sprintf('line %d: %s', $index + 1, $offender);
+      }
+    }
+
+    $this->assertSame([], $unprefixed, sprintf('%s references core paths without the `%s` docroot prefix.', basename($path), $prefix));
   }
 
   public static function dataProviderPhpunitCorePathsUseDocrootPrefix(): \Iterator {

--- a/.scaffold/tests/src/Unit/DocumentationTest.php
+++ b/.scaffold/tests/src/Unit/DocumentationTest.php
@@ -26,7 +26,9 @@ final class DocumentationTest extends UnitTestCase {
     $readme = file_get_contents(self::rootDir() . '/.devtools/README.md');
     $this->assertIsString($readme);
 
-    $documented = preg_match('/^\|.*`' . preg_quote($name, '/') . '`.*\|/m', $readme) === 1;
+    // Anchored to the entry column: a name mentioned in another row's
+    // description is a cross-reference, not an entry of its own.
+    $documented = preg_match('/^\|\s*`' . preg_quote($name, '/') . '`\s*\|/m', $readme) === 1;
 
     $this->assertTrue($documented, sprintf('.devtools/README.md has no table row for `%s`.', $name));
   }

--- a/phpunit.d10.xml
+++ b/phpunit.d10.xml
@@ -3,7 +3,7 @@
 <!-- For how to customize PHPUnit configuration, see web/core/tests/README.md. -->
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
 <!-- PHPUnit expects functional tests to be run with either a privileged user
- or your current system user. See core/tests/README.md and
+ or your current system user. See web/core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Drupal 11 PHPUnit configuration. -->
-<!-- For how to customize PHPUnit configuration, see core/tests/README.md. -->
+<!-- For how to customize PHPUnit configuration, see web/core/tests/README.md. -->
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
 <!-- PHPUnit expects functional tests to be run with either a privileged user
- or your current system user. See core/tests/README.md and
+ or your current system user. See web/core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Closes #493
Closes #494

## Summary

Fixes two documentation-correctness defects in files that ship into every scaffolded project. `.devtools/README.md` documented only 6 of the 9 entries under `.devtools/`, omitting `browser`, `info` and `qrcode`, all three reachable from the public command surface. `phpunit.xml` and `phpunit.d10.xml` referenced the PHPUnit README at `core/tests/README.md`, a path that only resolves from the Drupal docroot and not from `build/`, which is where these configs actually run. A new regression test pins both invariants so neither can silently drift back.

## Changes

**`.devtools/README.md`** - Added table rows for `browser` (backs `browser-start`/`browser-stop`), `info` (backs `make info`/`ahoy info`, plus the `site-url` and `webdriver-port` resolvers), and `qrcode` (backs `make login`/`ahoy login`).

**`phpunit.d10.xml`** - Corrected the `core/tests/README.md` reference to `web/core/tests/README.md`, matching the docroot prefix its own `bootstrap` attribute already carries.

**`phpunit.xml`** - Corrected both `core/tests/README.md` references to `web/core/tests/README.md`. This is the Drupal 11 default most consumers use, and both instances were wrong. These configs are project-authored derivatives rather than upstream mirrors - `bootstrap` is rewritten to `web/core/tests/bootstrap.php`, the test suites are rewritten around `web/modules/custom/*`, and a coverage block, a junit logging target and scaffold markers (`#;<`) are all added - so the paths just need to resolve for a reader running from `build/`.

**`.scaffold/tests/src/Unit/DocumentationTest.php`** - Added, tagged `#[Group('p0')]`. `testDevtoolsScriptsAreDocumented` asserts every entry in `.devtools/` except `README.md` itself has a table row in the README. `testPhpunitCorePathsUseDocrootPrefix` asserts every core-relative path in each `phpunit*.xml` carries the same docroot prefix its own `bootstrap` attribute carries. Both were confirmed failing before the fixes and passing after, modelled on the existing `WorkflowsEnvContextTest`, which enforces a comparable repo-level invariant no linter checks.

**`.scaffold/tests/fixtures/init/_baseline/`** - Regenerated with `composer update-snapshots` since `.devtools/README.md`, `phpunit.xml` and `phpunit.d10.xml` all live in the `InitTest` baseline. Only the baseline changed; all 23 datasets pass.

## Before / After

```
BEFORE
┌─ .devtools/README.md ───────────────────────────────────────┐
│ assemble, start, stop, provision, deploy, helpers.php        │
│ documented ................................. 6/9 entries    │
│ browser, info, qrcode ...................... undocumented ✗  │
└────────────────────────────────────────────────────────────┘
┌─ phpunit.xml / phpunit.d10.xml ───────────────────────────────┐
│ bootstrap="web/core/tests/bootstrap.php"                       │
│ README ref -> core/tests/README.md ............. resolves ✗   │
│               (only from web/, not from build/, where these    │
│               configs actually run)                            │
└─────────────────────────────────────────────────────────────┘
No regression test guards either invariant.

AFTER
┌─ .devtools/README.md ───────────────────────────────────────┐
│ assemble, start, stop, provision, deploy, helpers.php,       │
│ browser, info, qrcode                                        │
│ documented ................................. 9/9 entries ✓  │
└────────────────────────────────────────────────────────────┘
┌─ phpunit.xml / phpunit.d10.xml ───────────────────────────────┐
│ bootstrap="web/core/tests/bootstrap.php"                       │
│ README ref -> web/core/tests/README.md .......... resolves ✓  │
│               (matches bootstrap's own docroot prefix)         │
└─────────────────────────────────────────────────────────────┘
DocumentationTest [p0] now guards both invariants permanently.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documented the `browser`, `info`, and `qrcode` entries in `.devtools/README.md`.
- Corrected PHPUnit README paths to `web/core/tests/README.md` in `phpunit.xml` and `phpunit.d10.xml`.
- Added `DocumentationTest` to verify `.devtools` coverage and PHPUnit docroot prefixes.
- Regenerated `InitTest` baseline snapshots.
- Addresses issues `#493` and `#494`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->