### PR TITLE
[#509] Deployed the commit that CI tested instead of the default branch.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,13 @@ permissions:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # The checkout below names the commit that triggered the run. Only a push
+    # to this repository carries a commit meant for deployment; a pull
+    # request, fork or not, does not.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-24.04
 
     permissions:
@@ -28,6 +34,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # `workflow_run` resolves refs against the default branch, so the
+          # tested commit is named explicitly.
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml
@@ -12,7 +12,13 @@ permissions:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # The checkout below names the commit that triggered the run. Only a push
+    # to this repository carries a commit meant for deployment; a pull
+    # request, fork or not, does not.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-24.04
 
     permissions:
@@ -28,6 +34,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@__HASH__ # __VERSION__
         with:
+          # `workflow_run` resolves refs against the default branch, so the
+          # tested commit is named explicitly.
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.scaffold/tests/src/Traits/DeployWorkflowTrait.php
+++ b/.scaffold/tests/src/Traits/DeployWorkflowTrait.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Traits;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Reads the deploy workflow so that tests can assert on its definition.
+ */
+trait DeployWorkflowTrait {
+
+  /**
+   * Path of the deploy workflow.
+   *
+   * @return string
+   *   The absolute path.
+   */
+  protected static function deployWorkflowPath(): string {
+    return dirname(__DIR__, 4) . '/.github/workflows/deploy.yml';
+  }
+
+  /**
+   * Read the deploy job out of the workflow.
+   *
+   * @return array<mixed, mixed>
+   *   The job definition.
+   */
+  protected static function deployJob(): array {
+    $path = self::deployWorkflowPath();
+    $contents = file_get_contents($path);
+
+    if ($contents === FALSE) {
+      self::fail(sprintf('Unable to read %s.', $path));
+    }
+
+    $job = self::child(self::child(Yaml::parse($contents), 'jobs'), 'deploy');
+
+    if (!is_array($job)) {
+      self::fail(sprintf('%s has no "deploy" job.', basename($path)));
+    }
+
+    return $job;
+  }
+
+  /**
+   * Read the steps of the deploy job.
+   *
+   * @return array<mixed, mixed>
+   *   The step definitions.
+   */
+  protected static function deploySteps(): array {
+    $steps = self::child(self::deployJob(), 'steps');
+
+    if (!is_array($steps)) {
+      self::fail(sprintf('The deploy job of %s declares no steps.', basename(self::deployWorkflowPath())));
+    }
+
+    return $steps;
+  }
+
+  /**
+   * Read a named step of the deploy job.
+   *
+   * @param string $name
+   *   Name of the step.
+   *
+   * @return array<mixed, mixed>
+   *   The step definition.
+   */
+  protected static function deployStep(string $name): array {
+    foreach (self::deploySteps() as $step) {
+      if (!is_array($step)) {
+        continue;
+      }
+
+      if (self::child($step, 'name') !== $name) {
+        continue;
+      }
+
+      return $step;
+    }
+
+    self::fail(sprintf('%s has no "%s" step.', basename(self::deployWorkflowPath()), $name));
+  }
+
+  /**
+   * Read a child of a parsed workflow node.
+   *
+   * @param mixed $node
+   *   Node to read from.
+   * @param string $key
+   *   Key of the child.
+   *
+   * @return mixed
+   *   The child, or NULL when the node does not hold it.
+   */
+  protected static function child(mixed $node, string $key): mixed {
+    return is_array($node) && array_key_exists($key, $node) ? $node[$key] : NULL;
+  }
+
+}

--- a/.scaffold/tests/src/Unit/DeployWorkflowBranchTest.php
+++ b/.scaffold/tests/src/Unit/DeployWorkflowBranchTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Traits\DeployWorkflowTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Tests the branch the deploy workflow hands to the deploy script.
@@ -26,6 +26,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 #[Group('p0')]
 final class DeployWorkflowBranchTest extends UnitTestCase {
+
+  use DeployWorkflowTrait;
 
   protected const string STEP = 'Deploy to Remote';
 
@@ -231,38 +233,13 @@ final class DeployWorkflowBranchTest extends UnitTestCase {
    *   The step's `run` script.
    */
   protected static function stepScript(): string {
-    $path = dirname(__DIR__, 4) . '/.github/workflows/deploy.yml';
-    $contents = file_get_contents($path);
+    $script = self::child(self::deployStep(self::STEP), 'run');
 
-    if ($contents === FALSE) {
-      self::fail(sprintf('Unable to read %s.', $path));
+    if (!is_string($script)) {
+      self::fail(sprintf('The "%s" step of %s runs no script.', self::STEP, basename(self::deployWorkflowPath())));
     }
 
-    $steps = self::child(self::child(self::child(Yaml::parse($contents), 'jobs'), 'deploy'), 'steps');
-
-    if (!is_array($steps)) {
-      self::fail(sprintf('The deploy job of %s declares no steps.', basename($path)));
-    }
-
-    foreach ($steps as $step) {
-      if (self::child($step, 'name') !== self::STEP) {
-        continue;
-      }
-
-      $script = self::child($step, 'run');
-
-      if (!is_string($script)) {
-        self::fail(sprintf('The "%s" step of %s runs no script.', self::STEP, basename($path)));
-      }
-
-      return $script;
-    }
-
-    self::fail(sprintf('%s has no "%s" step.', basename($path), self::STEP));
-  }
-
-  protected static function child(mixed $node, string $key): mixed {
-    return is_array($node) && array_key_exists($key, $node) ? $node[$key] : NULL;
+    return $script;
   }
 
 }

--- a/.scaffold/tests/src/Unit/DeployWorkflowCheckoutTest.php
+++ b/.scaffold/tests/src/Unit/DeployWorkflowCheckoutTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Traits\DeployWorkflowTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the commit the deploy workflow publishes.
+ *
+ * A `workflow_run` event resolves refs against the default branch, so a
+ * checkout that names no ref holds default-branch code while the deploy
+ * script pushes it under the triggering branch's name. Naming the tested
+ * commit is only safe while the job is gated on a push from this repository,
+ * because the deployment key is in scope for whatever was checked out.
+ *
+ * Neither half can be executed locally, so both are read out of the workflow.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class DeployWorkflowCheckoutTest extends UnitTestCase {
+
+  use DeployWorkflowTrait;
+
+  protected const string STEP = 'Checkout code';
+
+  protected const string CHECKOUT_ACTION = 'actions/checkout@';
+
+  public function testCheckoutNamesTheTestedCommit(): void {
+    $ref = self::child(self::child(self::deployStep(self::STEP), 'with'), 'ref');
+
+    $this->assertSame('${{ github.event.workflow_run.head_sha }}', $ref, sprintf('The "%s" step must check out the commit that triggered the run, otherwise the deployment publishes default-branch code.', self::STEP));
+  }
+
+  public function testEveryCheckoutNamesItsRef(): void {
+    $unnamed = [];
+
+    foreach (self::deploySteps() as $step) {
+      $uses = self::child($step, 'uses');
+
+      if (!is_string($uses)) {
+        continue;
+      }
+
+      if (!str_starts_with($uses, self::CHECKOUT_ACTION)) {
+        continue;
+      }
+
+      if (!is_string(self::child(self::child($step, 'with'), 'ref'))) {
+        $name = self::child($step, 'name');
+        $unnamed[] = is_string($name) ? $name : $uses;
+      }
+    }
+
+    $this->assertSame([], $unnamed, sprintf('The deploy job checks out without naming a ref in: %s', implode(', ', $unnamed)));
+  }
+
+  #[DataProvider('dataProviderJobIsGated')]
+  public function testJobIsGated(string $condition, string $message): void {
+    $this->assertStringContainsString($condition, self::deployCondition(), $message);
+  }
+
+  public static function dataProviderJobIsGated(): \Iterator {
+    yield 'successful run' => [
+      'condition' => "github.event.workflow_run.conclusion == 'success'",
+      'message' => 'A failed test run must not be deployed.',
+    ];
+
+    yield 'push event' => [
+      'condition' => "github.event.workflow_run.event == 'push'",
+      'message' => 'A pull request must not be deployed, otherwise unmerged code reaches the remote branch.',
+    ];
+
+    yield 'own repository' => [
+      'condition' => 'github.event.workflow_run.head_repository.full_name == github.repository',
+      'message' => 'A run originating from a fork must not be deployed, otherwise fork-controlled code reaches the deployment key.',
+    ];
+  }
+
+  public function testConditionHasNoDisjunction(): void {
+    $this->assertStringNotContainsString('||', self::deployCondition(), 'Every gate of the deploy condition must hold on its own, so the condition cannot contain a disjunction.');
+  }
+
+  /**
+   * Read the condition guarding the deploy job.
+   *
+   * @return string
+   *   The condition, with its folded whitespace collapsed.
+   */
+  protected static function deployCondition(): string {
+    $condition = self::child(self::deployJob(), 'if');
+
+    if (!is_string($condition)) {
+      self::fail(sprintf('The deploy job of %s declares no condition.', basename(self::deployWorkflowPath())));
+    }
+
+    return trim((string) preg_replace('/\s+/', ' ', $condition));
+  }
+
+}

--- a/.scaffold/tests/zizmor.yml
+++ b/.scaffold/tests/zizmor.yml
@@ -12,8 +12,10 @@ rules:
     # These triggers are required and do not execute attacker-supplied code:
     # - assign-author: assigns the PR author via 'toshimaru/auto-author-assign';
     #   needs a write token on fork PRs and never checks out PR code.
-    # - deploy: a chained run after the 'Test' workflow completes; it deploys
-    #   the already-tested branch over an SSH key and never checks out PR code.
+    # - deploy: a chained run after the 'Test' workflow completes; it checks
+    #   out the commit that run tested and deploys it over an SSH key. The job
+    #   is gated on a push from this repository, so fork-controlled code never
+    #   reaches the deployment key.
     ignore:
       - assign-author.yml
       - deploy.yml

--- a/README.md
+++ b/README.md
@@ -446,6 +446,10 @@ The `deploy` job runs when commits are pushed to main branches
 that out-of-the-box, the deployment job will not run for other branches or
 pull requests, but you can adjust the CI configuration to suit your needs.
 
+The code pushed to the destination repository is the commit that CI tested,
+so a release tag deploys the tagged commit rather than the tip of the branch
+it was cut from.
+
 See these examples of the deployment destination repository:
 [GitHub Actions](https://github.com/AlexSkrypnyk/drupal_extension_scaffold_destination_github) and
 [CircleCI](https://github.com/AlexSkrypnyk/drupal_extension_scaffold_destination_circleci)


### PR DESCRIPTION
Closes #509

## Summary

The deploy workflow triggers on `workflow_run` and checked out code without pinning a ref, so `GITHUB_SHA` resolved to the tip of the default branch instead of the commit the triggering `Test` run actually tested. `.devtools/deploy` then force-pushed that default-branch tree to a destination branch named after `github.event.workflow_run.head_branch`, so the branch's name and its content disagreed for every run that was not on the default branch. This pins the checkout to the tested commit and tightens the job's `if:` condition so only same-repository push events reach the deploy job.

Both halves have to land together. `test.yml` also triggers on `pull_request`, and with the documented `vars.DEPLOY_BRANCH` set, pinning the ref on its own would make every same-repository pull request force-push unmerged code over the pinned Drupal.org release branch. Gating first keeps the deployment key out of reach of any tree this repository did not produce.

## Changes

- Added `github.event.workflow_run.event == 'push'` and `github.event.workflow_run.head_repository.full_name == github.repository` to the deploy job's `if:` condition in `.github/workflows/deploy.yml`, alongside the existing `conclusion == 'success'` check.
- Pinned the checkout step to `ref: ${{ github.event.workflow_run.head_sha }}` so the workspace holds the commit the `Test` workflow ran against.
- Applied the same two changes to the baseline fixture at `.scaffold/tests/fixtures/init/_baseline/.github/workflows/deploy.yml` by regenerating the snapshot baseline.
- Extracted `DeployWorkflowTrait` (`.scaffold/tests/src/Traits/DeployWorkflowTrait.php`) so `DeployWorkflowBranchTest` and the new `DeployWorkflowCheckoutTest` share one reader for the workflow YAML.
- Added `DeployWorkflowCheckoutTest` (group `p0`) asserting that the checkout step pins the tested commit's ref, that no checkout step in the job is left without a ref, that each gate of the `if:` condition is present, and that the condition contains no `||` disjunction.
- Reworded the Zizmor `dangerous-triggers` justification for `deploy.yml` in `.scaffold/tests/zizmor.yml` so it states that the job checks out the commit its `Test` run tested and is gated on a push from this repository.
- Added a README sentence noting that the deployed code is the commit CI tested, so a release tag deploys the tagged commit rather than the tip of the branch it was cut from.

The tag guard in the `Deploy to Remote` step is unchanged. It already reads the explicit `HEAD_SHA`, and `fetch-depth: 0` fetches all branches and tags either way, so pinning the checkout only means it now evaluates against a clone positioned at the triggering commit.

`allow-unsafe-pr-checkout` is deliberately not enabled. `.devtools/deploy` and `.circleci/config.yml` are deliberately unchanged, since CircleCI's `checkout` natively resolves the pipeline commit and never had this bug.

## Before / After

```
BEFORE

  Test run completes (any branch, any pull request, any fork)
       |
       v
  deploy job     if: conclusion == 'success'
       |
       v
  checkout       no ref:  -->  HEAD = tip of the default branch
       |
       v
  .devtools/deploy    git push --force HEAD:<head_branch>
       |
       v
  destination branch "feature/x"
       name    = feature/x           (from the triggering run)
       content = default branch tip  (from the checkout)
       MISMATCH: the name and the content describe different commits


AFTER

  Test run completes
       |
       +-->  pull_request run, or head_repository != this repository
       |          |
       |          v
       |     job skipped, deployment key never in scope
       |
       v  push, same repository
  deploy job     if: conclusion == 'success'
                     && event == 'push'
                     && head_repository.full_name == github.repository
       |
       v
  checkout       ref: head_sha  -->  HEAD = the tested commit
       |
       v
  .devtools/deploy    git push --force HEAD:<head_branch>
       |
       v
  destination branch "feature/x"
       name    = feature/x      (from the triggering run)
       content = tested commit  (from the checkout)
       MATCH: the name and the content describe the same commit
```
