### PR TITLE
[#510] Made the 'qrcode' command render on invocation and report a missing 'qrencode'.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -54,7 +54,7 @@ commands:
     cmd: |
       url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
       printf '%s\n' "$url"
-      ./.devtools/qrcode --if-enabled "$url"
+      if [ -n "$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$url"; fi
 
   lint:
     usage: Check coding standards for violations.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -54,7 +54,7 @@ commands:
     cmd: |
       url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
       printf '%s\n' "$url"
-      ./.devtools/qrcode "$url"
+      ./.devtools/qrcode --if-enabled "$url"
 
   lint:
     usage: Check coding standards for violations.

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -649,24 +649,29 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
 /**
  * Render a URL as a scannable QR code in the terminal.
  *
- * Opt-in: draws nothing unless the QRCODE variable - read from the shell
- * environment or '.env' - is set to a truthy value ('1', 'true', 'yes',
- * 'on'). When enabled it uses `qrencode -t ANSIUTF8` to draw the code with
- * Unicode block glyphs, and is still a no-op when the URL is empty or the
- * `qrencode` binary is not installed, so callers may invoke it
- * unconditionally.
+ * Opt-in by default: draws nothing unless the QRCODE variable - read from
+ * the shell environment or '.env' - is set to a truthy value ('1', 'true',
+ * 'yes', 'on'), or $force skips that check. When it draws, it uses
+ * `qrencode -t ANSIUTF8` to render the code with Unicode block glyphs, and
+ * is still a no-op when the URL is empty or the `qrencode` binary is not
+ * installed, so callers may invoke it unconditionally.
  *
  * @param string $url
  *   The URL to encode. An empty string renders nothing.
+ * @param bool $force
+ *   Skip the QRCODE opt-in check, for callers whose invocation already
+ *   expresses the intent to draw a code.
  */
-function print_qrcode(string $url): void {
+function print_qrcode(string $url, bool $force = FALSE): void {
   if ($url === '') {
     return;
   }
 
-  $enabled = resolve_env_value('QRCODE', '')['value'];
-  if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
-    return;
+  if (!$force) {
+    $enabled = resolve_env_value('QRCODE', '')['value'];
+    if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
+      return;
+    }
   }
 
   if (!command_path('qrencode')) {

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -650,9 +650,8 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
  * Render a URL as a scannable QR code in the terminal.
  *
  * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
- * A missing `qrencode` binary is a failure rather than a silent no-op:
- * whether to draw a code at all is decided before this point, so there is
- * no case here where drawing nothing is the intended outcome.
+ * A missing `qrencode` binary fails rather than returning quietly, so a
+ * requested code never goes undrawn without explanation.
  *
  * @param string $url
  *   The URL to encode. An empty string renders nothing, so an optional URL

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -649,33 +649,22 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
 /**
  * Render a URL as a scannable QR code in the terminal.
  *
- * Opt-in by default: draws nothing unless the QRCODE variable - read from
- * the shell environment or '.env' - is set to a truthy value ('1', 'true',
- * 'yes', 'on'), or $force skips that check. When it draws, it uses
- * `qrencode -t ANSIUTF8` to render the code with Unicode block glyphs, and
- * is still a no-op when the URL is empty or the `qrencode` binary is not
- * installed, so callers may invoke it unconditionally.
+ * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
+ * A missing `qrencode` binary is a failure rather than a silent no-op:
+ * whether to draw a code at all is decided before this point, so there is
+ * no case here where drawing nothing is the intended outcome.
  *
  * @param string $url
- *   The URL to encode. An empty string renders nothing.
- * @param bool $force
- *   Skip the QRCODE opt-in check, for callers whose invocation already
- *   expresses the intent to draw a code.
+ *   The URL to encode. An empty string renders nothing, so an optional URL
+ *   can be passed through without guarding first.
  */
-function print_qrcode(string $url, bool $force = FALSE): void {
+function print_qrcode(string $url): void {
   if ($url === '') {
     return;
   }
 
-  if (!$force) {
-    $enabled = resolve_env_value('QRCODE', '')['value'];
-    if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
-      return;
-    }
-  }
-
   if (!command_path('qrencode')) {
-    return;
+    FAIL("Command 'qrencode' is not available. Install it from https://fukuchi.org/works/qrencode/ to render QR codes");
   }
 
   passthru(sprintf('qrencode -t ANSIUTF8 %s', escapeshellarg($url)));

--- a/.devtools/qrcode
+++ b/.devtools/qrcode
@@ -5,9 +5,20 @@
  * @file
  * Render a URL as a scannable QR code in the terminal.
  *
- * Reads the URL from the first CLI argument and prints a QR code using
- * `qrencode`. A no-op when no URL is given or `qrencode` is not installed,
- * so callers can pipe an optional URL through without guarding first.
+ * Reads the URL from the first non-flag CLI argument and prints a QR code
+ * using `qrencode`.
+ *
+ * Two modes:
+ * - 'qrcode <url>': render whenever `qrencode` is installed. Running the
+ *   command is itself the expression of intent.
+ * - 'qrcode --if-enabled <url>': render only when the QRCODE variable -
+ *   read from the shell environment or '.env' - is truthy. The login
+ *   wrappers call the script for every login, so they opt in this way to
+ *   leave their default output unchanged.
+ *
+ * Both modes are a no-op when no URL is given or `qrencode` is not
+ * installed, so callers can pipe an optional URL through without guarding
+ * first.
  */
 
 declare(strict_types=1);
@@ -16,4 +27,8 @@ namespace DrupalExtensionScaffold\DevTools;
 
 require_once __DIR__ . '/helpers.php';
 
-print_qrcode($argv[1] ?? '');
+$args = array_slice($argv, 1);
+$if_enabled = in_array('--if-enabled', $args, TRUE);
+$positional = array_values(array_filter($args, fn(string $arg): bool => !str_starts_with($arg, '-')));
+
+print_qrcode($positional[0] ?? '', force: !$if_enabled);

--- a/.devtools/qrcode
+++ b/.devtools/qrcode
@@ -9,12 +9,11 @@
  * using `qrencode`.
  *
  * Two modes:
- * - 'qrcode <url>': render whenever `qrencode` is installed. Running the
- *   command is itself the expression of intent.
+ * - 'qrcode <url>': render whenever `qrencode` is installed. Invoking the
+ *   command is the opt-in.
  * - 'qrcode --if-enabled <url>': render only when the QRCODE variable -
- *   read from the shell environment or '.env' - is truthy. The login
- *   wrappers call the script for every login, so they opt in this way to
- *   leave their default output unchanged.
+ *   read from the shell environment or '.env' - is truthy, for callers
+ *   that invoke the script on every run rather than on request.
  *
  * Both modes are a no-op when no URL is given or `qrencode` is not
  * installed, so callers can pipe an optional URL through without guarding

--- a/.devtools/qrcode
+++ b/.devtools/qrcode
@@ -5,19 +5,11 @@
  * @file
  * Render a URL as a scannable QR code in the terminal.
  *
- * Reads the URL from the first non-flag CLI argument and prints a QR code
- * using `qrencode`.
- *
- * Two modes:
- * - 'qrcode <url>': render whenever `qrencode` is installed. Invoking the
- *   command is the opt-in.
- * - 'qrcode --if-enabled <url>': render only when the QRCODE variable -
- *   read from the shell environment or '.env' - is truthy, for callers
- *   that invoke the script on every run rather than on request.
- *
- * Both modes are a no-op when no URL is given or `qrencode` is not
- * installed, so callers can pipe an optional URL through without guarding
- * first.
+ * Reads the URL from the first CLI argument and prints a QR code using
+ * `qrencode`. Invoking the command is the request, so the code is drawn
+ * regardless of any environment variable. Exits non-zero with an install
+ * hint when `qrencode` is not on PATH, and renders nothing when no URL is
+ * given.
  */
 
 declare(strict_types=1);
@@ -26,8 +18,4 @@ namespace DrupalExtensionScaffold\DevTools;
 
 require_once __DIR__ . '/helpers.php';
 
-$args = array_slice($argv, 1);
-$if_enabled = in_array('--if-enabled', $args, TRUE);
-$positional = array_values(array_filter($args, fn(string $arg): bool => !str_starts_with($arg, '-')));
-
-print_qrcode($positional[0] ?? '', force: !$if_enabled);
+print_qrcode($argv[1] ?? '');

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -54,7 +54,7 @@ commands:
     cmd: |
       url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
       printf '%s\n' "$url"
-      ./.devtools/qrcode --if-enabled "$url"
+      if [ -n "$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$url"; fi
 
   lint:
     usage: Check coding standards for violations.

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -54,7 +54,7 @@ commands:
     cmd: |
       url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
       printf '%s\n' "$url"
-      ./.devtools/qrcode "$url"
+      ./.devtools/qrcode --if-enabled "$url"
 
   lint:
     usage: Check coding standards for violations.

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -649,24 +649,29 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
 /**
  * Render a URL as a scannable QR code in the terminal.
  *
- * Opt-in: draws nothing unless the QRCODE variable - read from the shell
- * environment or '.env' - is set to a truthy value ('1', 'true', 'yes',
- * 'on'). When enabled it uses `qrencode -t ANSIUTF8` to draw the code with
- * Unicode block glyphs, and is still a no-op when the URL is empty or the
- * `qrencode` binary is not installed, so callers may invoke it
- * unconditionally.
+ * Opt-in by default: draws nothing unless the QRCODE variable - read from
+ * the shell environment or '.env' - is set to a truthy value ('1', 'true',
+ * 'yes', 'on'), or $force skips that check. When it draws, it uses
+ * `qrencode -t ANSIUTF8` to render the code with Unicode block glyphs, and
+ * is still a no-op when the URL is empty or the `qrencode` binary is not
+ * installed, so callers may invoke it unconditionally.
  *
  * @param string $url
  *   The URL to encode. An empty string renders nothing.
+ * @param bool $force
+ *   Skip the QRCODE opt-in check, for callers whose invocation already
+ *   expresses the intent to draw a code.
  */
-function print_qrcode(string $url): void {
+function print_qrcode(string $url, bool $force = FALSE): void {
   if ($url === '') {
     return;
   }
 
-  $enabled = resolve_env_value('QRCODE', '')['value'];
-  if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
-    return;
+  if (!$force) {
+    $enabled = resolve_env_value('QRCODE', '')['value'];
+    if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
+      return;
+    }
   }
 
   if (!command_path('qrencode')) {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -650,9 +650,8 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
  * Render a URL as a scannable QR code in the terminal.
  *
  * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
- * A missing `qrencode` binary is a failure rather than a silent no-op:
- * whether to draw a code at all is decided before this point, so there is
- * no case here where drawing nothing is the intended outcome.
+ * A missing `qrencode` binary fails rather than returning quietly, so a
+ * requested code never goes undrawn without explanation.
  *
  * @param string $url
  *   The URL to encode. An empty string renders nothing, so an optional URL

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/helpers.php
@@ -649,33 +649,22 @@ function passthru_verbose_or_fail(string $command, string $format = '', string|i
 /**
  * Render a URL as a scannable QR code in the terminal.
  *
- * Opt-in by default: draws nothing unless the QRCODE variable - read from
- * the shell environment or '.env' - is set to a truthy value ('1', 'true',
- * 'yes', 'on'), or $force skips that check. When it draws, it uses
- * `qrencode -t ANSIUTF8` to render the code with Unicode block glyphs, and
- * is still a no-op when the URL is empty or the `qrencode` binary is not
- * installed, so callers may invoke it unconditionally.
+ * Uses `qrencode -t ANSIUTF8` to draw the code with Unicode block glyphs.
+ * A missing `qrencode` binary is a failure rather than a silent no-op:
+ * whether to draw a code at all is decided before this point, so there is
+ * no case here where drawing nothing is the intended outcome.
  *
  * @param string $url
- *   The URL to encode. An empty string renders nothing.
- * @param bool $force
- *   Skip the QRCODE opt-in check, for callers whose invocation already
- *   expresses the intent to draw a code.
+ *   The URL to encode. An empty string renders nothing, so an optional URL
+ *   can be passed through without guarding first.
  */
-function print_qrcode(string $url, bool $force = FALSE): void {
+function print_qrcode(string $url): void {
   if ($url === '') {
     return;
   }
 
-  if (!$force) {
-    $enabled = resolve_env_value('QRCODE', '')['value'];
-    if (!in_array(strtolower($enabled), ['1', 'true', 'yes', 'on'], TRUE)) {
-      return;
-    }
-  }
-
   if (!command_path('qrencode')) {
-    return;
+    FAIL("Command 'qrencode' is not available. Install it from https://fukuchi.org/works/qrencode/ to render QR codes");
   }
 
   passthru(sprintf('qrencode -t ANSIUTF8 %s', escapeshellarg($url)));

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
@@ -5,9 +5,20 @@
  * @file
  * Render a URL as a scannable QR code in the terminal.
  *
- * Reads the URL from the first CLI argument and prints a QR code using
- * `qrencode`. A no-op when no URL is given or `qrencode` is not installed,
- * so callers can pipe an optional URL through without guarding first.
+ * Reads the URL from the first non-flag CLI argument and prints a QR code
+ * using `qrencode`.
+ *
+ * Two modes:
+ * - 'qrcode <url>': render whenever `qrencode` is installed. Running the
+ *   command is itself the expression of intent.
+ * - 'qrcode --if-enabled <url>': render only when the QRCODE variable -
+ *   read from the shell environment or '.env' - is truthy. The login
+ *   wrappers call the script for every login, so they opt in this way to
+ *   leave their default output unchanged.
+ *
+ * Both modes are a no-op when no URL is given or `qrencode` is not
+ * installed, so callers can pipe an optional URL through without guarding
+ * first.
  */
 
 declare(strict_types=1);
@@ -16,4 +27,8 @@ namespace DrupalExtensionScaffold\DevTools;
 
 require_once __DIR__ . '/helpers.php';
 
-print_qrcode($argv[1] ?? '');
+$args = array_slice($argv, 1);
+$if_enabled = in_array('--if-enabled', $args, TRUE);
+$positional = array_values(array_filter($args, fn(string $arg): bool => !str_starts_with($arg, '-')));
+
+print_qrcode($positional[0] ?? '', force: !$if_enabled);

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
@@ -9,12 +9,11 @@
  * using `qrencode`.
  *
  * Two modes:
- * - 'qrcode <url>': render whenever `qrencode` is installed. Running the
- *   command is itself the expression of intent.
+ * - 'qrcode <url>': render whenever `qrencode` is installed. Invoking the
+ *   command is the opt-in.
  * - 'qrcode --if-enabled <url>': render only when the QRCODE variable -
- *   read from the shell environment or '.env' - is truthy. The login
- *   wrappers call the script for every login, so they opt in this way to
- *   leave their default output unchanged.
+ *   read from the shell environment or '.env' - is truthy, for callers
+ *   that invoke the script on every run rather than on request.
  *
  * Both modes are a no-op when no URL is given or `qrencode` is not
  * installed, so callers can pipe an optional URL through without guarding

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/qrcode
@@ -5,19 +5,11 @@
  * @file
  * Render a URL as a scannable QR code in the terminal.
  *
- * Reads the URL from the first non-flag CLI argument and prints a QR code
- * using `qrencode`.
- *
- * Two modes:
- * - 'qrcode <url>': render whenever `qrencode` is installed. Invoking the
- *   command is the opt-in.
- * - 'qrcode --if-enabled <url>': render only when the QRCODE variable -
- *   read from the shell environment or '.env' - is truthy, for callers
- *   that invoke the script on every run rather than on request.
- *
- * Both modes are a no-op when no URL is given or `qrencode` is not
- * installed, so callers can pipe an optional URL through without guarding
- * first.
+ * Reads the URL from the first CLI argument and prints a QR code using
+ * `qrencode`. Invoking the command is the request, so the code is drawn
+ * regardless of any environment variable. Exits non-zero with an install
+ * hint when `qrencode` is not on PATH, and renders nothing when no URL is
+ * given.
  */
 
 declare(strict_types=1);
@@ -26,8 +18,4 @@ namespace DrupalExtensionScaffold\DevTools;
 
 require_once __DIR__ . '/helpers.php';
 
-$args = array_slice($argv, 1);
-$if_enabled = in_array('--if-enabled', $args, TRUE);
-$positional = array_values(array_filter($args, fn(string $arg): bool => !str_starts_with($arg, '-')));
-
-print_qrcode($positional[0] ?? '', force: !$if_enabled);
+print_qrcode($argv[1] ?? '');

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -114,7 +114,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -104,7 +104,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -104,7 +104,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/src/Traits/MockTrait.php
+++ b/.scaffold/tests/src/Traits/MockTrait.php
@@ -333,7 +333,7 @@ trait MockTrait {
     $this->registerMock('exec', $namespace, function (string $cmd, ?array &$output = NULL, ?int &$code = NULL) use ($command, $available): bool {
       $output ??= [];
 
-      if ($available && str_contains($cmd, 'command -v ' . $command)) {
+      if ($available && $cmd === sprintf('command -v %s 2>/dev/null', $command)) {
         $output[] = '/usr/bin/' . $command;
         $code = 0;
 

--- a/.scaffold/tests/src/Traits/MockTrait.php
+++ b/.scaffold/tests/src/Traits/MockTrait.php
@@ -316,6 +316,37 @@ trait MockTrait {
   }
 
   /**
+   * Mock command_path() resolution through the exec() probe behind it.
+   *
+   * Any command other than the named one always resolves as missing, so a
+   * test that expects one probe cannot be satisfied by another.
+   *
+   * @param string $command
+   *   Command name to resolve.
+   * @param bool $available
+   *   TRUE to resolve the command to a stub path, FALSE to report it as
+   *   not installed.
+   * @param string $namespace
+   *   Namespace to mock the function in.
+   */
+  protected function mockCommandAvailable(string $command, bool $available, string $namespace = 'DrupalExtensionScaffold\\DevTools'): void {
+    $this->registerMock('exec', $namespace, function (string $cmd, ?array &$output = NULL, ?int &$code = NULL) use ($command, $available): bool {
+      $output ??= [];
+
+      if ($available && str_contains($cmd, 'command -v ' . $command)) {
+        $output[] = '/usr/bin/' . $command;
+        $code = 0;
+
+        return TRUE;
+      }
+
+      $code = 1;
+
+      return FALSE;
+    });
+  }
+
+  /**
    * Mock sleep() function as a no-op.
    *
    * @param string $namespace

--- a/.scaffold/tests/src/Traits/MockTrait.php
+++ b/.scaffold/tests/src/Traits/MockTrait.php
@@ -251,6 +251,19 @@ trait MockTrait {
   }
 
   /**
+   * Mock passthru() with no allowed calls, so any call raises.
+   *
+   * Lets a test that asserts empty output prove the command was never run,
+   * rather than passing because the output happened to be empty.
+   *
+   * @param string $namespace
+   *   Namespace to mock the functions in.
+   */
+  protected function mockPassthruNever(string $namespace = 'DrupalExtensionScaffold\\DevTools'): void {
+    $this->mockPassthruMultiple([], $namespace);
+  }
+
+  /**
    * Verify all mocked passthru responses were consumed.
    *
    * @throws \PHPUnit\Framework\AssertionFailedError

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 
 use function DrupalExtensionScaffold\DevTools\print_qrcode;
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -30,7 +31,10 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   }
 
   public function testEmptyUrlDoesNothing(): void {
-    // An empty URL short-circuits before the opt-in check or any probe.
+    // Nothing else can stop the render, so the empty URL has to.
+    $this->mockCommandAvailable('qrencode', TRUE);
+    $this->mockPassthruNever();
+
     ob_start();
     print_qrcode('');
     $output = ob_get_clean();
@@ -39,45 +43,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testDisabledByDefaultDoesNothing(): void {
-    // QRCODE is unset in both the environment and '.env'. The feature is
-    // opt-in, so nothing is drawn and qrencode is not probed.
-    $this->envUnset('QRCODE');
-    $this->mockDotenvAbsent();
-
-    ob_start();
-    print_qrcode('https://example.com');
-    $output = ob_get_clean();
-    $this->assertIsString($output);
-
-    $this->assertSame('', $output);
-  }
-
-  public function testExplicitlyDisabledDoesNothing(): void {
-    $this->envSet('QRCODE', '0');
-
-    ob_start();
-    print_qrcode('https://example.com');
-    $output = ob_get_clean();
-    $this->assertIsString($output);
-
-    $this->assertSame('', $output);
-  }
-
-  public function testEnabledButQrencodeMissingDoesNothing(): void {
-    $this->envSet('QRCODE', '1');
-    $this->mockCommandAvailable('qrencode', FALSE);
-
-    ob_start();
-    print_qrcode('https://example.com');
-    $output = ob_get_clean();
-    $this->assertIsString($output);
-
-    $this->assertSame('', $output);
-  }
-
-  public function testEnabledViaEnvRendersCode(): void {
-    $this->envSet('QRCODE', '1');
+  public function testRendersCode(): void {
     $this->mockCommandAvailable('qrencode', TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
@@ -92,8 +58,10 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertStringContainsString('[QR-CODE]', $output);
   }
 
-  public function testForcedRendersWhileExplicitlyDisabled(): void {
-    $this->envSet('QRCODE', '0');
+  public function testRendersCodeRegardlessOfLoginOptIn(): void {
+    // Whether to draw a code is decided by the caller, so the login opt-in
+    // has no bearing on this helper.
+    $this->envSet('LOGIN_QRCODE', '');
     $this->mockCommandAvailable('qrencode', TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
@@ -101,62 +69,33 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     ]);
 
     ob_start();
-    print_qrcode('https://example.com', force: TRUE);
+    print_qrcode('https://example.com');
     $output = ob_get_clean();
     $this->assertIsString($output);
 
     $this->assertStringContainsString('[QR-CODE]', $output);
   }
 
-  public function testForcedWithEmptyUrlDoesNothing(): void {
-    // Nothing else can stop the render, so the empty URL has to.
-    $this->mockCommandAvailable('qrencode', TRUE);
-    $this->mockPassthruNever();
-
-    ob_start();
-    print_qrcode('', force: TRUE);
-    $output = ob_get_clean();
-    $this->assertIsString($output);
-
-    $this->assertSame('', $output);
-  }
-
-  public function testForcedButQrencodeMissingDoesNothing(): void {
-    $this->envSet('QRCODE', '0');
+  public function testMissingQrencodeFailsWithInstallHint(): void {
     $this->mockCommandAvailable('qrencode', FALSE);
     $this->mockPassthruNever();
+    $this->mockQuit(1);
 
     ob_start();
-    print_qrcode('https://example.com', force: TRUE);
-    $output = ob_get_clean();
-    $this->assertIsString($output);
+    try {
+      print_qrcode('https://example.com');
+      $this->fail('Expected QuitErrorException to be thrown.');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertSame(1, $e->getCode());
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+    }
 
-    $this->assertSame('', $output);
-  }
-
-  public function testEnabledViaDotenvRendersCode(): void {
-    $this->envUnset('QRCODE');
-    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
-    $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(string $file): string => $file === '.env' ? "QRCODE=1\n" : '');
-    $this->mockCommandAvailable('qrencode', TRUE);
-    $this->mockPassthru([
-      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
-      'output' => '[QR-CODE]',
-    ]);
-
-    ob_start();
-    print_qrcode('https://example.com');
-    $output = ob_get_clean();
-    $this->assertIsString($output);
-
-    $this->assertStringContainsString('[QR-CODE]', $output);
-  }
-
-  /**
-   * Mock '.env' as not present so QRCODE resolves to its default.
-   */
-  protected function mockDotenvAbsent(): void {
-    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+    $this->assertStringContainsString("Command 'qrencode' is not available", $output);
+    $this->assertStringContainsString('https://fukuchi.org/works/qrencode/', $output);
   }
 
 }

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -109,6 +109,10 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   }
 
   public function testForcedWithEmptyUrlDoesNothing(): void {
+    // Nothing else can stop the render, so the empty URL has to.
+    $this->mockCommandAvailable('qrencode', TRUE);
+    $this->mockPassthruNever();
+
     ob_start();
     print_qrcode('', force: TRUE);
     $output = ob_get_clean();
@@ -120,6 +124,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
   public function testForcedButQrencodeMissingDoesNothing(): void {
     $this->envSet('QRCODE', '0');
     $this->mockCommandAvailable('qrencode', FALSE);
+    $this->mockPassthruNever();
 
     ob_start();
     print_qrcode('https://example.com', force: TRUE);

--- a/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
+++ b/.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php
@@ -66,7 +66,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
   public function testEnabledButQrencodeMissingDoesNothing(): void {
     $this->envSet('QRCODE', '1');
-    $this->mockQrencodeAvailable(FALSE);
+    $this->mockCommandAvailable('qrencode', FALSE);
 
     ob_start();
     print_qrcode('https://example.com');
@@ -78,7 +78,7 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
 
   public function testEnabledViaEnvRendersCode(): void {
     $this->envSet('QRCODE', '1');
-    $this->mockQrencodeAvailable(TRUE);
+    $this->mockCommandAvailable('qrencode', TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
       'output' => '[QR-CODE]',
@@ -92,11 +92,48 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
     $this->assertStringContainsString('[QR-CODE]', $output);
   }
 
+  public function testForcedRendersWhileExplicitlyDisabled(): void {
+    $this->envSet('QRCODE', '0');
+    $this->mockCommandAvailable('qrencode', TRUE);
+    $this->mockPassthru([
+      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
+      'output' => '[QR-CODE]',
+    ]);
+
+    ob_start();
+    print_qrcode('https://example.com', force: TRUE);
+    $output = ob_get_clean();
+    $this->assertIsString($output);
+
+    $this->assertStringContainsString('[QR-CODE]', $output);
+  }
+
+  public function testForcedWithEmptyUrlDoesNothing(): void {
+    ob_start();
+    print_qrcode('', force: TRUE);
+    $output = ob_get_clean();
+    $this->assertIsString($output);
+
+    $this->assertSame('', $output);
+  }
+
+  public function testForcedButQrencodeMissingDoesNothing(): void {
+    $this->envSet('QRCODE', '0');
+    $this->mockCommandAvailable('qrencode', FALSE);
+
+    ob_start();
+    print_qrcode('https://example.com', force: TRUE);
+    $output = ob_get_clean();
+    $this->assertIsString($output);
+
+    $this->assertSame('', $output);
+  }
+
   public function testEnabledViaDotenvRendersCode(): void {
     $this->envUnset('QRCODE');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(string $file): bool => $file === '.env');
     $this->registerMock('file_get_contents', 'DrupalExtensionScaffold\\DevTools', fn(string $file): string => $file === '.env' ? "QRCODE=1\n" : '');
-    $this->mockQrencodeAvailable(TRUE);
+    $this->mockCommandAvailable('qrencode', TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
       'output' => '[QR-CODE]',
@@ -115,24 +152,6 @@ final class HelpersPrintQrcodeTest extends UnitTestCase {
    */
   protected function mockDotenvAbsent(): void {
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
-  }
-
-  /**
-   * Mock command_path('qrencode') resolution via the underlying exec().
-   */
-  protected function mockQrencodeAvailable(bool $available): void {
-    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL) use ($available): bool {
-      $output ??= [];
-      if ($available && str_contains($cmd, 'command -v qrencode')) {
-        $output[] = '/usr/bin/qrencode';
-        $code = 0;
-
-        return TRUE;
-      }
-      $code = 1;
-
-      return FALSE;
-    });
   }
 
 }

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -51,9 +51,12 @@ final class QrcodeTest extends UnitTestCase {
   }
 
   public function testQrcodeIfEnabledDoesNothingWhenOptInUnset(): void {
-    // QRCODE is unset in both the environment and '.env'.
+    // QRCODE is unset in both the environment and '.env'. Nothing else can
+    // stop the render, so the opt-in check has to.
     $this->envUnset('QRCODE');
     $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+    $this->mockCommandAvailable('qrencode', TRUE);
+    $this->mockPassthruNever();
 
     $argv = ['qrcode', '--if-enabled', 'https://example.com'];
     ob_start();

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
 
+use AlexSkrypnyk\drupal_extension_scaffold\Tests\Exceptions\QuitErrorException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -23,8 +24,8 @@ final class QrcodeTest extends UnitTestCase {
   }
 
   public function testQrcodeRendersQrcodeForUrlArgument(): void {
-    // Invoking the command is the opt-in, so the QRCODE gate does not apply.
-    $this->envSet('QRCODE', '0');
+    // Invoking the command is the request, so no opt-in is consulted.
+    $this->envSet('LOGIN_QRCODE', '');
     $this->mockCommandAvailable('qrencode', TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
@@ -41,6 +42,9 @@ final class QrcodeTest extends UnitTestCase {
   }
 
   public function testQrcodeDoesNothingWithoutUrlArgument(): void {
+    $this->mockCommandAvailable('qrencode', TRUE);
+    $this->mockPassthruNever();
+
     $argv = ['qrcode'];
     ob_start();
     require dirname(__DIR__, 4) . '/.devtools/qrcode';
@@ -50,38 +54,26 @@ final class QrcodeTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  public function testQrcodeIfEnabledDoesNothingWhenOptInUnset(): void {
-    // QRCODE is unset in both the environment and '.env'. Nothing else can
-    // stop the render, so the opt-in check has to.
-    $this->envUnset('QRCODE');
-    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
-    $this->mockCommandAvailable('qrencode', TRUE);
+  public function testQrcodeFailsWhenQrencodeMissing(): void {
+    $this->mockCommandAvailable('qrencode', FALSE);
     $this->mockPassthruNever();
+    $this->mockQuit(1);
 
-    $argv = ['qrcode', '--if-enabled', 'https://example.com'];
+    $argv = ['qrcode', 'https://example.com'];
     ob_start();
-    require dirname(__DIR__, 4) . '/.devtools/qrcode';
-    $output = ob_get_clean();
-    $this->assertIsString($output);
+    try {
+      require dirname(__DIR__, 4) . '/.devtools/qrcode';
+      $this->fail('Expected QuitErrorException to be thrown.');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertSame(1, $e->getCode());
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertIsString($output);
+    }
 
-    $this->assertSame('', $output);
-  }
-
-  public function testQrcodeIfEnabledRendersWhenOptInSet(): void {
-    $this->envSet('QRCODE', '1');
-    $this->mockCommandAvailable('qrencode', TRUE);
-    $this->mockPassthru([
-      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
-      'output' => '[QR-CODE]',
-    ]);
-
-    $argv = ['qrcode', '--if-enabled', 'https://example.com'];
-    ob_start();
-    require dirname(__DIR__, 4) . '/.devtools/qrcode';
-    $output = ob_get_clean();
-    $this->assertIsString($output);
-
-    $this->assertStringContainsString('[QR-CODE]', $output);
+    $this->assertStringContainsString("Command 'qrencode' is not available", $output);
   }
 
 }

--- a/.scaffold/tests/src/Unit/QrcodeTest.php
+++ b/.scaffold/tests/src/Unit/QrcodeTest.php
@@ -23,20 +23,9 @@ final class QrcodeTest extends UnitTestCase {
   }
 
   public function testQrcodeRendersQrcodeForUrlArgument(): void {
-    // Rendering is opt-in.
-    $this->envSet('QRCODE', '1');
-    $this->registerMock('exec', 'DrupalExtensionScaffold\\DevTools', function (string $cmd, ?array &$output = NULL, ?int &$code = NULL): bool {
-      $output ??= [];
-      if (str_contains($cmd, 'command -v qrencode')) {
-        $output[] = '/usr/bin/qrencode';
-        $code = 0;
-
-        return TRUE;
-      }
-      $code = 1;
-
-      return FALSE;
-    });
+    // Invoking the command is the opt-in, so the QRCODE gate does not apply.
+    $this->envSet('QRCODE', '0');
+    $this->mockCommandAvailable('qrencode', TRUE);
     $this->mockPassthru([
       'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
       'output' => '[QR-CODE]',
@@ -59,6 +48,37 @@ final class QrcodeTest extends UnitTestCase {
     $this->assertIsString($output);
 
     $this->assertSame('', $output);
+  }
+
+  public function testQrcodeIfEnabledDoesNothingWhenOptInUnset(): void {
+    // QRCODE is unset in both the environment and '.env'.
+    $this->envUnset('QRCODE');
+    $this->registerMock('file_exists', 'DrupalExtensionScaffold\\DevTools', fn(): bool => FALSE);
+
+    $argv = ['qrcode', '--if-enabled', 'https://example.com'];
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/qrcode';
+    $output = ob_get_clean();
+    $this->assertIsString($output);
+
+    $this->assertSame('', $output);
+  }
+
+  public function testQrcodeIfEnabledRendersWhenOptInSet(): void {
+    $this->envSet('QRCODE', '1');
+    $this->mockCommandAvailable('qrencode', TRUE);
+    $this->mockPassthru([
+      'cmd' => "qrencode -t ANSIUTF8 'https://example.com'",
+      'output' => '[QR-CODE]',
+    ]);
+
+    $argv = ['qrcode', '--if-enabled', 'https://example.com'];
+    ob_start();
+    require dirname(__DIR__, 4) . '/.devtools/qrcode';
+    $output = ob_get_clean();
+    $this->assertIsString($output);
+
+    $this->assertStringContainsString('[QR-CODE]', $output);
   }
 
 }

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
 
 provision:
 	./.devtools/provision

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ drush:
 	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; ./.devtools/qrcode --if-enabled "$$url"
+	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Any tool that writes a `TUNNEL_URL` to `.env` (ngrok, tailscale funnel, etc.) is
 
 Render any URL as a terminal QR code with `./.devtools/qrcode <url>`. Scan it to open the URL on a phone or another device, which is most useful for a one-time login link while the site is exposed through a public tunnel. The command requires [`qrencode`](https://fukuchi.org/works/qrencode/) on `PATH` and exits with an install hint when it is missing.
 
-A QR code below the `make login` / `ahoy login` link is opt-in. Set `LOGIN_QRCODE=1` in `.env` (or in your shell environment) and both commands render the one-time login link as a QR code under the printed URL. Left unset (the default) the login output is unchanged; set with `qrencode` missing, `login` prints the link and then fails with the install hint.
+A QR code below the `make login` / `ahoy login` link is opt-in. Set `LOGIN_QRCODE=1` in `.env` (or in your shell environment) and both commands render the one-time login link as a QR code under the printed URL. The wrappers test only that the variable is non-empty, so unset it to turn the QR code off rather than setting it to `0`. Left unset (the default) the login output is unchanged; set with `qrencode` missing, `login` prints the link and then fails with the install hint.
 
 ### Step-debugging with XDebug
 

--- a/README.md
+++ b/README.md
@@ -297,9 +297,9 @@ Any tool that writes a `TUNNEL_URL` to `.env` (ngrok, tailscale funnel, etc.) is
 
 #### Scannable QR codes
 
-QR rendering is opt-in. Set `QRCODE=1` (in your shell environment or `.env`) with [`qrencode`](https://fukuchi.org/works/qrencode/) on `PATH`, and `make login` / `ahoy login` render the one-time login link as a terminal QR code below the link. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Left unset (the default) or without `qrencode` installed, the output is unchanged.
+Render any URL as a terminal QR code with `./.devtools/qrcode <url>`. Scan it to open the URL on a phone or another device, which is most useful for a one-time login link while the site is exposed through a public tunnel. The command requires [`qrencode`](https://fukuchi.org/works/qrencode/) on `PATH` and exits with an install hint when it is missing.
 
-Any URL can also be rendered on demand with `./.devtools/qrcode <url>`, which draws the code whatever `QRCODE` is set to, because running the command is itself the opt-in.
+A QR code below the `make login` / `ahoy login` link is opt-in. Set `LOGIN_QRCODE=1` in `.env` (or in your shell environment) and both commands render the one-time login link as a QR code under the printed URL. Left unset (the default) the login output is unchanged; set with `qrencode` missing, `login` prints the link and then fails with the install hint.
 
 ### Step-debugging with XDebug
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Any tool that writes a `TUNNEL_URL` to `.env` (ngrok, tailscale funnel, etc.) is
 
 QR rendering is opt-in. Set `QRCODE=1` (in your shell environment or `.env`) with [`qrencode`](https://fukuchi.org/works/qrencode/) on `PATH`, and `make login` / `ahoy login` render the one-time login link as a terminal QR code below the link. Scan it to open the site - already logged in - on a phone or another device, which is most useful when the site is exposed through a public tunnel. Left unset (the default) or without `qrencode` installed, the output is unchanged.
 
+Any URL can also be rendered on demand with `./.devtools/qrcode <url>`, which draws the code whatever `QRCODE` is set to, because running the command is itself the opt-in.
+
 ### Step-debugging with XDebug
 
 PHP step-debugging is supported via [XDebug](https://xdebug.org/docs/install). Install the XDebug PHP extension on your host (`php -v` should mention `with Xdebug`), then toggle it on the development server:


### PR DESCRIPTION
Closes #510

## Summary

`.devtools/qrcode` was documented on the command surface but printed nothing on a normal machine. The cause was a policy check living inside the rendering helper: `print_qrcode()` returned early unless a `QRCODE` variable was truthy, so a human running the command got silence, and the script's docblock listed only two of its three no-op conditions.

The variable itself was there for a good reason. `make login` and `ahoy login` call the qrcode script on every single login, and without a gate they would draw a QR code for everyone whether or not they wanted one. The mistake was putting that gate where both callers share it, which let a setting meant for the automatic caller silence the deliberate one.

This separates policy from rendering. `print_qrcode()` now only renders, and each caller decides for itself whether to call it: the `qrcode` command always renders because invoking it is the request, and the `login` wrappers render only when `LOGIN_QRCODE` is set. The variable is renamed from `QRCODE` to `LOGIN_QRCODE` because it now governs the login pathway alone, and both wrappers already load `.env` into their environment (`Makefile` via `-include .env` plus `export`, `.ahoy.yml` via `env: - .env`), so setting it there is enough.

A missing `qrencode` binary is also no longer swallowed. Previously the helper returned silently, so a user who explicitly asked for a QR code got nothing and no explanation. Both entry points now fail with an install hint.

## Changes

- `.devtools/helpers.php`: `print_qrcode()` no longer reads any environment variable and no longer takes a force flag, so it renders or fails and does nothing else. A missing `qrencode` now calls `FAIL()` with an install hint instead of returning silently. An empty URL is still a no-op, so an optional URL can be passed through without guarding.
- `.devtools/qrcode`: back to a single `print_qrcode($argv[1] ?? '')` call with no flag parsing, since the script no longer has to distinguish its callers. Docblock rewritten to state that it always renders and that a missing binary exits non-zero.
- `Makefile` and `.ahoy.yml`: `login` now gates the call itself with `if [ -n "$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$url"; fi`. The variable expansion is quoted because an unquoted `[ -n $VAR ]` collapses to the single-argument test `[ -n ]`, which is always true and would draw a QR code for everyone. The `if` form is used rather than a trailing `&&` so that not opting in does not leave `login` with a non-zero exit status.
- `README.md`: documents the on-demand command, the renamed `LOGIN_QRCODE` opt-in, the install-hint failure, and that the gate tests only for non-emptiness so the variable should be unset rather than set to `0` to disable it.
- `.scaffold/tests/src/Traits/MockTrait.php`: added `mockCommandAvailable()`, which mocks the `exec()` probe behind `command_path()` against the exact command string, and `mockPassthruNever()`, which raises if the renderer is reached at all.
- `.scaffold/tests/src/Unit/HelpersPrintQrcodeTest.php` and `QrcodeTest.php`: rewritten for the new contract, covering the empty-URL no-op, rendering regardless of `LOGIN_QRCODE`, and the missing-binary failure asserting both the exit code and the install hint. The no-op cases pin `mockPassthruNever()` so they prove the renderer was never reached instead of passing on any machine that happens to lack `qrencode`.
- `.scaffold/tests/fixtures/init/**`: regenerated for the changed `.devtools` files and `login` wrapper lines.

## Screenshots

N/A

## Before / After

```
BEFORE - one gate, shared by both callers
┌──────────────────────┐   ┌──────────────────────┐
│ ./.devtools/qrcode   │   │ make / ahoy login    │
│ (human asks for it)  │   │ (runs every login)   │
└──────────┬───────────┘   └──────────┬───────────┘
           └────────────┬─────────────┘
                        v
              ┌───────────────────┐
              │  print_qrcode()   │
              │  if !QRCODE: quit │  <- silences BOTH callers
              │  if !qrencode:    │
              │      quit quietly │  <- no explanation either
              └───────────────────┘
   result: human gets silence; login stays quiet as intended

AFTER - each caller owns its own policy
┌──────────────────────┐   ┌───────────────────────────────┐
│ ./.devtools/qrcode   │   │ make / ahoy login             │
│ always calls         │   │ if [ -n "$LOGIN_QRCODE" ]     │
│ (invoking = request) │   │   then call, else skip        │
└──────────┬───────────┘   └──────────┬────────────────────┘
           └────────────┬─────────────┘
                        v
              ┌────────────────────────┐
              │  print_qrcode()        │
              │  renders               │
              │  no qrencode -> FAIL   │  <- install hint, exit 1
              └────────────────────────┘
   result: human gets a code or a reason; login unchanged by default
```

| Invocation | `LOGIN_QRCODE` | `qrencode` | Before | After |
|---|---|---|---|---|
| `./.devtools/qrcode <url>` | unset | present | silent | renders |
| `./.devtools/qrcode <url>` | set | present | renders | renders |
| `./.devtools/qrcode <url>` | any | missing | silent | `[FAIL]` + install hint, exit 1 |
| `make` / `ahoy login` | unset | present | link only | link only |
| `make` / `ahoy login` | set | present | link + code | link + code |
| `make` / `ahoy login` | set | missing | link only, silent | link, then `[FAIL]` + install hint |
