### PR TITLE
[#508] Fixed Selenium pinning port 4444 and 'MINK_DRIVER_ARGS_WEBDRIVER' overriding the environment.

### DIFF
--- a/.devtools/browser
+++ b/.devtools/browser
@@ -32,7 +32,7 @@ require_once __DIR__ . '/helpers.php';
 // by git and safe to delete.
 const CHROMEDRIVER_DIR = '.chromedriver';
 
-const SELENIUM_CONTAINER = 'selenium';
+const SELENIUM_CONTAINER_PREFIX = 'selenium';
 const SELENIUM_IMAGE = 'selenium/standalone-chromium:latest';
 
 $command = $argv[1] ?? '';
@@ -91,7 +91,7 @@ function browser_stop(): void {
 
   if (command_path('docker') !== FALSE) {
     TASK('Removing the Selenium container, if any.');
-    @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+    @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(selenium_container($port))));
   }
 
   TASK('Stopping the WebDriver process on port %s, if any.', $port);
@@ -155,11 +155,11 @@ function selenium_start(): void {
   }
 
   TASK('Starting the Selenium container on port %s.', $port);
-  @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+  @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(selenium_container($port))));
 
   // The default 64 MB '/dev/shm' is too small for Chromium and leads to tab
   // crashes mid-test; the Selenium images document 2g as the required size.
