### PR TITLE
[#504] Migrated the deprecated 'version-resolver.default' field to a resolver category.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,8 +2,11 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  default: minor
+# A resolver with no `when` condition matches every change, so this is the
+# increment applied to a release that no other category resolves.
+categories:
+  - type: 'version-resolver'
+    semver-increment: 'minor'
 template: |
   ## What's new since $PREVIOUS_TAG
 

--- a/.scaffold/tests/fixtures/init/_baseline/.github/release-drafter.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/release-drafter.yml
@@ -2,8 +2,11 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  default: minor
+# A resolver with no `when` condition matches every change, so this is the
+# increment applied to a release that no other category resolves.
+categories:
+  - type: 'version-resolver'
+    semver-increment: 'minor'
 template: |
   ## What's new since $PREVIOUS_TAG
 

--- a/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
+++ b/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests the version increment the release drafter configuration resolves.
+ *
+ * Release Drafter resolves the increment through `categories` and warns that
+ * the top-level `version-resolver` block is deprecated. Once that block is
+ * removed upstream, a configuration still relying on it silently falls back to
+ * the built-in `patch` increment and the next draft is named after the wrong
+ * release.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class ReleaseDrafterConfigTest extends UnitTestCase {
+
+  public function testDeprecatedVersionResolverIsAbsent(): void {
+    $this->assertArrayNotHasKey('version-resolver', self::config(), 'The `version-resolver` block is deprecated: version resolution belongs in `categories`.');
+  }
+
+  public function testResolvedIncrementIsMinor(): void {
+    $categories = self::config()['categories'] ?? NULL;
+
+    if (!is_array($categories)) {
+      self::fail('The release drafter configuration declares no `categories`.');
+    }
+
+    $increments = [];
+
+    foreach ($categories as $category) {
+      // A category with no `when` condition matches every change, so it holds
+      // the increment that applies when no other category does. Release
+      // Drafter assumes `patch` for a category that names no increment.
+      if (!is_array($category) || array_key_exists('when', $category) || ($category['type'] ?? NULL) !== 'version-resolver') {
+        continue;
+      }
+
+      $increments[] = $category['semver-increment'] ?? 'patch';
+    }
+
+    $this->assertSame(['minor'], $increments, 'Exactly one `version-resolver` category with no `when` condition must resolve the "minor" increment.');
+  }
+
+  /**
+   * Read the release drafter configuration.
+   *
+   * @return array<mixed, mixed>
+   *   The parsed configuration.
+   */
+  protected static function config(): array {
+    $path = dirname(__DIR__, 4) . '/.github/release-drafter.yml';
+    $contents = file_get_contents($path);
+
+    if ($contents === FALSE) {
+      self::fail(sprintf('Unable to read %s.', $path));
+    }
+
+    $parsed = Yaml::parse($contents);
+
+    if (!is_array($parsed)) {
+      self::fail(sprintf('%s does not parse to a mapping.', basename($path)));
+    }
+
+    return $parsed;
+  }
+
+}

--- a/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
+++ b/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
@@ -39,10 +39,15 @@ final class ReleaseDrafterConfigTest extends UnitTestCase {
       // A category with no `when` condition matches every change, so it holds
       // the increment that applies when no other category does. Release
       // Drafter assumes `patch` for a category that names no increment.
-      if (!is_array($category) || array_key_exists('when', $category) || ($category['type'] ?? NULL) !== 'version-resolver') {
+      if (!is_array($category)) {
         continue;
       }
-
+      if (array_key_exists('when', $category)) {
+        continue;
+      }
+      if (($category['type'] ?? NULL) !== 'version-resolver') {
+        continue;
+      }
       $increments[] = $category['semver-increment'] ?? 'patch';
     }
 

--- a/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
+++ b/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
@@ -36,18 +36,22 @@ final class ReleaseDrafterConfigTest extends UnitTestCase {
     $increments = [];
 
     foreach ($categories as $category) {
-      // A category with no `when` condition matches every change, so it holds
-      // the increment that applies when no other category does. Release
-      // Drafter assumes `patch` for a category that names no increment.
       if (!is_array($category)) {
         continue;
       }
-      if (array_key_exists('when', $category)) {
-        continue;
-      }
+
       if (($category['type'] ?? NULL) !== 'version-resolver') {
         continue;
       }
+
+      // A category with no `when` condition matches every change, so it holds
+      // the increment that applies when no other category does.
+      if (array_key_exists('when', $category)) {
+        continue;
+      }
+
+      // Release Drafter assumes `patch` for a category that names no
+      // increment.
       $increments[] = $category['semver-increment'] ?? 'patch';
     }
 

--- a/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
+++ b/.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php
@@ -44,9 +44,11 @@ final class ReleaseDrafterConfigTest extends UnitTestCase {
         continue;
       }
 
-      // A category with no `when` condition matches every change, so it holds
-      // the increment that applies when no other category does.
-      if (array_key_exists('when', $category)) {
+      // A category that carries no condition matches every change, so it holds
+      // the increment that applies when no other category does. An empty
+      // `when` list expresses the same thing: Release Drafter matches every
+      // change once the parsed condition list is empty.
+      if (($category['when'] ?? []) !== []) {
         continue;
       }
 


### PR DESCRIPTION
Closes #504

## Summary

`release-drafter/release-drafter` v7.7.0 (pinned by SHA in `.github/workflows/draft-release-notes.yml`) emits a deprecation warning on every run of the `Draft release notes` workflow, because `.github/release-drafter.yml` resolved the version bump through the deprecated top-level `version-resolver` block. Release Drafter v7 folded version resolution into `categories`, where a category of `type: version-resolver` with no `when` condition is the replacement for the old `default`, and `semver-increment` names the bump. Once the deprecated field is removed upstream, the increment would silently fall back to Release Drafter's built-in `patch` default, so the next draft would be named `4.18.1` instead of `4.19.0` - and the mistake would be easy to miss, since drafts are created without human involvement.

## Changes

- `.github/release-drafter.yml`: replaced `version-resolver: {default: minor}` with a `categories` entry of `type: 'version-resolver'` and `semver-increment: 'minor'`. A `version-resolver` category was chosen over the `type: changelog` alternative the deprecation warning also offers, because a changelog category requires a `title` that `category-template` renders, which would introduce a heading into the published notes. A `version-resolver` category contributes to `$RESOLVED_VERSION` without rendering a section, so the notes stay byte-identical - no changelog categories are defined, so every pull request stays uncategorized and `$CHANGES` keeps producing the same flat list.
- `.scaffold/tests/src/Unit/ReleaseDrafterConfigTest.php`: new `p0` unit test, written first and confirmed failing against the deprecated configuration before the fix landed. It asserts the deprecated `version-resolver` key is absent, and that exactly one unconditional `version-resolver` category resolves the `minor` increment, so the configuration cannot silently degrade to Release Drafter's `patch` default. A category counts as unconditional when it carries no `when` key or an empty `when` list, matching how Release Drafter itself evaluates conditions: `parse-categories.ts` leaves `when: []` as an empty condition list, and `matchesCategory` returns `true` as soon as that list is empty.
- `.scaffold/tests/fixtures/init/_baseline/.github/release-drafter.yml`: init snapshot fixture, regenerated with `composer update-snapshots` to match the source file. The file ships with the scaffold, so every extension generated from this template inherits the fix.

## Before / After

```
BEFORE: deprecated top-level resolver
──────────────────────────────────────────────────────
 .github/release-drafter.yml
 ┌──────────────────────────────────────────┐
 │ version-resolver:                        │
 │   default: minor                         │
 └──────────────────────────────────────────┘
                    │
                    ▼
 release-drafter v7.7.0 run
                    │
                    ├─ logs: "deprecated 'version-resolver.default'
                    │         field detected... will be removed"
                    ▼
 $RESOLVED_VERSION = minor bump     (until upstream removes the
                                     field, then silently falls
                                     back to a patch bump)


AFTER: resolver folded into categories
──────────────────────────────────────────────────────
 .github/release-drafter.yml
 ┌──────────────────────────────────────────┐
 │ categories:                              │
 │   - type: 'version-resolver'             │
 │     semver-increment: 'minor'            │
 └──────────────────────────────────────────┘
                    │
                    ▼
 release-drafter v7.7.0 run
                    │
                    ├─ no deprecation warning logged
                    ▼
 $RESOLVED_VERSION = minor bump     ✓ stable regardless of
                                     upstream field removal
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaces deprecated `version-resolver.default` with an unconditional `version-resolver` category.
- Preserves minor version increments and flat release-note output.
- Adds unit tests for the configuration.
- Updates the scaffold baseline fixture.

## Possibly related

- Possibly related to `#504`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
