### PR TITLE
[#499] Fixed Drupal 10 static analysis rejecting PHPUnit attribute classes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,59 @@ aliases:
     image: selenium/standalone-chromium:latest
   #;> DEV_FUNCTIONAL_JAVASCRIPT
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    #;< DEV_CSPELL
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+    #;> DEV_CSPELL
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    #;< DEV_PHPCS
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+    #;> DEV_PHPCS
+
+    #;< DEV_PHPSTAN
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+    #;> DEV_PHPSTAN
+
+    #;< DEV_RECTOR
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+    #;> DEV_RECTOR
+
+    #;< DEV_TWIGCS
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+    #;> DEV_TWIGCS
+
+    #;< DEV_NODEJS_LINT
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+    #;> DEV_NODEJS_LINT
+
 job-test: &job-test
   steps:
     - checkout
@@ -100,63 +153,15 @@ job-test: &job-test
     #;> DEV_PHPUNIT
 
 jobs:
-  lint:
+  #;< DRUPAL_10
+  lint-d10:
     <<: *container_config
     docker:
-      - image: cimg/php:8.5-browsers
-    steps:
-      - checkout
+      - image: cimg/php:8.4-browsers
+    environment:
+      DRUPAL_VERSION: 10
+    <<: *job-lint
 
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      #;< DEV_CSPELL
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-      #;> DEV_CSPELL
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      #;< DEV_PHPCS
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-      #;> DEV_PHPCS
-
-      #;< DEV_PHPSTAN
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-      #;> DEV_PHPSTAN
-
-      #;< DEV_RECTOR
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-      #;> DEV_RECTOR
-
-      #;< DEV_TWIGCS
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-      #;> DEV_TWIGCS
-
-      #;< DEV_NODEJS_LINT
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
-      #;> DEV_NODEJS_LINT
-
-  #;< DRUPAL_10
   test-php-min-d10-stable:
     <<: *container_config
     docker:
@@ -181,6 +186,14 @@ jobs:
 
   #;> DRUPAL_10
   #;< DRUPAL_11
+  lint-d11:
+    <<: *container_config
+    docker:
+      - image: cimg/php:8.5-browsers
+    environment:
+      DRUPAL_VERSION: 11
+    <<: *job-lint
+
   test-php-min-d11-stable:
     <<: *container_config
     docker:
@@ -248,11 +261,11 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      #;< DRUPAL_10
+      - lint-d10:
           filters:
             tags:
               only: /.*/
-      #;< DRUPAL_10
       - test-php-min-d10-stable:
           filters:
             tags:
@@ -263,6 +276,10 @@ workflows:
               only: /.*/
       #;> DRUPAL_10
       #;< DRUPAL_11
+      - lint-d11:
+          filters:
+            tags:
+              only: /.*/
       - test-php-min-d11-stable:
           filters:
             tags:
@@ -282,12 +299,13 @@ workflows:
       #;> DRUPAL_11
       - deploy:
           requires:
-            - lint
             #;< DRUPAL_10
+            - lint-d10
             - test-php-min-d10-stable
             - test-php-max-d10-stable
             #;> DRUPAL_10
             #;< DRUPAL_11
+            - lint-d11
             - test-php-min-d11-stable
             - test-php-max-d11-stable
             - test-php-min-d11-legacy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,28 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          #;< DRUPAL_10
+          - name: lint-d10
+            php-version: 8.4
+            drupal-version: 10
+
+          #;> DRUPAL_10
+          #;< DRUPAL_11
+          - name: lint-d11
+            php-version: 8.5
+            drupal-version: 11
+
+          #;> DRUPAL_11
+    name: ${{ matrix.name }}
+
+    env:
+      DRUPAL_VERSION: ${{ matrix.drupal-version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -50,7 +72,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: 8.5
+          php-version: ${{ matrix.php-version }}
           extensions: gd, sqlite, pdo_sqlite
 
       - name: Assemble the codebase

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -20,6 +20,24 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - name: lint-d10
+            php-version: 8.4
+            drupal-version: 10
+
+          - name: lint-d11
+            php-version: 8.5
+            drupal-version: 11
+
+    name: ${{ matrix.name }}
+
+    env:
+      DRUPAL_VERSION: ${{ matrix.drupal-version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@__HASH__ # __VERSION__
@@ -48,7 +66,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@__HASH__ # __VERSION__
         with:
-          php-version: 8.5
+          php-version: ${{ matrix.php-version }}
           extensions: gd, sqlite, pdo_sqlite
 
       - name: Assemble the codebase

--- a/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
+++ b/.scaffold/tests/fixtures/init/_baseline/phpstan.neon
@@ -35,5 +35,12 @@ parameters:
         - '#.* no value type specified in iterable type array#'
         - '#.* has no return type specified#'
       reportUnmatched: false
+    -
+      # PHP resolves attribute classes lazily and PHPUnit 9.6 reads doc-comment
+      # metadata, so these are inert rather than broken on a Drupal 10 build.
+      # Rector writes them from the Drupal 11 set.
+      messages:
+        - '#^Attribute class PHPUnit\\Framework\\Attributes\\.+ does not exist\.$#'
+      reportUnmatched: false
 
   reportUnmatchedIgnoredErrors: false

--- a/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
@@ -18,6 +18,47 @@ aliases:
   - &selenium_image
     image: selenium/standalone-chromium:latest
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+
 job-test: &job-test
   steps:
     - checkout
@@ -92,49 +133,13 @@ job-test: &job-test
           fi
 
 jobs:
-  lint:
+  lint-d10:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
-    steps:
-      - checkout
-
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
+    environment:
+      DRUPAL_VERSION: 10
+    <<: *job-lint
 
   test-php-min-d10-stable:
     <<: *container_config
@@ -153,6 +158,14 @@ jobs:
     environment:
       DRUPAL_VERSION: 10
     <<: *job-test
+
+  lint-d11:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    environment:
+      DRUPAL_VERSION: 11
+    <<: *job-lint
 
   test-php-min-d11-stable:
     <<: *container_config
@@ -212,7 +225,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      - lint-d10:
           filters:
             tags:
               only: /.*/
@@ -221,6 +234,10 @@ workflows:
             tags:
               only: /.*/
       - test-php-max-d10-stable:
+          filters:
+            tags:
+              only: /.*/
+      - lint-d11:
           filters:
             tags:
               only: /.*/
@@ -242,9 +259,10 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - lint
+            - lint-d10
             - test-php-min-d10-stable
             - test-php-max-d10-stable
+            - lint-d11
             - test-php-min-d11-stable
             - test-php-max-d11-stable
             - test-php-min-d11-legacy

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
@@ -18,6 +18,47 @@ aliases:
   - &selenium_image
     image: selenium/standalone-chromium:latest
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+
 job-test: &job-test
   steps:
     - checkout
@@ -92,49 +133,13 @@ job-test: &job-test
           fi
 
 jobs:
-  lint:
+  lint-d10:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
-    steps:
-      - checkout
-
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
+    environment:
+      DRUPAL_VERSION: 10
+    <<: *job-lint
 
   test-php-min-d10-stable:
     <<: *container_config
@@ -153,6 +158,14 @@ jobs:
     environment:
       DRUPAL_VERSION: 10
     <<: *job-test
+
+  lint-d11:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    environment:
+      DRUPAL_VERSION: 11
+    <<: *job-lint
 
   test-php-min-d11-stable:
     <<: *container_config
@@ -212,7 +225,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      - lint-d10:
           filters:
             tags:
               only: /.*/
@@ -221,6 +234,10 @@ workflows:
             tags:
               only: /.*/
       - test-php-max-d10-stable:
+          filters:
+            tags:
+              only: /.*/
+      - lint-d11:
           filters:
             tags:
               only: /.*/
@@ -242,9 +259,10 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - lint
+            - lint-d10
             - test-php-min-d10-stable
             - test-php-max-d10-stable
+            - lint-d11
             - test-php-min-d11-stable
             - test-php-max-d11-stable
             - test-php-min-d11-legacy

--- a/.scaffold/tests/fixtures/init/circleci_d10_only/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_d10_only/.circleci/config.yml
@@ -18,6 +18,47 @@ aliases:
   - &selenium_image
     image: selenium/standalone-chromium:latest
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+
 job-test: &job-test
   steps:
     - checkout
@@ -92,49 +133,13 @@ job-test: &job-test
           fi
 
 jobs:
-  lint:
+  lint-d10:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
-    steps:
-      - checkout
-
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
+    environment:
+      DRUPAL_VERSION: 10
+    <<: *job-lint
 
   test-php-min-d10-stable:
     <<: *container_config
@@ -176,7 +181,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      - lint-d10:
           filters:
             tags:
               only: /.*/
@@ -190,7 +195,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - lint
+            - lint-d10
             - test-php-min-d10-stable
             - test-php-max-d10-stable
           filters:

--- a/.scaffold/tests/fixtures/init/circleci_d11_only/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_d11_only/.circleci/config.yml
@@ -18,6 +18,47 @@ aliases:
   - &selenium_image
     image: selenium/standalone-chromium:latest
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+
 job-test: &job-test
   steps:
     - checkout
@@ -92,49 +133,13 @@ job-test: &job-test
           fi
 
 jobs:
-  lint:
+  lint-d11:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
-    steps:
-      - checkout
-
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
+    environment:
+      DRUPAL_VERSION: 11
+    <<: *job-lint
 
   test-php-min-d11-stable:
     <<: *container_config
@@ -194,7 +199,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      - lint-d11:
           filters:
             tags:
               only: /.*/
@@ -216,7 +221,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - lint
+            - lint-d11
             - test-php-min-d11-stable
             - test-php-max-d11-stable
             - test-php-min-d11-legacy

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
@@ -18,6 +18,47 @@ aliases:
   - &selenium_image
     image: selenium/standalone-chromium:latest
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+
 job-test: &job-test
   steps:
     - checkout
@@ -92,49 +133,13 @@ job-test: &job-test
           fi
 
 jobs:
-  lint:
+  lint-d10:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
-    steps:
-      - checkout
-
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
+    environment:
+      DRUPAL_VERSION: 10
+    <<: *job-lint
 
   test-php-min-d10-stable:
     <<: *container_config
@@ -153,6 +158,14 @@ jobs:
     environment:
       DRUPAL_VERSION: 10
     <<: *job-test
+
+  lint-d11:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    environment:
+      DRUPAL_VERSION: 11
+    <<: *job-lint
 
   test-php-min-d11-stable:
     <<: *container_config
@@ -212,7 +225,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      - lint-d10:
           filters:
             tags:
               only: /.*/
@@ -221,6 +234,10 @@ workflows:
             tags:
               only: /.*/
       - test-php-max-d10-stable:
+          filters:
+            tags:
+              only: /.*/
+      - lint-d11:
           filters:
             tags:
               only: /.*/
@@ -242,9 +259,10 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - lint
+            - lint-d10
             - test-php-min-d10-stable
             - test-php-max-d10-stable
+            - lint-d11
             - test-php-min-d11-stable
             - test-php-max-d11-stable
             - test-php-min-d11-legacy

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
@@ -18,6 +18,47 @@ aliases:
   - &selenium_image
     image: selenium/standalone-chromium:latest
 
+job-lint: &job-lint
+  steps:
+    - checkout
+
+    - run:
+        name: Install Node.js dependencies
+        command: npm ci --ignore-scripts
+
+    - run:
+        name: Lint code with CSpell
+        command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
+
+    - run:
+        name: Assemble the codebase
+        command: .devtools/assemble
+
+    - run:
+        name: Lint code with PHPCS
+        command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with PHPStan
+        command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Rector
+        command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with Twig CS Fixer
+        command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
+        working_directory: build
+
+    - run:
+        name: Lint code with NodeJS linters
+        command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
+        working_directory: build
+
 job-test: &job-test
   steps:
     - checkout
@@ -92,49 +133,13 @@ job-test: &job-test
           fi
 
 jobs:
-  lint:
+  lint-d10:
     <<: *container_config
     docker:
       - image: cimg/php:__VERSION__
-    steps:
-      - checkout
-
-      - run:
-          name: Install Node.js dependencies
-          command: npm ci --ignore-scripts
-
-      - run:
-          name: Lint code with CSpell
-          command: npm run lint-spell || [ "${CI_CSPELL_IGNORE_FAILURE:-0}" -eq 1 ]
-
-      - run:
-          name: Assemble the codebase
-          command: .devtools/assemble
-
-      - run:
-          name: Lint code with PHPCS
-          command: vendor/bin/phpcs || [ "${CI_PHPCS_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with PHPStan
-          command: vendor/bin/phpstan || [ "${CI_PHPSTAN_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Rector
-          command: vendor/bin/rector --clear-cache --dry-run || [ "${CI_RECTOR_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with Twig CS Fixer
-          command: vendor/bin/twig-cs-fixer || [ "${CI_TWIGCSFIXER_IGNORE_FAILURE:-0}" -eq 1 ]
-          working_directory: build
-
-      - run:
-          name: Lint code with NodeJS linters
-          command: '[ ! -d node_modules ] || npm run lint || [ "${CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]'
-          working_directory: build
+    environment:
+      DRUPAL_VERSION: 10
+    <<: *job-lint
 
   test-php-min-d10-stable:
     <<: *container_config
@@ -153,6 +158,14 @@ jobs:
     environment:
       DRUPAL_VERSION: 10
     <<: *job-test
+
+  lint-d11:
+    <<: *container_config
+    docker:
+      - image: cimg/php:__VERSION__
+    environment:
+      DRUPAL_VERSION: 11
+    <<: *job-lint
 
   test-php-min-d11-stable:
     <<: *container_config
@@ -212,7 +225,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint:
+      - lint-d10:
           filters:
             tags:
               only: /.*/
@@ -221,6 +234,10 @@ workflows:
             tags:
               only: /.*/
       - test-php-max-d10-stable:
+          filters:
+            tags:
+              only: /.*/
+      - lint-d11:
           filters:
             tags:
               only: /.*/
@@ -242,9 +259,10 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - lint
+            - lint-d10
             - test-php-min-d10-stable
             - test-php-max-d10-stable
+            - lint-d11
             - test-php-min-d11-stable
             - test-php-max-d11-stable
             - test-php-min-d11-legacy

--- a/.scaffold/tests/fixtures/init/d10_only/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/d10_only/.github/workflows/test.yml
@@ -1,7 +1,19 @@
-@@ -101,23 +101,6 @@
+@@ -29,10 +29,6 @@
              php-version: 8.4
              drupal-version: 10
  
+-          - name: lint-d11
+-            php-version: 8.5
+-            drupal-version: 11
+-
+     name: ${{ matrix.name }}
+ 
+     env:
+@@ -118,23 +114,6 @@
+           - name: test-php-max-d10-stable
+             php-version: 8.4
+             drupal-version: 10
+-
 -          - name: test-php-min-d11-stable
 -            php-version: 8.3
 -            drupal-version: 11
@@ -18,7 +30,6 @@
 -            php-version: 8.5
 -            drupal-version: 11@beta
 -            stability: canary
--
+ 
      services:
        chrome:
-         image: selenium/standalone-chromium:latest@sha256:1d3d834a2ce93f26cc0d0ae3c61abd189755b32649f5c356c6c5cf9502aa397e

--- a/.scaffold/tests/fixtures/init/d11_only/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/d11_only/.github/workflows/test.yml
@@ -1,4 +1,15 @@
-@@ -93,14 +93,6 @@
+@@ -25,10 +25,6 @@
+ 
+       matrix:
+         include:
+-          - name: lint-d10
+-            php-version: 8.4
+-            drupal-version: 10
+-
+           - name: lint-d11
+             php-version: 8.5
+             drupal-version: 11
+@@ -111,14 +107,6 @@
  
        matrix:
          include:

--- a/.scaffold/tests/fixtures/init/no_cspell/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_cspell/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -35,9 +35,6 @@
+@@ -53,9 +53,6 @@
        - name: Install Node.js dependencies
          run: npm ci --ignore-scripts
  

--- a/.scaffold/tests/fixtures/init/no_functional_javascript/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_functional_javascript/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -118,11 +118,6 @@
+@@ -136,11 +136,6 @@
              drupal-version: 11@beta
              stability: canary
  
@@ -10,7 +10,7 @@
  
      name: ${{ matrix.name }}
  
-@@ -192,7 +187,6 @@
+@@ -210,7 +205,6 @@
          env:
            BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
            SIMPLETEST_DB: sqlite://tmp/db.sqlite

--- a/.scaffold/tests/fixtures/init/no_javascript_lint/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_javascript_lint/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -76,11 +76,6 @@
+@@ -94,11 +94,6 @@
          run: vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.CI_TWIGCSFIXER_IGNORE_FAILURE == '1' }}
  

--- a/.scaffold/tests/fixtures/init/no_jest/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_jest/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -179,11 +179,6 @@
+@@ -197,11 +197,6 @@
        - name: Provision site
          run: .devtools/provision
  

--- a/.scaffold/tests/fixtures/init/no_php_lint/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_php_lint/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -56,25 +56,9 @@
+@@ -74,25 +74,9 @@
          env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  

--- a/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -118,11 +118,6 @@
+@@ -136,11 +136,6 @@
              drupal-version: 11@beta
              stability: canary
  
@@ -10,7 +10,7 @@
  
      name: ${{ matrix.name }}
  
-@@ -185,37 +180,3 @@
+@@ -203,37 +198,3 @@
          run: npm test
          continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
  

--- a/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-@@ -35,9 +35,6 @@
+@@ -53,9 +53,6 @@
        - name: Install Node.js dependencies
          run: npm ci --ignore-scripts
  
@@ -8,7 +8,7 @@
  
        - name: Cache Composer dependencies
          uses: actions/cache@__HASH__ # __VERSION__
-@@ -56,31 +53,10 @@
+@@ -74,31 +71,10 @@
          env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  
@@ -40,7 +40,7 @@
  
    test:
      runs-on: ubuntu-24.04
-@@ -118,11 +94,6 @@
+@@ -136,11 +112,6 @@
              drupal-version: 11@beta
              stability: canary
  
@@ -52,7 +52,7 @@
  
      name: ${{ matrix.name }}
  
-@@ -179,43 +150,4 @@
+@@ -197,43 +168,4 @@
        - name: Provision site
          run: .devtools/provision
  

--- a/.scaffold/tests/src/Unit/PhpunitAttributesTest.php
+++ b/.scaffold/tests/src/Unit/PhpunitAttributesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that Drupal 10 static analysis tolerates the PHPUnit attributes.
+ *
+ * Rector writes `PHPUnit\Framework\Attributes\*` alongside the doc-comment
+ * metadata it converts, and those classes first exist in PHPUnit 10. Drupal 10
+ * resolves PHPUnit 9.6, so on a Drupal 10 build PHPStan reports each one as
+ * `attribute.notFound` while the tests themselves keep passing - PHP resolves
+ * attribute classes lazily, and PHPUnit 9.6 reads the doc-comment.
+ *
+ * `phpstan.neon` therefore ignores that message, and this test pins the two
+ * halves together: an attribute added to the shipped tests without a matching
+ * ignore pattern breaks the Drupal 10 lint, and the failure otherwise surfaces
+ * only after a full Drupal 10 assemble in CI.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class PhpunitAttributesTest extends UnitTestCase {
+
+  #[DataProvider('dataProviderShippedAttributesAreIgnored')]
+  public function testShippedAttributesAreIgnored(string $path): void {
+    $contents = file_get_contents($path);
+    $this->assertIsString($contents);
+
+    preg_match_all('/PHPUnit\\\\Framework\\\\Attributes\\\\(\w+)/', $contents, $matches);
+
+    $patterns = self::ignorePatterns();
+    $uncovered = [];
+
+    foreach (array_unique($matches[1]) as $name) {
+      // The message is the one PHPStan emits verbatim, so a pattern that stops
+      // matching it is caught here rather than on the next Drupal 10 build.
+      $message = sprintf('Attribute class PHPUnit\Framework\Attributes\%s does not exist.', $name);
+
+      foreach ($patterns as $pattern) {
+        if (preg_match($pattern, $message) === 1) {
+          continue 2;
+        }
+      }
+
+      $uncovered[] = $name;
+    }
+
+    $this->assertSame([], $uncovered, sprintf('%s uses PHPUnit attributes that no phpstan.neon ignoreErrors pattern matches: %s.', basename($path), implode(', ', $uncovered)));
+  }
+
+  public static function dataProviderShippedAttributesAreIgnored(): \Iterator {
+    $directory = self::rootDir() . '/tests/src';
+
+    $paths = [];
+    $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS));
+
+    foreach ($iterator as $file) {
+      if ($file instanceof \SplFileInfo && $file->getExtension() === 'php') {
+        $paths[] = $file->getPathname();
+      }
+    }
+
+    self::assertNotSame([], $paths, 'No test files found in tests/src.');
+
+    sort($paths);
+
+    foreach ($paths as $path) {
+      yield basename($path) => ['path' => $path];
+    }
+  }
+
+  /**
+   * Get the message patterns PHPStan is configured to ignore.
+   *
+   * @return array<int, string>
+   *   The patterns, in declaration order.
+   */
+  protected static function ignorePatterns(): array {
+    // NEON is a superset of the YAML this file stays within, and the parser
+    // preserves the backslash escaping the patterns rely on.
+    $parsed = Yaml::parseFile(self::rootDir() . '/phpstan.neon');
+
+    $parameters = is_array($parsed) ? $parsed['parameters'] ?? NULL : NULL;
+    $entries = is_array($parameters) ? $parameters['ignoreErrors'] ?? NULL : NULL;
+
+    if (!is_array($entries)) {
+      self::fail('phpstan.neon declares no ignoreErrors list.');
+    }
+
+    $patterns = [];
+
+    // An entry is either a bare pattern or a mapping whose `messages` key
+    // holds several.
+    foreach ($entries as $entry) {
+      $messages = is_array($entry) ? $entry['messages'] ?? NULL : $entry;
+
+      foreach (is_array($messages) ? $messages : [$messages] as $message) {
+        if (is_string($message)) {
+          $patterns[] = $message;
+        }
+      }
+    }
+
+    return $patterns;
+  }
+
+  /**
+   * Get the project root directory.
+   *
+   * @return string
+   *   The absolute path to the project root.
+   */
+  protected static function rootDir(): string {
+    return dirname(__DIR__, 4);
+  }
+
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,5 +38,12 @@ parameters:
         - '#.* no value type specified in iterable type array#'
         - '#.* has no return type specified#'
       reportUnmatched: false
+    -
+      # PHP resolves attribute classes lazily and PHPUnit 9.6 reads doc-comment
+      # metadata, so these are inert rather than broken on a Drupal 10 build.
+      # Rector writes them from the Drupal 11 set.
+      messages:
+        - '#^Attribute class PHPUnit\\Framework\\Attributes\\.+ does not exist\.$#'
+      reportUnmatched: false
 
   reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Closes #499

## Summary

A Drupal 10 build fails `make lint` with 9 PHPStan `attribute.notFound` errors on the shipped PHPUnit tests, because `PHPUnit\Framework\Attributes\Group`, `DataProvider`, and `RunTestsInSeparateProcesses` first exist in PHPUnit 10, and Drupal 10.6 (the final Drupal 10 minor) resolves `phpunit/phpunit ^9.6.34` via `core-dev` with no path to a newer PHPUnit. The attributes were written into the shipped tests by Rector's Drupal 11 set during a routine dependency-update commit, and CI never noticed because the `lint` job did not set `DRUPAL_VERSION` and so only ever assembled and linted Drupal 11. This PR fixes the false positive in static analysis, adds a regression test that pins the fix to the shipped test suite, and splits `lint` into a per-Drupal-major CI matrix so this class of divergence cannot go unnoticed again.

## Breaking change for consumers

**The GitHub Actions check name changes from `lint` to `lint-d10` / `lint-d11`.** Anyone using `lint` as a required status check in branch protection must update it to the new job name(s), or the branch protection rule will wait forever on a check that no longer runs.

## Changes

**Static analysis fix (`phpstan.neon`)** - One `ignoreErrors` entry anchored to the exact PHPStan message and scoped to `PHPUnit\Framework\Attributes\*`, so an unrelated misspelled attribute class is still reported. The attributes are kept rather than removed: PHP resolves attribute classes lazily and PHPUnit 9.6 reads the doc-comment metadata that sits alongside them, so they are inert, not broken, on Drupal 10 - upstream `palantirnet/drupal-rector` documents this as intentional. Removing the attributes instead was measured and rejected: it makes PHPUnit 11 fall back to the doc-comments, which emits 2 `Metadata found in doc-comment ... deprecated ... will no longer be supported in PHPUnit 12` deprecations on every Drupal 11 test run, and it ships metadata PHPUnit 12 removes outright. Keeping both forms means PHPUnit 11 reads the attribute and stays silent, so the fix belongs in static analysis, not in the test code. `phpstan.neon` already sets `reportUnmatchedIgnoredErrors: false`, so on Drupal 11 - where the classes exist - the pattern matches nothing and costs nothing. The same entry is mirrored into `.scaffold/tests/fixtures/init/_baseline/phpstan.neon` so the init snapshot fixtures stay consistent with the shipped file.

**Regression guard (`.scaffold/tests/src/Unit/PhpunitAttributesTest.php`)** - New `p0` test that scans the shipped extension tests for PHPUnit attributes, reconstructs the exact message PHPStan emits for each, and asserts some `phpstan.neon` pattern matches it. It catches both a newly-added uncovered attribute and a pattern that stops matching, and it fails when the ignore entry above is removed.

**CI matrix (`.github/workflows/test.yml`, `.circleci/config.yml`)** - `lint` becomes a per-Drupal-major matrix: `lint-d10` on PHP 8.4 and `lint-d11` on PHP 8.5, wrapped in the same `#;< DRUPAL_10` / `#;< DRUPAL_11` markers as the existing `test` matrix so `init.php` prunes deselected majors correctly. Drupal 10 uses PHP 8.4 because PHP 8.5 requires Drupal 11.3+, mirroring the existing `test-php-max-d10-stable` leg. CircleCI has no native matrix, so the lint steps move into a `&job-lint` YAML anchor and become two named jobs, mirroring the existing `&job-test`; the workflow job list and the `deploy` job's `requires` list are updated to match. The `.scaffold/tests/fixtures/init/*` snapshots are regenerated to match the new matrix shape.

## Verification

| Check | Result |
|---|---|
| Drupal 10 `make lint`, base branch | 9 errors - bug reproduced |
| Drupal 10 `make lint`, fixed | No errors across all 6 tools |
| Drupal 11 `make lint`, fixed | No errors |
| Drupal 10 `make test-unit` / `test-kernel` | 4 tests / 1 test, PHPUnit 9.6.36 |
| Drupal 11 `make test-unit` / `test-kernel` | 4 tests / 1 test, PHPUnit 11.5.56, 0 deprecations |
| New test with the ignore entry removed | Fails, naming the uncovered attributes |
| `--group=p0` | 448 tests, 2626 assertions |
| `--filter=InitTest` | 23 datasets |

## Before / After

BEFORE - single Drupal-11-only lint job, so Drupal 10 is never linted in CI:

```
    ┌───────────────────────────────────────┐
    │ lint  (PHP 8.5, DRUPAL_VERSION unset)  │
    │   .devtools/assemble -> Drupal 11 only │
    │   vendor/bin/phpstan -> Drupal 10 code │
    │                          never checked │
    └───────────────────────────────────────┘
                      │
                      ▼
    deploy requires: [lint, test-*-d10-*, test-*-d11-*]

    Drupal 10 `make lint` (reproduced against this branch's base):
      9x Attribute class PHPUnit\Framework\Attributes\* does not exist.
```

AFTER - per-Drupal-major lint matrix, each major linted against its own PHPUnit:

```
    ┌───────────────────────────┐   ┌───────────────────────────┐
    │ lint-d10 (PHP 8.4)        │   │ lint-d11 (PHP 8.5)        │
    │   DRUPAL_VERSION: 10      │   │   DRUPAL_VERSION: 11      │
    │   assemble -> phpunit ^9.6│   │   assemble -> phpunit ^11 │
    │   phpstan  -> 0 errors    │   │   phpstan  -> 0 errors    │
    └───────────────────────────┘   └───────────────────────────┘
                 │                                │
                 ▼                                ▼
    deploy requires: [lint-d10, lint-d11, test-*-d10-*, test-*-d11-*]

    Drupal 10 `make lint` (this branch, fixed):
      0 errors across all 6 tools (PHPUnit\Framework\Attributes\* ignored)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add a scoped PHPStan suppression for missing `PHPUnit\Framework\Attributes\*` classes generated by Rector’s Drupal 11 set.
- Add a regression test that verifies PHPUnit attributes in shipped tests match PHPStan ignore patterns.
- Split linting into Drupal 10 and Drupal 11 jobs with version-specific PHP versions and dependencies.
- Update CircleCI, GitHub Actions, and init snapshots.
- Drupal 10 linting now passes, while Drupal 11 remains clean.

> GitHub Actions check names changed from `lint` to `lint-d10` and `lint-d11`. Update branch protection rules that require the former `lint` check.

## Possibly related

- No matching repository issue was identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->