-  passthru_or_fail(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), 'Failed to start the Selenium container.');
+  passthru_or_fail(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(selenium_container($port)), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), 'Failed to start the Selenium container.');
 
   NOTE('Waiting for Selenium to be ready.');
   for ($i = 0; $i < 30; $i++) {
@@ -189,6 +189,17 @@ function webdriver_backend(): string {
   }
 
   return $backend;
+}
+
+/**
+ * Build the container name for the Selenium endpoint on the given port.
+ *
+ * The port is the per-project identity of the endpoint, so naming the
+ * container after it keeps projects running side by side from removing or
+ * overwriting each other's container.
+ */
+function selenium_container(string $port): string {
+  return SELENIUM_CONTAINER_PREFIX . '-' . $port;
 }
 
 /**

--- a/.devtools/browser
+++ b/.devtools/browser
@@ -195,7 +195,7 @@ function webdriver_backend(): string {
  * Build the container name for the Selenium endpoint on the given port.
  *
  * The port is the per-project identity of the endpoint, so naming the
- * container after it keeps projects running side by side from removing or
+ * container after it stops projects running side by side from removing or
  * overwriting each other's container.
  */
 function selenium_container(string $port): string {

--- a/.devtools/browser
+++ b/.devtools/browser
@@ -11,10 +11,11 @@
  * - 'selenium': the browser runs inside a Docker container.
  *
  * Both backends serve the WebDriver endpoint on the same per-project port
- * (env -> '.env' -> 4444). The chromedriver backend auto-discovers a free
- * port from 4444 and persists it to '.env' like the webserver port, so
- * several projects can run their own endpoint simultaneously without
- * contending for a single port.
+ * (env -> '.env' -> 4444). Starting either one auto-discovers a free port
+ * from 4444 and persists it to '.env' like the webserver port, so several
+ * projects can run their own endpoint simultaneously without contending for
+ * a single port. Stopping reads the persisted port instead of discovering,
+ * so it targets the endpoint the matching start created.
  *
  * Usage:
  * - 'browser start': ensure the selected backend is listening.
@@ -141,7 +142,7 @@ function chromedriver_start(): void {
  * Ensure a Selenium container is serving the WebDriver endpoint.
  */
 function selenium_start(): void {
-  $port = resolve_webdriver_port()['port'];
+  $port = resolve_webdriver_port(auto_discover: TRUE)['port'];
 
   if (webdriver_ready($port)) {
     PASS('Selenium is already running on port %s.', $port);

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -24,8 +24,12 @@ jobs:
 
     env:
       # In CI each job is a single project, so the pre-start step and the
-      # tests share a fixed chromedriver port.
-      WEBDRIVER_PORT: ${{ matrix.backend == 'chromedriver' && '4444' || '' }}
+      # tests share a fixed port instead of discovering one. The selenium legs
+      # must use 4444 because that is what the container step publishes. The
+      # chromedriver legs deliberately use a different port, so a run that
+      # reaches the browser proves the Mink endpoint follows WEBDRIVER_PORT
+      # rather than the literal in phpunit.xml.
+      WEBDRIVER_PORT: ${{ matrix.backend == 'chromedriver' && '4455' || '4444' }}
 
     strategy:
       fail-fast: false

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
@@ -32,7 +32,7 @@ require_once __DIR__ . '/helpers.php';
 // by git and safe to delete.
 const CHROMEDRIVER_DIR = '.chromedriver';
 
-const SELENIUM_CONTAINER = 'selenium';
+const SELENIUM_CONTAINER_PREFIX = 'selenium';
 const SELENIUM_IMAGE = 'selenium/standalone-chromium:latest';
 
 $command = $argv[1] ?? '';
@@ -91,7 +91,7 @@ function browser_stop(): void {
 
   if (command_path('docker') !== FALSE) {
     TASK('Removing the Selenium container, if any.');
-    @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+    @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(selenium_container($port))));
   }
 
   TASK('Stopping the WebDriver process on port %s, if any.', $port);
@@ -155,11 +155,11 @@ function selenium_start(): void {
   }
 
   TASK('Starting the Selenium container on port %s.', $port);
-  @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(SELENIUM_CONTAINER)));
+  @passthru(sprintf('docker rm -f %s >/dev/null 2>&1', escapeshellarg(selenium_container($port))));
 
   // The default 64 MB '/dev/shm' is too small for Chromium and leads to tab
   // crashes mid-test; the Selenium images document 2g as the required size.
-  passthru_or_fail(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(SELENIUM_CONTAINER), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), 'Failed to start the Selenium container.');
+  passthru_or_fail(sprintf('docker run -d --name %s --shm-size=2g -p %s:4444 %s', escapeshellarg(selenium_container($port)), escapeshellarg($port), escapeshellarg(SELENIUM_IMAGE)), 'Failed to start the Selenium container.');
 
   NOTE('Waiting for Selenium to be ready.');
   for ($i = 0; $i < 30; $i++) {
@@ -189,6 +189,17 @@ function webdriver_backend(): string {
   }
 
   return $backend;
+}
+
+/**
+ * Build the container name for the Selenium endpoint on the given port.
+ *
+ * The port is the per-project identity of the endpoint, so naming the
+ * container after it keeps projects running side by side from removing or
+ * overwriting each other's container.
+ */
+function selenium_container(string $port): string {
+  return SELENIUM_CONTAINER_PREFIX . '-' . $port;
 }
 
 /**

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
@@ -195,7 +195,7 @@ function webdriver_backend(): string {
  * Build the container name for the Selenium endpoint on the given port.
  *
  * The port is the per-project identity of the endpoint, so naming the
- * container after it keeps projects running side by side from removing or
+ * container after it stops projects running side by side from removing or
  * overwriting each other's container.
  */
 function selenium_container(string $port): string {

--- a/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
+++ b/.scaffold/tests/fixtures/init/_baseline/.devtools/browser
@@ -11,10 +11,11 @@
  * - 'selenium': the browser runs inside a Docker container.
  *
  * Both backends serve the WebDriver endpoint on the same per-project port
- * (env -> '.env' -> 4444). The chromedriver backend auto-discovers a free
- * port from 4444 and persists it to '.env' like the webserver port, so
- * several projects can run their own endpoint simultaneously without
- * contending for a single port.
+ * (env -> '.env' -> 4444). Starting either one auto-discovers a free port
+ * from 4444 and persists it to '.env' like the webserver port, so several
+ * projects can run their own endpoint simultaneously without contending for
+ * a single port. Stopping reads the persisted port instead of discovering,
+ * so it targets the endpoint the matching start created.
  *
  * Usage:
  * - 'browser start': ensure the selected backend is listening.
@@ -141,7 +142,7 @@ function chromedriver_start(): void {
  * Ensure a Selenium container is serving the WebDriver endpoint.
  */
 function selenium_start(): void {
-  $port = resolve_webdriver_port()['port'];
+  $port = resolve_webdriver_port(auto_discover: TRUE)['port'];
 
   if (webdriver_ready($port)) {
     PASS('Selenium is already running on port %s.', $port);

--- a/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/_baseline/AGENTS.md
@@ -84,7 +84,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `WEBSERVER_HOST` - Development server host (default: localhost)
 - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 - `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously. The endpoint in `phpunit.xml` is the default for port 4444; tests reach the resolved port because the FunctionalJavascript base class rewrites the port in `MINK_DRIVER_ARGS_WEBDRIVER` from this variable, so FunctionalJavascript tests must extend that base class (or export their own `MINK_DRIVER_ARGS_WEBDRIVER`)
 - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
 - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
 

--- a/.scaffold/tests/fixtures/init/_baseline/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/_baseline/CONTRIBUTING.md
@@ -173,6 +173,15 @@ WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
 ahoy browser-stop
 ```
 
+Either backend gets its own WebDriver port: a free one is claimed starting
+at 4444 and stored in `.env`, so several projects can run FunctionalJavascript
+tests at the same time. Set `WEBDRIVER_PORT` to pin a specific one. Tests
+reach the claimed port because the base class applies it to the WebDriver
+endpoint, so extend `ForceCrystalFunctionalJavascriptTestBase` rather than
+`WebDriverTestBase` directly - a test that bypasses it keeps the default
+endpoint from `phpunit.xml` unless it exports its own
+`MINK_DRIVER_ARGS_WEBDRIVER`.
+
 ### Running specific tests
 
 You can run specific tests by passing a path to the test file or PHPUnit CLI

--- a/.scaffold/tests/fixtures/init/_baseline/phpunit.d10.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpunit.d10.xml
@@ -64,7 +64,13 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=''/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
+        <!-- The endpoint below is the default. Both WebDriver backends bind the
+          per-project port resolved by '.devtools/browser' (WEBDRIVER_PORT), so
+          the FunctionalJavascript base class replaces the port in this value at
+          run time. Tests that do not extend that base class can export their own
+          MINK_DRIVER_ARGS_WEBDRIVER, which takes precedence over this entry.
+        -->
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]'/>
     </php>
     <testsuites>
         <testsuite name="unit">

--- a/.scaffold/tests/fixtures/init/_baseline/phpunit.xml
+++ b/.scaffold/tests/fixtures/init/_baseline/phpunit.xml
@@ -54,7 +54,13 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=""/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "goog:chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
+        <!-- The endpoint below is the default. Both WebDriver backends bind the
+          per-project port resolved by '.devtools/browser' (WEBDRIVER_PORT), so
+          the FunctionalJavascript base class replaces the port in this value at
+          run time. Tests that do not extend that base class can export their own
+          MINK_DRIVER_ARGS_WEBDRIVER, which takes precedence over this entry.
+        -->
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]'/>
     </php>
     <extensions>
         <!-- Functional tests HTML output logging. -->

--- a/.scaffold/tests/fixtures/init/no_functional_javascript/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_functional_javascript/AGENTS.md
@@ -14,7 +14,7 @@
  - `WEBSERVER_HOST` - Development server host (default: localhost)
  - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 -- `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
--- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously. The endpoint in `phpunit.xml` is the default for port 4444; tests reach the resolved port because the FunctionalJavascript base class rewrites the port in `MINK_DRIVER_ARGS_WEBDRIVER` from this variable, so FunctionalJavascript tests must extend that base class (or export their own `MINK_DRIVER_ARGS_WEBDRIVER`)
  - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
  - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
  

--- a/.scaffold/tests/fixtures/init/no_functional_javascript/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_functional_javascript/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-@@ -140,37 +140,10 @@
+@@ -140,47 +140,11 @@
  make test-unit                    # Run Unit tests
  make test-kernel                  # Run Kernel tests
  make test-functional              # Run Functional tests
@@ -8,7 +8,7 @@
  ahoy test-kernel                  # Run Kernel tests
  ahoy test-functional              # Run Functional tests
 -ahoy test-functional-javascript   # Run FunctionalJavascript tests
--```
+ ```
 -
 -### Running FunctionalJavascript tests
 -
@@ -33,6 +33,16 @@
 -ahoy provision
 -WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
 -ahoy browser-stop
- ```
+-```
+-
+-Either backend gets its own WebDriver port: a free one is claimed starting
+-at 4444 and stored in `.env`, so several projects can run FunctionalJavascript
+-tests at the same time. Set `WEBDRIVER_PORT` to pin a specific one. Tests
+-reach the claimed port because the base class applies it to the WebDriver
+-endpoint, so extend `ForceCrystalFunctionalJavascriptTestBase` rather than
+-`WebDriverTestBase` directly - a test that bypasses it keeps the default
+-endpoint from `phpunit.xml` unless it exports its own
+-`MINK_DRIVER_ARGS_WEBDRIVER`.
  
  ### Running specific tests
+ 

--- a/.scaffold/tests/fixtures/init/no_functional_javascript/phpunit.d10.xml
+++ b/.scaffold/tests/fixtures/init/no_functional_javascript/phpunit.d10.xml
@@ -1,4 +1,4 @@
-@@ -80,10 +80,6 @@
+@@ -86,10 +86,6 @@
              <directory>web/themes/custom/*/tests/src/Functional</directory>
          </testsuite>
  

--- a/.scaffold/tests/fixtures/init/no_functional_javascript/phpunit.xml
+++ b/.scaffold/tests/fixtures/init/no_functional_javascript/phpunit.xml
@@ -1,4 +1,4 @@
-@@ -90,10 +90,6 @@
+@@ -96,10 +96,6 @@
              <directory>web/themes/custom/*/tests/src/Functional</directory>
          </testsuite>
  

--- a/.scaffold/tests/fixtures/init/no_php_lint/phpunit.d10.xml
+++ b/.scaffold/tests/fixtures/init/no_php_lint/phpunit.d10.xml
@@ -1,4 +1,4 @@
-@@ -103,8 +103,6 @@
+@@ -109,8 +109,6 @@
          <exclude>
              <directory>web/modules/custom/*/tests</directory>
              <directory>web/themes/custom/*/tests</directory>

--- a/.scaffold/tests/fixtures/init/no_php_lint/phpunit.xml
+++ b/.scaffold/tests/fixtures/init/no_php_lint/phpunit.xml
@@ -1,4 +1,4 @@
-@@ -119,8 +119,6 @@
+@@ -125,8 +125,6 @@
          <exclude>
              <directory>web/modules/custom/*/tests</directory>
              <directory>web/themes/custom/*/tests</directory>

--- a/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/AGENTS.md
@@ -33,7 +33,7 @@
  - `WEBSERVER_HOST` - Development server host (default: localhost)
  - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 -- `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
--- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously. The endpoint in `phpunit.xml` is the default for port 4444; tests reach the resolved port because the FunctionalJavascript base class rewrites the port in `MINK_DRIVER_ARGS_WEBDRIVER` from this variable, so FunctionalJavascript tests must extend that base class (or export their own `MINK_DRIVER_ARGS_WEBDRIVER`)
  - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
  - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
  

--- a/.scaffold/tests/fixtures/init/no_phpunit/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_phpunit/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-@@ -129,67 +129,3 @@
+@@ -129,76 +129,3 @@
  ## Testing
  
  The `make test` or `ahoy test` command runs the tests for this extension.
@@ -45,6 +45,15 @@
 -WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
 -ahoy browser-stop
 -```
+-
+-Either backend gets its own WebDriver port: a free one is claimed starting
+-at 4444 and stored in `.env`, so several projects can run FunctionalJavascript
+-tests at the same time. Set `WEBDRIVER_PORT` to pin a specific one. Tests
+-reach the claimed port because the base class applies it to the WebDriver
+-endpoint, so extend `ForceCrystalFunctionalJavascriptTestBase` rather than
+-`WebDriverTestBase` directly - a test that bypasses it keeps the default
+-endpoint from `phpunit.xml` unless it exports its own
+-`MINK_DRIVER_ARGS_WEBDRIVER`.
 -
 -### Running specific tests
 -

--- a/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
+++ b/.scaffold/tests/fixtures/init/no_tools/AGENTS.md
@@ -76,7 +76,7 @@
  - `WEBSERVER_HOST` - Development server host (default: localhost)
  - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 -- `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
--- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously. The endpoint in `phpunit.xml` is the default for port 4444; tests reach the resolved port because the FunctionalJavascript base class rewrites the port in `MINK_DRIVER_ARGS_WEBDRIVER` from this variable, so FunctionalJavascript tests must extend that base class (or export their own `MINK_DRIVER_ARGS_WEBDRIVER`)
  - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
  - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails
  

--- a/.scaffold/tests/fixtures/init/no_tools/CONTRIBUTING.md
+++ b/.scaffold/tests/fixtures/init/no_tools/CONTRIBUTING.md
@@ -11,7 +11,7 @@
  
  The configuration files for these tools are located in the root of the codebase.
  
-@@ -129,67 +123,3 @@
+@@ -129,76 +123,3 @@
  ## Testing
  
  The `make test` or `ahoy test` command runs the tests for this extension.
@@ -58,6 +58,15 @@
 -WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
 -ahoy browser-stop
 -```
+-
+-Either backend gets its own WebDriver port: a free one is claimed starting
+-at 4444 and stored in `.env`, so several projects can run FunctionalJavascript
+-tests at the same time. Set `WEBDRIVER_PORT` to pin a specific one. Tests
+-reach the claimed port because the base class applies it to the WebDriver
+-endpoint, so extend `ForceCrystalFunctionalJavascriptTestBase` rather than
+-`WebDriverTestBase` directly - a test that bypasses it keeps the default
+-endpoint from `phpunit.xml` unless it exports its own
+-`MINK_DRIVER_ARGS_WEBDRIVER`.
 -
 -### Running specific tests
 -

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -222,6 +222,46 @@ final class BrowserTest extends UnitTestCase {
     $this->assertStringContainsString('standalone-chromium', $run_command);
   }
 
+  public function testBrowserSeleniumStartAutoDiscoversPort(): void {
+    $this->envFileContent = "WEBSERVER_PORT=8000\n";
+    $this->envSet('WEBDRIVER_BACKEND', 'selenium');
+    $this->mockCommands(['docker' => '/usr/bin/docker']);
+    $this->mockPortsInUse([4444]);
+    $persisted = NULL;
+    $this->recordDotenvWrites($persisted);
+    $this->mockReady([FALSE, TRUE]);
+    $commands = [];
+    $this->recordPassthru($commands);
+
+    $output = $this->runBrowser('start', 0);
+
+    $this->assertStringContainsString('Selenium is ready on port 4445', $output);
+    $this->assertSame('4445', $persisted, 'The discovered port must be persisted to .env.');
+    $run_commands = array_filter($commands, fn(string $c): bool => str_contains($c, 'docker run'));
+    $this->assertNotEmpty($run_commands, 'The Selenium container must be started.');
+    $this->assertStringContainsString("'4445':4444", (string) reset($run_commands), 'The container must publish the discovered port, not the occupied default.');
+  }
+
+  public function testBrowserChromedriverStartAutoDiscoversPort(): void {
+    $this->envFileContent = "WEBSERVER_PORT=8000\n";
+    $this->mockChrome(FALSE);
+    $this->mockCommands(['google-chrome' => '/usr/bin/google-chrome', 'chromedriver' => '/usr/local/bin/chromedriver']);
+    $this->mockVersions('Google Chrome 150.0.7871.129', 'ChromeDriver 150.0.7871.129 (abc)');
+    $this->mockPortsInUse([4444]);
+    $persisted = NULL;
+    $this->recordDotenvWrites($persisted);
+    $this->mockReady([FALSE, TRUE]);
+    $commands = [];
+    $this->recordPassthru($commands);
+
+    $output = $this->runBrowser('start', 0);
+
+    $this->assertStringContainsString('chromedriver is ready on port 4445', $output);
+    $this->assertSame('4445', $persisted, 'The discovered port must be persisted to .env.');
+    $this->assertNotEmpty($commands);
+    $this->assertStringContainsString("--port='4445'", $commands[0], 'chromedriver must bind the discovered port, not the occupied default.');
+  }
+
   public function testBrowserSeleniumStartFailsWithoutDocker(): void {
     $this->envSet('WEBDRIVER_BACKEND', 'selenium');
     $this->mockCommands([]);
@@ -315,6 +355,42 @@ final class BrowserTest extends UnitTestCase {
   protected function mockReady(array $sequence): void {
     $this->readySequence = $sequence;
     $this->readyIndex = 0;
+  }
+
+  /**
+   * @param array<int, int> $ports
+   *   Ports that answer a connect probe; every other port reads as free.
+   */
+  protected function mockPortsInUse(array $ports): void {
+    $this->registerMock('stream_socket_client', 'DrupalExtensionScaffold\\DevTools', function (string $address, &$errno = NULL, &$errstr = NULL, ?float $timeout = NULL) use ($ports) {
+      if (preg_match('/:(\d+)$/', $address, $matches) !== 1 || !in_array((int) $matches[1], $ports, TRUE)) {
+        $errno = 61;
+        $errstr = 'Connection refused';
+
+        return FALSE;
+      }
+
+      $stream = fopen('php://memory', 'r');
+      if ($stream === FALSE) {
+        throw new \RuntimeException('Unable to open php://memory stream for mock.');
+      }
+
+      return $stream;
+    });
+  }
+
+  /**
+   * @param string|null $persisted
+   *   Populated by reference with the WEBDRIVER_PORT value written to '.env'.
+   */
+  protected function recordDotenvWrites(?string &$persisted): void {
+    $this->registerMock('file_put_contents', 'DrupalExtensionScaffold\\DevTools', function (string $file, string $body) use (&$persisted): int {
+      if (preg_match('/WEBDRIVER_PORT=(\d+)/', $body, $matches) === 1) {
+        $persisted = $matches[1];
+      }
+
+      return strlen($body);
+    });
   }
 
   protected function mockChrome(bool $mac_present): void {

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -239,7 +239,10 @@ final class BrowserTest extends UnitTestCase {
     $this->assertSame('4445', $persisted, 'The discovered port must be persisted to .env.');
     $run_commands = array_filter($commands, fn(string $c): bool => str_contains($c, 'docker run'));
     $this->assertNotEmpty($run_commands, 'The Selenium container must be started.');
-    $this->assertStringContainsString("'4445':4444", (string) reset($run_commands), 'The container must publish the discovered port, not the occupied default.');
+    $run_command = (string) reset($run_commands);
+    $this->assertStringContainsString("'4445':4444", $run_command, 'The container must publish the discovered port, not the occupied default.');
+    $this->assertStringContainsString("--name 'selenium-4445'", $run_command, 'The container name must be scoped to the endpoint port, or a second project removes the first project container.');
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "docker rm -f 'selenium-4445'")), 'Only this project stale container may be removed before starting a new one.');
   }
 
   public function testBrowserChromedriverStartAutoDiscoversPort(): void {
@@ -304,7 +307,7 @@ final class BrowserTest extends UnitTestCase {
     $output = $this->runBrowser('stop', 0);
 
     $this->assertStringContainsString('Browser stopped on port 4444', $output);
-    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, 'docker rm -f')), 'The Selenium container must be removed.');
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "docker rm -f 'selenium-4444'")), 'Stop must remove the container serving this project port, leaving other projects containers alone.');
     $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "lsof -ti:'4444'")), 'The WebDriver process on the resolved port must be terminated.');
   }
 

--- a/.scaffold/tests/src/Unit/BrowserTest.php
+++ b/.scaffold/tests/src/Unit/BrowserTest.php
@@ -241,8 +241,8 @@ final class BrowserTest extends UnitTestCase {
     $this->assertNotEmpty($run_commands, 'The Selenium container must be started.');
     $run_command = (string) reset($run_commands);
     $this->assertStringContainsString("'4445':4444", $run_command, 'The container must publish the discovered port, not the occupied default.');
-    $this->assertStringContainsString("--name 'selenium-4445'", $run_command, 'The container name must be scoped to the endpoint port, or a second project removes the first project container.');
-    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "docker rm -f 'selenium-4445'")), 'Only this project stale container may be removed before starting a new one.');
+    $this->assertStringContainsString("--name 'selenium-4445'", $run_command, "The container name must be scoped to the endpoint port, or a second project removes the first project's container.");
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "docker rm -f 'selenium-4445'")), "Only this project's stale container may be removed before starting a new one.");
   }
 
   public function testBrowserChromedriverStartAutoDiscoversPort(): void {
@@ -307,7 +307,7 @@ final class BrowserTest extends UnitTestCase {
     $output = $this->runBrowser('stop', 0);
 
     $this->assertStringContainsString('Browser stopped on port 4444', $output);
-    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "docker rm -f 'selenium-4444'")), 'Stop must remove the container serving this project port, leaving other projects containers alone.');
+    $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "docker rm -f 'selenium-4444'")), "Stop must remove the container serving this project's port, leaving other projects' containers alone.");
     $this->assertTrue((bool) array_filter($commands, fn(string $c): bool => str_contains($c, "lsof -ti:'4444'")), 'The WebDriver process on the resolved port must be terminated.');
   }
 

--- a/.scaffold/tests/src/Unit/PhpunitWebdriverEndpointTest.php
+++ b/.scaffold/tests/src/Unit/PhpunitWebdriverEndpointTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that the WebDriver endpoint follows the resolved WEBDRIVER_PORT.
+ *
+ * The shipped PHPUnit configs carry the WebDriver endpoint as a literal, but
+ * the port that both backends actually bind is resolved at run time and
+ * persisted to '.env' so several projects can run FunctionalJavascript tests
+ * at once. Two rules keep the literal from becoming authoritative:
+ *
+ * - The FunctionalJavascript base class rewrites the endpoint from
+ *   WEBDRIVER_PORT, so every test that extends it reaches the browser
+ *   wherever '.devtools/browser' put it.
+ * - The env entry is not forced, so a project whose tests do not extend that
+ *   base class can still export its own MINK_DRIVER_ARGS_WEBDRIVER.
+ *
+ * Dropping either one leaves the tests dialling 4444 while the browser
+ * listens elsewhere, which surfaces only on a machine where 4444 is busy.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class PhpunitWebdriverEndpointTest extends UnitTestCase {
+
+  #[DataProvider('dataProviderPhpunitConfig')]
+  public function testEndpointIsOverridableFromTheEnvironment(string $path): void {
+    $element = self::minkDriverArgsElement($path);
+
+    $this->assertFalse($element->hasAttribute('force'), sprintf('%s forces MINK_DRIVER_ARGS_WEBDRIVER, so an exported value cannot override the hardcoded endpoint.', basename($path)));
+  }
+
+  #[DataProvider('dataProviderPhpunitConfig')]
+  public function testEndpointLiteralIsTheDefaultPort(string $path): void {
+    $args = json_decode(self::minkDriverArgsElement($path)->getAttribute('value'), TRUE);
+
+    $this->assertIsArray($args, sprintf('%s does not hold a JSON array in MINK_DRIVER_ARGS_WEBDRIVER.', basename($path)));
+    $this->assertArrayHasKey(2, $args, sprintf('%s omits the WebDriver endpoint from MINK_DRIVER_ARGS_WEBDRIVER.', basename($path)));
+    $this->assertSame('http://localhost:4444', $args[2], sprintf('%s must carry the default WebDriver endpoint; anything else desynchronises from resolve_webdriver_port().', basename($path)));
+  }
+
+  public function testBaseClassRewritesEndpointFromResolvedPort(): void {
+    $path = dirname(__DIR__, 4) . '/tests/src/FunctionalJavascript/YourExtensionFunctionalJavascriptTestBase.php';
+    $contents = file_get_contents($path);
+
+    $this->assertIsString($contents);
+    $this->assertStringContainsString('function getMinkDriverArgs()', $contents, 'The base class must override getMinkDriverArgs() to apply the resolved WebDriver port.');
+    $this->assertStringContainsString("getenv('WEBDRIVER_PORT')", $contents, 'The base class must read WEBDRIVER_PORT; without it the endpoint stays pinned to the phpunit.xml literal.');
+  }
+
+  /**
+   * @return \Iterator<string, array{path: string}>
+   *   Path of each shipped PHPUnit configuration file.
+   */
+  public static function dataProviderPhpunitConfig(): \Iterator {
+    $root = dirname(__DIR__, 4);
+
+    foreach (['phpunit.xml', 'phpunit.d10.xml'] as $file) {
+      yield $file => ['path' => $root . '/' . $file];
+    }
+  }
+
+  /**
+   * Get the MINK_DRIVER_ARGS_WEBDRIVER env element from a PHPUnit config.
+   */
+  protected static function minkDriverArgsElement(string $path): \DOMElement {
+    $document = new \DOMDocument();
+    self::assertTrue($document->load($path), sprintf('Unable to parse %s.', $path));
+
+    $nodes = (new \DOMXPath($document))->query('//php/env[@name="MINK_DRIVER_ARGS_WEBDRIVER"]');
+    self::assertInstanceOf(\DOMNodeList::class, $nodes);
+    self::assertSame(1, $nodes->length, sprintf('%s must declare exactly one MINK_DRIVER_ARGS_WEBDRIVER entry.', basename($path)));
+
+    $element = $nodes->item(0);
+    self::assertInstanceOf(\DOMElement::class, $element);
+
+    return $element;
+  }
+
+}

--- a/.scaffold/tests/src/Unit/PhpunitWebdriverEndpointTest.php
+++ b/.scaffold/tests/src/Unit/PhpunitWebdriverEndpointTest.php
@@ -30,20 +30,36 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('p0')]
 final class PhpunitWebdriverEndpointTest extends UnitTestCase {
 
-  #[DataProvider('dataProviderPhpunitConfig')]
+  #[DataProvider('dataProviderEndpointIsOverridableFromTheEnvironment')]
   public function testEndpointIsOverridableFromTheEnvironment(string $path): void {
     $element = self::minkDriverArgsElement($path);
 
     $this->assertFalse($element->hasAttribute('force'), sprintf('%s forces MINK_DRIVER_ARGS_WEBDRIVER, so an exported value cannot override the hardcoded endpoint.', basename($path)));
   }
 
-  #[DataProvider('dataProviderPhpunitConfig')]
+  /**
+   * @return \Iterator<string, array{path: string}>
+   *   Path of each shipped PHPUnit configuration file.
+   */
+  public static function dataProviderEndpointIsOverridableFromTheEnvironment(): \Iterator {
+    yield from self::phpunitConfigPaths();
+  }
+
+  #[DataProvider('dataProviderEndpointLiteralIsTheDefaultPort')]
   public function testEndpointLiteralIsTheDefaultPort(string $path): void {
     $args = json_decode(self::minkDriverArgsElement($path)->getAttribute('value'), TRUE);
 
     $this->assertIsArray($args, sprintf('%s does not hold a JSON array in MINK_DRIVER_ARGS_WEBDRIVER.', basename($path)));
     $this->assertArrayHasKey(2, $args, sprintf('%s omits the WebDriver endpoint from MINK_DRIVER_ARGS_WEBDRIVER.', basename($path)));
     $this->assertSame('http://localhost:4444', $args[2], sprintf('%s must carry the default WebDriver endpoint; anything else desynchronises from resolve_webdriver_port().', basename($path)));
+  }
+
+  /**
+   * @return \Iterator<string, array{path: string}>
+   *   Path of each shipped PHPUnit configuration file.
+   */
+  public static function dataProviderEndpointLiteralIsTheDefaultPort(): \Iterator {
+    yield from self::phpunitConfigPaths();
   }
 
   public function testBaseClassRewritesEndpointFromResolvedPort(): void {
@@ -56,10 +72,12 @@ final class PhpunitWebdriverEndpointTest extends UnitTestCase {
   }
 
   /**
+   * Get the path of each shipped PHPUnit configuration file.
+   *
    * @return \Iterator<string, array{path: string}>
-   *   Path of each shipped PHPUnit configuration file.
+   *   Configuration file name mapped to its absolute path.
    */
-  public static function dataProviderPhpunitConfig(): \Iterator {
+  protected static function phpunitConfigPaths(): \Iterator {
     $root = dirname(__DIR__, 4);
 
     foreach (['phpunit.xml', 'phpunit.d10.xml'] as $file) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Run each tool through its `ahoy` wrapper, never the binary directly:
 - `WEBSERVER_PORT` - Development server port. Auto-discovered from range 8000-8099 and written to `.env` if not already set
 <!-- #;< DEV_FUNCTIONAL_JAVASCRIPT -->
 - `WEBDRIVER_BACKEND` - FunctionalJavascript WebDriver backend: `chromedriver` (default, drives the locally installed Chrome with no Docker) or `selenium` (Docker container)
-- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously
+- `WEBDRIVER_PORT` - Port for the WebDriver endpoint (both backends). Auto-discovered from 4444 and written to `.env` if not already set, so several projects can run FunctionalJavascript tests simultaneously. The endpoint in `phpunit.xml` is the default for port 4444; tests reach the resolved port because the FunctionalJavascript base class rewrites the port in `MINK_DRIVER_ARGS_WEBDRIVER` from this variable, so FunctionalJavascript tests must extend that base class (or export their own `MINK_DRIVER_ARGS_WEBDRIVER`)
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 - `GITHUB_TOKEN` - GitHub API token to avoid rate limits
 - `DEBUG` - Set to `1` to stream the full output of the underlying commands (Composer, npm, Drush). By default this output is suppressed and shown only when a command fails

--- a/CONTRIBUTING.dist.md
+++ b/CONTRIBUTING.dist.md
@@ -192,6 +192,15 @@ WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
 ahoy browser-stop
 ```
 
+Either backend gets its own WebDriver port: a free one is claimed starting
+at 4444 and stored in `.env`, so several projects can run FunctionalJavascript
+tests at the same time. Set `WEBDRIVER_PORT` to pin a specific one. Tests
+reach the claimed port because the base class applies it to the WebDriver
+endpoint, so extend `YourExtensionFunctionalJavascriptTestBase` rather than
+`WebDriverTestBase` directly - a test that bypasses it keeps the default
+endpoint from `phpunit.xml` unless it exports its own
+`MINK_DRIVER_ARGS_WEBDRIVER`.
+
 <!-- #;> DEV_FUNCTIONAL_JAVASCRIPT -->
 <!-- #;< DEV_PHPUNIT -->
 ### Running specific tests

--- a/README.md
+++ b/README.md
@@ -389,6 +389,15 @@ WEBDRIVER_BACKEND=selenium ahoy test-functional-javascript
 ahoy browser-stop
 ```
 
+Either backend gets its own WebDriver port: a free one is claimed starting
+at 4444 and stored in `.env`, so several projects can run FunctionalJavascript
+tests at the same time. Set `WEBDRIVER_PORT` to pin a specific one. Tests
+reach the claimed port because the base class applies it to the WebDriver
+endpoint, so extend `YourExtensionFunctionalJavascriptTestBase` rather than
+`WebDriverTestBase` directly - a test that bypasses it keeps the default
+endpoint from `phpunit.xml` unless it exports its own
+`MINK_DRIVER_ARGS_WEBDRIVER`.
+
 ![Test process](.scaffold/assets/test.svg)
 
 ### Running specific tests

--- a/phpunit.d10.xml
+++ b/phpunit.d10.xml
@@ -64,7 +64,13 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=''/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
+        <!-- The endpoint below is the default. Both WebDriver backends bind the
+          per-project port resolved by '.devtools/browser' (WEBDRIVER_PORT), so
+          the FunctionalJavascript base class replaces the port in this value at
+          run time. Tests that do not extend that base class can export their own
+          MINK_DRIVER_ARGS_WEBDRIVER, which takes precedence over this entry.
+        -->
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]'/>
     </php>
     <testsuites>
         <testsuite name="unit">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -54,7 +54,13 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=""/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "goog:chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
+        <!-- The endpoint below is the default. Both WebDriver backends bind the
+          per-project port resolved by '.devtools/browser' (WEBDRIVER_PORT), so
+          the FunctionalJavascript base class replaces the port in this value at
+          run time. Tests that do not extend that base class can export their own
+          MINK_DRIVER_ARGS_WEBDRIVER, which takes precedence over this entry.
+        -->
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]'/>
     </php>
     <extensions>
         <!-- Functional tests HTML output logging. -->


### PR DESCRIPTION
Closes #508

## Summary

Issue #508 reported two halves of one problem: `phpunit.xml` force-pins `MINK_DRIVER_ARGS_WEBDRIVER` to `http://localhost:4444` so the resolved `WEBDRIVER_PORT` is discarded, and `selenium_start()` never auto-discovers a free port. The second half is correct. The first is not accurate as filed: `YourExtensionFunctionalJavascriptTestBase::getMinkDriverArgs()` decodes the forced value and replaces the endpoint with the resolved `WEBDRIVER_PORT`, and that override landed in the same PR as the auto-discovery, so the reported reproduction does not fail for any test extending the shipped base class.

What was genuinely broken is fixed here. Selenium pinned 4444, which broke the free-port contract for that backend and let `webdriver_ready(4444)` mistake an unrelated WebDriver for the container. `force="true"` left no way to override the driver args from the environment, so a test that does not descend from the shipped base class had no escape hatch, contrary to the env -> `.env` -> default precedence every other setting follows. Making Selenium per-project then exposed a second collision: the container name was the fixed string `selenium`, so a second project's `docker rm -f` destroyed the first project's still-running container.

## Changes

**Selenium auto-discovers its port.** `selenium_start()` in `.devtools/browser` calls `resolve_webdriver_port(auto_discover: TRUE)`, claiming a free port from 4444 and persisting it to `.env` exactly as the chromedriver backend already did. `browser_stop()` still resolves without discovery, so it targets the endpoint its matching start created.

**The Selenium container name is scoped to the port.** A new `selenium_container()` helper names the container `selenium-<port>` rather than the fixed `selenium`. Both `selenium_start()` and `browser_stop()` use it, so projects running side by side no longer remove or overwrite each other's container.

**`MINK_DRIVER_ARGS_WEBDRIVER` is no longer forced.** `phpunit.xml` and `phpunit.d10.xml` drop `force="true"` and gain a comment recording that the literal is the default for port 4444 and that the base class substitutes the resolved port at run time. Tests that do not extend that base class can now export their own value.

**CI proves the endpoint follows the resolved port.** `.github/workflows/scaffold-test.yml` sets `WEBDRIVER_PORT` for both backends instead of only chromedriver. The selenium legs pin 4444 because the container step publishes that port; the chromedriver legs deliberately use 4455. Since p3/p4 run `ahoy`/`make test-functional-javascript` for real, a green run is now an executed assertion that Mink reaches the browser on the resolved port rather than the `phpunit.xml` literal.

**Documentation matches the implementation.** `AGENTS.md`, `README.md` and `CONTRIBUTING.dist.md` describe auto-discovery for both backends, and state that FunctionalJavascript tests must extend the shipped base class (or export their own `MINK_DRIVER_ARGS_WEBDRIVER`) to reach the resolved port.

**Tests.** `BrowserTest` gains `testBrowserSeleniumStartAutoDiscoversPort()` and `testBrowserChromedriverStartAutoDiscoversPort()`, covering the previously untested case where 4444 is occupied and `.env` carries no port - the gap that let this ship unnoticed - plus assertions that the container name is port-scoped on both start and stop. The new `PhpunitWebdriverEndpointTest` asserts both shipped PHPUnit configs leave `MINK_DRIVER_ARGS_WEBDRIVER` overridable and keep `http://localhost:4444` as the documented default, and that the base class still rewrites the endpoint from `WEBDRIVER_PORT`. The `init.php` snapshot fixtures are regenerated to match.

## Screenshots

N/A

## Before / After

```
BEFORE - one port and one container name, shared by every project

  ahoy test-functional-javascript
    └─ browser start
         └─ selenium_start()
              ├─ resolve_webdriver_port()     ──> always 4444
              └─ docker run --name selenium   ──> fixed name

  Project A ──> container "selenium" on :4444
  Project B ──> docker rm -f "selenium"  ──> removes A's container,
                then binds :4444 itself

  phpunit.xml: MINK_DRIVER_ARGS_WEBDRIVER force="true"
    └─ http://localhost:4444, and no environment value can override it


AFTER - each project claims a free port and names its container after it

  ahoy test-functional-javascript
    └─ browser start
         └─ selenium_start()
              ├─ resolve_webdriver_port(auto_discover: TRUE)
              │                               ──> first free port from 4444
              └─ docker run --name selenium-<port>
                                              ──> port-scoped name

  Project A ──> container "selenium-4444" on :4444
  Project B ──> container "selenium-4445" on :4445
                rm -f touches only its own container

  phpunit.xml: MINK_DRIVER_ARGS_WEBDRIVER (not forced)
    └─ http://localhost:4444 is the default; the FunctionalJavascript base
       class rewrites the port from WEBDRIVER_PORT, and a test that does not
       extend it can export its own value
```
