### PR TITLE
[#511] Stopped 'login' re-inlining the 'drush' invocation in both wrappers.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -47,12 +47,12 @@ commands:
 
   drush:
     usage: Run Drush command.
-    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" $*
+    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" "$@"
 
   login:
     usage: Login to a website.
     cmd: |
-      url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
+      url="$(ahoy drush uli)"
       printf '%s\n' "$url"
       if [ -n "$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$url"; fi
 

--- a/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.ahoy.yml
@@ -47,12 +47,12 @@ commands:
 
   drush:
     usage: Run Drush command.
-    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" $*
+    cmd: build/vendor/bin/drush -l "$(./.devtools/info site-url)" "$@"
 
   login:
     usage: Login to a website.
     cmd: |
-      url="$(build/vendor/bin/drush -l "$(./.devtools/info site-url)" uli)"
+      url="$(ahoy drush uli)"
       printf '%s\n' "$url"
       if [ -n "$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$url"; fi
 

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/Makefile
@@ -16,9 +16,9 @@ WEBSERVER_PORT ?= 8000
 
 # Resolve the site URL through the shared `.devtools/info` resolver so `drush`
 # and `login` report the same tunnel-aware URL as start, provision, and info
-# (see resolve_site_url()). Lazy `=` so the probe runs only when drush/login
-# are invoked.
-DRUSH_URI = $(shell ./.devtools/info site-url)
+# (see resolve_site_url()). Lazy `=` so the probe runs only when the recipes
+# that expand it are invoked.
+DRUSH = build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"
 
 # Test environment exported to every recipe (see the blanket `export` above),
 # matching what the ahoy entrypoint exports for every command, so `make
@@ -111,10 +111,10 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
 endif
 
 drush:
-	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
+	$(DRUSH) $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
+	@url="$$($(DRUSH) uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/Makefile
@@ -16,9 +16,9 @@ WEBSERVER_PORT ?= 8000
 
 # Resolve the site URL through the shared `.devtools/info` resolver so `drush`
 # and `login` report the same tunnel-aware URL as start, provision, and info
-# (see resolve_site_url()). Lazy `=` so the probe runs only when drush/login
-# are invoked.
-DRUSH_URI = $(shell ./.devtools/info site-url)
+# (see resolve_site_url()). Lazy `=` so the probe runs only when the recipes
+# that expand it are invoked.
+DRUSH = build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"
 
 # Test environment exported to every recipe (see the blanket `export` above),
 # matching what the ahoy entrypoint exports for every command, so `make
@@ -111,10 +111,10 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
 endif
 
 drush:
-	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
+	$(DRUSH) $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
+	@url="$$($(DRUSH) uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_both_wrappers/Makefile
@@ -16,9 +16,9 @@ WEBSERVER_PORT ?= 8000
 
 # Resolve the site URL through the shared `.devtools/info` resolver so `drush`
 # and `login` report the same tunnel-aware URL as start, provision, and info
-# (see resolve_site_url()). Lazy `=` so the probe runs only when drush/login
-# are invoked.
-DRUSH_URI = $(shell ./.devtools/info site-url)
+# (see resolve_site_url()). Lazy `=` so the probe runs only when the recipes
+# that expand it are invoked.
+DRUSH = build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"
 
 # Test environment exported to every recipe (see the blanket `export` above),
 # matching what the ahoy entrypoint exports for every command, so `make
@@ -111,10 +111,10 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
 endif
 
 drush:
-	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
+	$(DRUSH) $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
+	@url="$$($(DRUSH) uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/gha_makefile/Makefile
+++ b/.scaffold/tests/fixtures/init/gha_makefile/Makefile
@@ -16,9 +16,9 @@ WEBSERVER_PORT ?= 8000
 
 # Resolve the site URL through the shared `.devtools/info` resolver so `drush`
 # and `login` report the same tunnel-aware URL as start, provision, and info
-# (see resolve_site_url()). Lazy `=` so the probe runs only when drush/login
-# are invoked.
-DRUSH_URI = $(shell ./.devtools/info site-url)
+# (see resolve_site_url()). Lazy `=` so the probe runs only when the recipes
+# that expand it are invoked.
+DRUSH = build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"
 
 # Test environment exported to every recipe (see the blanket `export` above),
 # matching what the ahoy entrypoint exports for every command, so `make
@@ -111,10 +111,10 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
 endif
 
 drush:
-	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
+	$(DRUSH) $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
+	@url="$$($(DRUSH) uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/.scaffold/tests/fixtures/init/no_tools/Makefile
+++ b/.scaffold/tests/fixtures/init/no_tools/Makefile
@@ -16,9 +16,9 @@ WEBSERVER_PORT ?= 8000
 
 # Resolve the site URL through the shared `.devtools/info` resolver so `drush`
 # and `login` report the same tunnel-aware URL as start, provision, and info
-# (see resolve_site_url()). Lazy `=` so the probe runs only when drush/login
-# are invoked.
-DRUSH_URI = $(shell ./.devtools/info site-url)
+# (see resolve_site_url()). Lazy `=` so the probe runs only when the recipes
+# that expand it are invoked.
+DRUSH = build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"
 
 # Test environment exported to every recipe (see the blanket `export` above),
 # matching what the ahoy entrypoint exports for every command, so `make
@@ -101,10 +101,10 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
 endif
 
 drush:
-	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
+	$(DRUSH) $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
+	@url="$$($(DRUSH) uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ WEBSERVER_PORT ?= 8000
 
 # Resolve the site URL through the shared `.devtools/info` resolver so `drush`
 # and `login` report the same tunnel-aware URL as start, provision, and info
-# (see resolve_site_url()). Lazy `=` so the probe runs only when drush/login
-# are invoked.
-DRUSH_URI = $(shell ./.devtools/info site-url)
+# (see resolve_site_url()). Lazy `=` so the probe runs only when the recipes
+# that expand it are invoked.
+DRUSH = build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"
 
 # Test environment exported to every recipe (see the blanket `export` above),
 # matching what the ahoy entrypoint exports for every command, so `make
@@ -127,10 +127,10 @@ ifeq (drush,$(firstword $(MAKECMDGOALS)))
 endif
 
 drush:
-	build/vendor/bin/drush -l "$(DRUSH_URI)" $(DRUSH_RUN_ARGS)
+	$(DRUSH) $(DRUSH_RUN_ARGS)
 
 login:
-	@url="$$(build/vendor/bin/drush -l "$(DRUSH_URI)" uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
+	@url="$$($(DRUSH) uli)"; printf '%s\n' "$$url"; if [ -n "$$LOGIN_QRCODE" ]; then ./.devtools/qrcode "$$url"; fi
 
 provision:
 	./.devtools/provision


### PR DESCRIPTION
Closes #511

## Summary

The `login` command re-inlined the Drush binary path and the site-URL resolution that the `drush` command sitting directly above it already encapsulated. The duplication existed in both wrapper twins, so the same invocation was written four times across the scaffold, and it put a raw `build/vendor/bin/drush` call in the very files that teach consumers to use the wrappers instead of the tool binaries.

Each wrapper now spells the invocation once. `ahoy login` calls the sibling `ahoy drush` command, reusing the nesting pattern `lint` already uses for `ahoy title`. The `Makefile` cannot nest as neatly, because its `drush` target consumes `MAKECMDGOALS` through `DRUSH_RUN_ARGS` and a recursive `$(MAKE) drush uli` would be awkward, so the whole invocation moves into a `DRUSH` variable that both targets expand.

Behaviour is unchanged. Changing how Drush is located, or how the site URL is resolved, is now a one-line edit per wrapper instead of a four-site sweep with a silent failure mode where `login` reports a different URL than `drush`.

## Changes

### `.ahoy.yml`

- `login` resolves the one-time login URL with `ahoy drush uli` instead of re-inlining `build/vendor/bin/drush -l "$(./.devtools/info site-url)"`.
- `drush` forwards its arguments as `"$@"` rather than unquoted `$*`, so an argument containing spaces survives as one argument. This matches the `test`, `test-unit`, `test-kernel` and `test-functional` commands, which already use `"$@"`. Before this, `ahoy drush php:eval 'print "a b c"'` word-split its snippet; now it does not.

### `Makefile`

- The `DRUSH_URI` variable becomes `DRUSH`, holding the complete invocation (`build/vendor/bin/drush -l "$(shell ./.devtools/info site-url)"`) rather than just the URL. It stays recursively expanded, so the `.devtools/info` probe still runs only when a recipe that expands it is invoked.
- The `drush` and `login` targets both expand `$(DRUSH)`, so neither names the binary or the `-l` resolution itself.

### Snapshots

- Regenerated the `InitTest` fixtures for the six datasets that embed `.ahoy.yml` or `Makefile`.

## Verification

Exercised against a real assembled build, in both wrappers:

- `make drush status` and `ahoy drush status --field=drupal-version` return the expected values.
- `make login` and `ahoy login` print a working one-time login link.
- `ahoy drush php:eval 'print "a b c"'` prints `a b c`, confirming the `"$@"` change.

Gates: `composer --working-dir=.scaffold/tests lint` (PHPCS, PHPStan level 9, Rector) clean; `--group=p0` 471 tests green; `--filter=InitTest` 23 datasets green. The `p3` (`AhoyTest`) and `p4` (`MakeTest`) suites already drive `drush status` and `login` through both wrappers end to end against a provisioned site, so this change is covered there without new tests.

## Before / After

```
BEFORE - the invocation written four times

  .ahoy.yml                                Makefile
  ┌────────────────────────────────┐       ┌────────────────────────────────┐
  │ drush:                         │       │ DRUSH_URI = $(shell info ...)  │
  │   build/vendor/bin/drush       │       │                                │
  │     -l "$(info site-url)" $*   │       │ drush:                         │
  │                                │       │   build/vendor/bin/drush       │
  │ login:                         │       │     -l "$(DRUSH_URI)" $(ARGS)  │
  │   build/vendor/bin/drush       │       │                                │
  │     -l "$(info site-url)" uli  │       │ login:                         │
  │   printf                       │       │   build/vendor/bin/drush       │
  │   qrcode                       │       │     -l "$(DRUSH_URI)" uli      │
  └────────────────────────────────┘       │   printf; qrcode               │
                                           └────────────────────────────────┘
   binary path + -l resolution: 2 sites     binary path + -l resolution: 2 sites
                                            (URL shared, binary path repeated)


AFTER - once per wrapper

  .ahoy.yml                                Makefile
  ┌────────────────────────────────┐       ┌────────────────────────────────┐
  │ drush:                         │       │ DRUSH = build/vendor/bin/drush │
  │   build/vendor/bin/drush       │◄──┐   │   -l "$(shell info site-url)"  │
  │     -l "$(info site-url)" "$@" │   │   │                          ▲     │
  │                                │   │   │ drush:                   │     │
  │ login:                         │   │   │   $(DRUSH) $(ARGS) ──────┤     │
  │   url="$(ahoy drush uli)" ─────┼───┘   │                          │     │
  │   printf                       │       │ login:                   │     │
  │   qrcode                       │       │   url="$$($(DRUSH) uli)"─┘     │
  └────────────────────────────────┘       │   printf; qrcode               │
                                           └────────────────────────────────┘
   binary path + -l resolution: 1 site      binary path + -l resolution: 1 site
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Deduplicate Drush invocations in `.ahoy.yml` and `Makefile`.
- Reuse `ahoy drush` for the `login` command.
- Share the complete Drush invocation through the `DRUSH` Make variable.
- Regenerate six `InitTest` snapshot datasets.

## Verification

- Verified wrapper commands.
- Ran linting, static analysis, and test suites.

Possibly related to `#511`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->