### PR TITLE
[#524] Declared the CI runner roles centrally so each tool step reads its own flag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,22 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            #;< DEV_JEST
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            #;> DEV_JEST
+            #;< DEV_PHPUNIT
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            #;> DEV_PHPUNIT
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -118,14 +134,18 @@ job-test: &job-test
     #;< DEV_JEST
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
     #;> DEV_JEST
 
     #;< DEV_PHPUNIT
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -146,6 +166,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,17 @@ jobs:
     env:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}
 
+      # Which tools run on this runner. Each matrix leg is a runner of its own
+      # covering one Drupal and PHP pair, so every tool runs on all of them.
+      CI_RUNNER_INDEX: ${{ strategy.job-index }}
+      CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+      #;< DEV_JEST
+      CI_IS_JEST_RUNNER: true
+      #;> DEV_JEST
+      #;< DEV_PHPUNIT
+      CI_IS_PHPUNIT_RUNNER: true
+      #;> DEV_PHPUNIT
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -221,7 +232,7 @@ jobs:
 
       #;< DEV_JEST
       - name: Run JavaScript tests
-        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
+        if: ${{ env.CI_IS_JEST_RUNNER == 'true' && hashFiles('build/node_modules/.package-lock.json') != '' }}
         working-directory: build
         run: npm test
         continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
@@ -229,6 +240,7 @@ jobs:
 
       #;< DEV_PHPUNIT
       - name: Run tests
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         working-directory: build
         run: php -d pcov.directory=.. vendor/bin/phpunit
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
@@ -241,7 +253,7 @@ jobs:
 
       - name: Upload browser output as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: always()
+        if: ${{ always() && env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         with:
           name: Artifacts (${{ matrix.name }})
           path: .logs/browser_output
@@ -249,6 +261,7 @@ jobs:
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         with:
           name: ${{ github.job }}-code-coverage-report-${{ matrix.name }}
           path: ./.logs/coverage
@@ -257,7 +270,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' && env.CODECOV_TOKEN != '' }}
         with:
           directory: ./.logs/coverage
           fail_ci_if_error: true

--- a/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/_baseline/.github/workflows/test.yml
@@ -147,6 +147,13 @@ jobs:
     env:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}
 
+      # Which tools run on this runner. Each matrix leg is a runner of its own
+      # covering one Drupal and PHP pair, so every tool runs on all of them.
+      CI_RUNNER_INDEX: ${{ strategy.job-index }}
+      CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+      CI_IS_JEST_RUNNER: true
+      CI_IS_PHPUNIT_RUNNER: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@__HASH__ # __VERSION__
@@ -198,12 +205,13 @@ jobs:
         run: .devtools/provision
 
       - name: Run JavaScript tests
-        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
+        if: ${{ env.CI_IS_JEST_RUNNER == 'true' && hashFiles('build/node_modules/.package-lock.json') != '' }}
         working-directory: build
         run: npm test
         continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Run tests
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         working-directory: build
         run: php -d pcov.directory=.. vendor/bin/phpunit
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
@@ -214,7 +222,7 @@ jobs:
 
       - name: Upload browser output as an artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__
-        if: always()
+        if: ${{ always() && env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         with:
           name: Artifacts (${{ matrix.name }})
           path: .logs/browser_output
@@ -222,6 +230,7 @@ jobs:
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         with:
           name: ${{ github.job }}-code-coverage-report-${{ matrix.name }}
           path: ./.logs/coverage
@@ -230,7 +239,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@__HASH__ # __VERSION__
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' && env.CODECOV_TOKEN != '' }}
         with:
           directory: ./.logs/coverage
           fail_ci_if_error: true

--- a/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci/.circleci/config.yml
@@ -64,6 +64,18 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -103,12 +115,16 @@ job-test: &job-test
 
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
 
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -127,6 +143,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_both_wrappers/.circleci/config.yml
@@ -64,6 +64,18 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -103,12 +115,16 @@ job-test: &job-test
 
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
 
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -127,6 +143,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_d10_only/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_d10_only/.circleci/config.yml
@@ -64,6 +64,18 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -103,12 +115,16 @@ job-test: &job-test
 
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
 
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -127,6 +143,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_d11_only/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_d11_only/.circleci/config.yml
@@ -64,6 +64,18 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -103,12 +115,16 @@ job-test: &job-test
 
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
 
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -127,6 +143,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_makefile/.circleci/config.yml
@@ -64,6 +64,18 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -103,12 +115,16 @@ job-test: &job-test
 
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
 
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -127,6 +143,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
+++ b/.scaffold/tests/fixtures/init/circleci_no_command_wrapper/.circleci/config.yml
@@ -64,6 +64,18 @@ job-test: &job-test
     - checkout
 
     - run:
+        name: Set test runner roles
+        command: |
+          # Which tools run on this node. Nodes slice a single job, so a tool
+          # that only needs to run once is pinned to node 0.
+          {
+            echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+            echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+            echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+          } >> "${BASH_ENV}"
+
+    - run:
         name: Upgrade sqlite3
         command: |
           wget https://www.sqlite.org/2024/sqlite-autoconf-3450300.tar.gz -O /tmp/sqlite.tar.gz
@@ -103,12 +115,16 @@ job-test: &job-test
 
     - run:
         name: Run JavaScript tests
-        command: '[ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]'
+        command: |
+          [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+          [ ! -d node_modules ] || npm test || [ "${CI_NODEJS_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
 
     - run:
         name: Run tests
-        command: php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
+        command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+          php -d pcov.directory=.. vendor/bin/phpunit || [ "${CI_TEST_IGNORE_FAILURE:-0}" -eq 1 ]
         working_directory: build
         environment:
           BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
@@ -127,6 +143,7 @@ job-test: &job-test
     - run:
         name: Upload code coverage reports to Codecov
         command: |
+          [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
           if [ -z "${CIRCLE_TAG-}" ] && [ -n "${CODECOV_TOKEN-}" ] && [ -d .logs/coverage/phpunit ]; then
             curl -Os https://cli.codecov.io/latest/linux/codecov && sudo chmod +x codecov
             ./codecov --verbose upload-process --fail-on-error -n "circleci-$CIRCLE_JOB" -s .logs/coverage

--- a/.scaffold/tests/fixtures/init/no_functional_javascript/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_functional_javascript/.github/workflows/test.yml
@@ -10,7 +10,7 @@
  
      name: ${{ matrix.name }}
  
-@@ -210,7 +205,6 @@
+@@ -218,7 +213,6 @@
          env:
            BROWSERTEST_OUTPUT_DIRECTORY: ../.logs/browser_output
            SIMPLETEST_DB: sqlite://tmp/db.sqlite

--- a/.scaffold/tests/fixtures/init/no_jest/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_jest/.github/workflows/test.yml
@@ -1,12 +1,20 @@
-@@ -197,11 +197,6 @@
+@@ -151,7 +151,6 @@
+       # covering one Drupal and PHP pair, so every tool runs on all of them.
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+-      CI_IS_JEST_RUNNER: true
+       CI_IS_PHPUNIT_RUNNER: true
+ 
+     steps:
+@@ -204,11 +203,6 @@
        - name: Provision site
          run: .devtools/provision
  
 -      - name: Run JavaScript tests
--        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
+-        if: ${{ env.CI_IS_JEST_RUNNER == 'true' && hashFiles('build/node_modules/.package-lock.json') != '' }}
 -        working-directory: build
 -        run: npm test
 -        continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
  
        - name: Run tests
-         working-directory: build
+         if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}

--- a/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_phpunit/.github/workflows/test.yml
@@ -10,11 +10,20 @@
  
      name: ${{ matrix.name }}
  
-@@ -203,37 +198,3 @@
+@@ -152,7 +147,6 @@
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: true
+-      CI_IS_PHPUNIT_RUNNER: true
+ 
+     steps:
+       - name: Checkout code
+@@ -210,39 +204,3 @@
          run: npm test
          continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
  
 -      - name: Run tests
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        working-directory: build
 -        run: php -d pcov.directory=.. vendor/bin/phpunit
 -        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
@@ -25,7 +34,7 @@
 -
 -      - name: Upload browser output as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__
--        if: always()
+-        if: ${{ always() && env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        with:
 -          name: Artifacts (${{ matrix.name }})
 -          path: .logs/browser_output
@@ -33,6 +42,7 @@
 -
 -      - name: Upload coverage report as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        with:
 -          name: ${{ github.job }}-code-coverage-report-${{ matrix.name }}
 -          path: ./.logs/coverage
@@ -41,7 +51,7 @@
 -
 -      - name: Upload coverage report to Codecov
 -        uses: codecov/codecov-action@__HASH__ # __VERSION__
--        if: ${{ env.CODECOV_TOKEN != '' }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' && env.CODECOV_TOKEN != '' }}
 -        with:
 -          directory: ./.logs/coverage
 -          fail_ci_if_error: true

--- a/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
+++ b/.scaffold/tests/fixtures/init/no_tools/.github/workflows/test.yml
@@ -52,17 +52,27 @@
  
      name: ${{ matrix.name }}
  
-@@ -197,43 +168,4 @@
+@@ -151,8 +122,6 @@
+       # covering one Drupal and PHP pair, so every tool runs on all of them.
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+-      CI_IS_JEST_RUNNER: true
+-      CI_IS_PHPUNIT_RUNNER: true
+ 
+     steps:
+       - name: Checkout code
+@@ -204,45 +173,4 @@
        - name: Provision site
          run: .devtools/provision
  
 -      - name: Run JavaScript tests
--        if: ${{ hashFiles('build/node_modules/.package-lock.json') != '' }}
+-        if: ${{ env.CI_IS_JEST_RUNNER == 'true' && hashFiles('build/node_modules/.package-lock.json') != '' }}
 -        working-directory: build
 -        run: npm test
 -        continue-on-error: ${{ vars.CI_NODEJS_TEST_IGNORE_FAILURE == '1' }}
  
 -      - name: Run tests
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        working-directory: build
 -        run: php -d pcov.directory=.. vendor/bin/phpunit
 -        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
@@ -73,7 +83,7 @@
 -
 -      - name: Upload browser output as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__
--        if: always()
+-        if: ${{ always() && env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        with:
 -          name: Artifacts (${{ matrix.name }})
 -          path: .logs/browser_output
@@ -81,6 +91,7 @@
 -
 -      - name: Upload coverage report as an artifact
 -        uses: actions/upload-artifact@__HASH__ # __VERSION__
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        with:
 -          name: ${{ github.job }}-code-coverage-report-${{ matrix.name }}
 -          path: ./.logs/coverage
@@ -89,7 +100,7 @@
 -
 -      - name: Upload coverage report to Codecov
 -        uses: codecov/codecov-action@__HASH__ # __VERSION__
--        if: ${{ env.CODECOV_TOKEN != '' }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' && env.CODECOV_TOKEN != '' }}
 -        with:
 -          directory: ./.logs/coverage
 -          fail_ci_if_error: true

--- a/.scaffold/tests/src/Unit/CiRunnerVariablesTest.php
+++ b/.scaffold/tests/src/Unit/CiRunnerVariablesTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\drupal_extension_scaffold\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests the runner role variables that decide which tools run where.
+ *
+ * Each tool reads a `CI_IS_<TOOL>_RUNNER` flag declared once at the top of the
+ * job. A flag that no step reads leaves the tool running everywhere, and a flag
+ * whose declaration outlives its `#;< DEV_<TOOL>` block leaves a name nothing
+ * consumes. Both stay valid YAML, so no linter reports either.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment.Missing
+ * phpcs:disable Drupal.Commenting.DocComment.MissingShort
+ */
+#[Group('p0')]
+final class CiRunnerVariablesTest extends UnitTestCase {
+
+  /**
+   * The names that anchor the declaration when every tool is removed.
+   */
+  protected const ANCHORS = ['CI_RUNNER_INDEX', 'CI_RUNNER_TOTAL'];
+
+  public function testGithubActionsFlagsAreReadByAStep(): void {
+    $path = self::rootDir() . '/.github/workflows/test.yml';
+    $contents = file_get_contents($path);
+    $this->assertIsString($contents);
+
+    $parsed = Yaml::parse($contents);
+    $this->assertIsArray($parsed);
+    $this->assertArrayHasKey('jobs', $parsed);
+    $this->assertIsArray($parsed['jobs']);
+
+    $flags = [];
+    $unread = [];
+
+    foreach ($parsed['jobs'] as $job_name => $job) {
+      if (!is_array($job) || !is_array($job['env'] ?? NULL)) {
+        continue;
+      }
+
+      $conditions = '';
+      foreach (is_array($job['steps'] ?? NULL) ? $job['steps'] : [] as $step) {
+        $conditions .= is_array($step) && is_string($step['if'] ?? NULL) ? $step['if'] : '';
+      }
+
+      foreach (array_keys($job['env']) as $name) {
+        if (!is_string($name) || preg_match('/^CI_IS_[A-Z0-9]+_RUNNER$/', $name) !== 1) {
+          continue;
+        }
+
+        $flags[] = $name;
+
+        if (!str_contains($conditions, 'env.' . $name)) {
+          $unread[] = sprintf('%s: %s', $job_name, $name);
+        }
+      }
+    }
+
+    $this->assertNotSame([], $flags, 'test.yml declares no runner flags.');
+    $this->assertSame([], $unread, sprintf('test.yml declares runner flags that no step reads: %s', implode(', ', $unread)));
+  }
+
+  public function testCircleciFlagsAreGuardedByAStep(): void {
+    $path = self::rootDir() . '/.circleci/config.yml';
+    $contents = file_get_contents($path);
+    $this->assertIsString($contents);
+
+    $flags = [];
+    $unguarded = [];
+
+    foreach (array_keys(self::declaredVariables($path)) as $name) {
+      if (preg_match('/^CI_IS_[A-Z0-9]+_RUNNER$/', $name) !== 1) {
+        continue;
+      }
+
+      $flags[] = $name;
+
+      if (!str_contains($contents, sprintf('[ "${%s:-1}" = "1" ] || exit 0', $name))) {
+        $unguarded[] = $name;
+      }
+    }
+
+    $this->assertNotSame([], $flags, 'config.yml declares no runner flags.');
+    $this->assertSame([], $unguarded, sprintf('config.yml exports runner flags that no step guards: %s', implode(', ', $unguarded)));
+  }
+
+  #[DataProvider('dataProviderConfigurations')]
+  public function testAnchorsAreDeclaredOutsideToolBlocks(string $path): void {
+    $declared = self::declaredVariables($path);
+    $blocks = self::openBlocksByLine($path);
+
+    foreach (self::ANCHORS as $name) {
+      $this->assertArrayHasKey($name, $declared, sprintf('%s does not declare %s.', basename($path), $name));
+
+      $open = $blocks[$declared[$name]];
+
+      $this->assertSame([], $open, sprintf('%s declares %s inside the %s block, so removing that tool takes the anchor with it.', basename($path), $name, implode(' and ', $open)));
+    }
+  }
+
+  #[DataProvider('dataProviderConfigurations')]
+  public function testFlagsAreDeclaredInsideTheirToolBlocks(string $path): void {
+    $declared = self::declaredVariables($path);
+    $blocks = self::openBlocksByLine($path);
+
+    $flags = [];
+    $misplaced = [];
+
+    foreach ($declared as $name => $line) {
+      if (preg_match('/^CI_IS_([A-Z0-9]+)_RUNNER$/', $name, $matches) !== 1) {
+        continue;
+      }
+
+      $flags[] = $name;
+      $token = 'DEV_' . $matches[1];
+
+      if (!in_array($token, $blocks[$line], TRUE)) {
+        $misplaced[] = sprintf('%s (expected %s)', $name, $token);
+      }
+    }
+
+    $this->assertNotSame([], $flags, sprintf('%s declares no runner flags.', basename($path)));
+    $this->assertSame([], $misplaced, sprintf('%s declares runner flags outside the block that removes their tool: %s', basename($path), implode(', ', $misplaced)));
+  }
+
+  public static function dataProviderConfigurations(): \Iterator {
+    yield 'test.yml' => ['path' => self::rootDir() . '/.github/workflows/test.yml'];
+    yield 'config.yml' => ['path' => self::rootDir() . '/.circleci/config.yml'];
+  }
+
+  /**
+   * Find the runner variables a configuration declares.
+   *
+   * Covers both spellings: a GitHub Actions `env` entry and a CircleCI shell
+   * export.
+   *
+   * @param string $path
+   *   The configuration to read.
+   *
+   * @return array<string, int>
+   *   The line each name is declared on, keyed by name.
+   */
+  protected static function declaredVariables(string $path): array {
+    $declared = [];
+
+    foreach (self::lines($path) as $number => $line) {
+      if (preg_match('/^\s*(?:echo "export )?(CI_IS_[A-Z0-9]+_RUNNER|CI_RUNNER_[A-Z]+)\s*[:=]/', $line, $matches) === 1) {
+        $declared[$matches[1]] = $number;
+      }
+    }
+
+    return $declared;
+  }
+
+  /**
+   * Map each line of a configuration to the tool blocks open at that line.
+   *
+   * @param string $path
+   *   The configuration to read.
+   *
+   * @return array<int, array<int, string>>
+   *   The tokens of the open blocks, keyed by line.
+   */
+  protected static function openBlocksByLine(string $path): array {
+    $blocks = [];
+    $stack = [];
+
+    foreach (self::lines($path) as $number => $line) {
+      if (preg_match('/#;< (\S+)/', $line, $matches) === 1) {
+        $stack[] = $matches[1];
+      }
+      elseif (preg_match('/#;> (\S+)/', $line) === 1) {
+        array_pop($stack);
+      }
+
+      $blocks[$number] = array_values($stack);
+    }
+
+    return $blocks;
+  }
+
+  /**
+   * Read a configuration into lines.
+   *
+   * @param string $path
+   *   The configuration to read.
+   *
+   * @return array<int, string>
+   *   The lines.
+   */
+  protected static function lines(string $path): array {
+    $contents = file_get_contents($path);
+    self::assertIsString($contents);
+
+    return explode("\n", $contents);
+  }
+
+  /**
+   * Get the project root directory.
+   *
+   * @return string
+   *   The absolute path to the project root.
+   */
+  protected static function rootDir(): string {
+    return dirname(__DIR__, 4);
+  }
+
+}

--- a/.scaffold/tests/src/Unit/CiRunnerVariablesTest.php
+++ b/.scaffold/tests/src/Unit/CiRunnerVariablesTest.php
@@ -25,9 +25,9 @@ final class CiRunnerVariablesTest extends UnitTestCase {
   /**
    * The names that anchor the declaration when every tool is removed.
    */
-  protected const ANCHORS = ['CI_RUNNER_INDEX', 'CI_RUNNER_TOTAL'];
+  protected const array ANCHORS = ['CI_RUNNER_INDEX', 'CI_RUNNER_TOTAL'];
 
-  public function testGithubActionsFlagsAreReadByAStep(): void {
+  public function testGithubActionsFlagsAreReadByStep(): void {
     $path = self::rootDir() . '/.github/workflows/test.yml';
     $contents = file_get_contents($path);
     $this->assertIsString($contents);
@@ -41,7 +41,11 @@ final class CiRunnerVariablesTest extends UnitTestCase {
     $unread = [];
 
     foreach ($parsed['jobs'] as $job_name => $job) {
-      if (!is_array($job) || !is_array($job['env'] ?? NULL)) {
+      if (!is_array($job)) {
+        continue;
+      }
+
+      if (!is_array($job['env'] ?? NULL)) {
         continue;
       }
 
@@ -51,7 +55,11 @@ final class CiRunnerVariablesTest extends UnitTestCase {
       }
 
       foreach (array_keys($job['env']) as $name) {
-        if (!is_string($name) || preg_match('/^CI_IS_[A-Z0-9]+_RUNNER$/', $name) !== 1) {
+        if (!is_string($name)) {
+          continue;
+        }
+
+        if (preg_match('/^CI_IS_[A-Z0-9]+_RUNNER$/', $name) !== 1) {
           continue;
         }
 
@@ -67,7 +75,7 @@ final class CiRunnerVariablesTest extends UnitTestCase {
     $this->assertSame([], $unread, sprintf('test.yml declares runner flags that no step reads: %s', implode(', ', $unread)));
   }
 
-  public function testCircleciFlagsAreGuardedByAStep(): void {
+  public function testCircleciFlagsAreGuardedByStep(): void {
     $path = self::rootDir() . '/.circleci/config.yml';
     $contents = file_get_contents($path);
     $this->assertIsString($contents);
@@ -91,7 +99,7 @@ final class CiRunnerVariablesTest extends UnitTestCase {
     $this->assertSame([], $unguarded, sprintf('config.yml exports runner flags that no step guards: %s', implode(', ', $unguarded)));
   }
 
-  #[DataProvider('dataProviderConfigurations')]
+  #[DataProvider('dataProviderAnchorsAreDeclaredOutsideToolBlocks')]
   public function testAnchorsAreDeclaredOutsideToolBlocks(string $path): void {
     $declared = self::declaredVariables($path);
     $blocks = self::openBlocksByLine($path);
@@ -105,7 +113,7 @@ final class CiRunnerVariablesTest extends UnitTestCase {
     }
   }
 
-  #[DataProvider('dataProviderConfigurations')]
+  #[DataProvider('dataProviderFlagsAreDeclaredInsideTheirToolBlocks')]
   public function testFlagsAreDeclaredInsideTheirToolBlocks(string $path): void {
     $declared = self::declaredVariables($path);
     $blocks = self::openBlocksByLine($path);
@@ -130,7 +138,21 @@ final class CiRunnerVariablesTest extends UnitTestCase {
     $this->assertSame([], $misplaced, sprintf('%s declares runner flags outside the block that removes their tool: %s', basename($path), implode(', ', $misplaced)));
   }
 
-  public static function dataProviderConfigurations(): \Iterator {
+  public static function dataProviderAnchorsAreDeclaredOutsideToolBlocks(): \Iterator {
+    yield from self::configurationPaths();
+  }
+
+  public static function dataProviderFlagsAreDeclaredInsideTheirToolBlocks(): \Iterator {
+    yield from self::configurationPaths();
+  }
+
+  /**
+   * The configuration files both marker-block tests check.
+   *
+   * @return \Iterator<string, array{path: string}>
+   *   The dataset shared by the two marker-block data providers.
+   */
+  protected static function configurationPaths(): \Iterator {
     yield 'test.yml' => ['path' => self::rootDir() . '/.github/workflows/test.yml'];
     yield 'config.yml' => ['path' => self::rootDir() . '/.circleci/config.yml'];
   }
@@ -180,7 +202,7 @@ final class CiRunnerVariablesTest extends UnitTestCase {
         array_pop($stack);
       }
 
-      $blocks[$number] = array_values($stack);
+      $blocks[$number] = $stack;
     }
 
     return $blocks;

--- a/README.md
+++ b/README.md
@@ -189,6 +189,59 @@ The two axes behave differently:
 
 Because `stable` and `canary` float, the matrix follows Drupal core on its own - a new stable minor or pre-release is picked up on the next CI run with no manual changes. The pinned `legacy` minor and the PHP versions are set-and-forget: they keep exercising the same floor indefinitely, so there is nothing you have to maintain by hand. When you want to move that floor forward as core and PHP advance, re-pull from the scaffold (see [Updating your extension](#updating-your-extension)) - this template tracks the versions Drupal core provides, so updating from it refreshes the `legacy` pin and the PHP versions for you.
 
+### Distributing tools across CI runners
+
+A test job declares which tools it runs in a single variable block at the top of the job, and each tool step reads only its own flag. Moving a tool onto a different runner is one edit in one place rather than a repeated runner-index condition spread across every step that belongs to that tool - the kind of edit where missing one step is silent, because the step then either runs on every runner (duplicated work) or on none (the tool stops running and nothing reports it).
+
+Two anchors are always declared, whichever tools are enabled:
+
+| Variable | Meaning |
+|----------|---------|
+| `CI_RUNNER_INDEX` | Zero-based index of the current runner. |
+| `CI_RUNNER_TOTAL` | How many runners the job has. |
+
+Every tool adds one flag of its own, named `CI_IS_<TOOL>_RUNNER` and declared inside that tool's block so that removing the tool removes its flag too. Use one flag per tool rather than a single shared "primary runner" flag: a shared flag reads wrong as soon as it gates tools that have nothing to do with each other, and it cannot put two tools on two different runners.
+
+**GitHub Actions.** The matrix in [`.github/workflows/test.yml`](.github/workflows/test.yml) is a Drupal and PHP matrix, so each leg is a runner covering a different version pair and every tool has to run on all of them. The flags are therefore `true`:
+
+```yaml
+env:
+  CI_RUNNER_INDEX: ${{ strategy.job-index }}
+  CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+  CI_IS_PHPUNIT_RUNNER: true
+```
+
+```yaml
+- name: Run tests
+  if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
+```
+
+To shard a tool across extra runners, add a matrix dimension for the shard and compare that tool's flag against it. A matrix change that renames or duplicates an existing leg also renames its status check, so review the required checks under [branch protection](#branch-protection) first.
+
+**CircleCI.** A node is a slice of one job rather than a version pair of its own, so [`.circleci/config.yml`](.circleci/config.yml) derives the flags from the node index and pins each tool that needs a single run to node 0:
+
+```yaml
+- run:
+    name: Set test runner roles
+    command: |
+      {
+        echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+        echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+      } >> "${BASH_ENV}"
+```
+
+```yaml
+- run:
+    name: Run tests
+    command: |
+      [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+      php -d pcov.directory=.. vendor/bin/phpunit
+```
+
+Each guard defaults to running, so a step still runs where the variable is not set at all. Add a node with `parallelism: 2` on the job: the distribution stays correct - PHPUnit runs once and coverage is uploaded once - but the extra node is idle until you give it work by pinning a tool to it with `-eq 1`. The `store_test_results` and `store_artifacts` steps take no runtime condition, so an idle node reports no results for them.
+
+One trap is worth knowing before moving a tool. Where a test runner derives a shard or profile name from the runner index, excluding runner 0 from that tool orphans the first shard, and if that shard is the catch-all then everything untagged silently stops being tested. Give such a tool the *last* runner rather than the first when it needs one to itself.
+
 ### Patching dependencies
 
 To apply patches to the dependencies, add a patch to the `patches` section of


### PR DESCRIPTION
Closes #524

## Summary

The scaffold's CI test job had no per-tool runner assignment: a step either ran unconditionally on every runner or, when it needed a condition at all, that condition was written by hand at its own call site (`if: always()`, `env.CODECOV_TOKEN != ''`), with no shared vocabulary for "does this tool run on this runner." Moving a tool to its own runner meant finding and auditing every step that tool touches.

Both CI providers now declare one `CI_RUNNER_INDEX`/`CI_RUNNER_TOTAL` pair plus one `CI_IS_<TOOL>_RUNNER` flag per tool - GitHub Actions in the job's `env:` block (derived from `strategy.job-index`/`job-total`), CircleCI in a new "Set test runner roles" step (derived from `CIRCLE_NODE_INDEX`/`CIRCLE_NODE_TOTAL`) exported to `$BASH_ENV`. Each flag is declared inside its tool's `#;< DEV_<TOOL>` marker block so removing the tool removes the flag too, and every step belonging to that tool reads the flag by name instead of re-deriving a condition.

Behaviour is unchanged: GitHub Actions ships every flag as `true` because each matrix leg is a full Drupal/PHP version runner that must run every tool (the matrix deliberately carries no shard dimension, since the repository's branch ruleset pins the per-leg check names verbatim), and CircleCI's flags resolve to node 0 because `parallelism` is unset. Raising `parallelism` or adding a shard dimension later now distributes tools correctly instead of silently double-running PHPUnit or double-uploading coverage.

## Changes

### GitHub Actions (`.github/workflows/test.yml`)

- The `test` job's `env:` block gains `CI_RUNNER_INDEX`/`CI_RUNNER_TOTAL` (always present) plus `CI_IS_JEST_RUNNER`/`CI_IS_PHPUNIT_RUNNER`, each inside its own `#;< DEV_JEST`/`#;< DEV_PHPUNIT` block.
- The "Run JavaScript tests" step's `if` now also requires `env.CI_IS_JEST_RUNNER == 'true'`.
- The "Run tests" (PHPUnit) step gains `if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}`.
- The three PHPUnit-only output steps - "Upload browser output as an artifact", "Upload coverage report as an artifact", "Upload coverage report to Codecov" - each add `env.CI_IS_PHPUNIT_RUNNER == 'true'` to their existing (or previously absent) condition.

### CircleCI (`.circleci/config.yml`)

- A new "Set test runner roles" step in the shared `job-test` alias exports `CI_RUNNER_INDEX`/`CI_RUNNER_TOTAL` (from `CIRCLE_NODE_INDEX`/`CIRCLE_NODE_TOTAL`) and `CI_IS_JEST_RUNNER`/`CI_IS_PHPUNIT_RUNNER` (pinned to node 0) into `$BASH_ENV`.
- The "Run JavaScript tests" and "Run tests" commands each start with `[ "${CI_IS_<TOOL>_RUNNER:-1}" = "1" ] || exit 0`, defaulting to running when the variable is unset.
- The Codecov upload command gets the same guard ahead of its existing upload logic.

### Tests (`.scaffold/tests/src/Unit/CiRunnerVariablesTest.php`)

- New `p0` test class asserting the wiring no linter can see: every declared flag is read by a step on both providers, both anchor variables sit outside every tool's marker block, and every `CI_IS_<TOOL>_RUNNER` flag sits inside the `#;< DEV_<TOOL>` block that removes its tool.

### Documentation (`README.md`)

- New "Distributing tools across CI runners" section documenting both anchor variables, the per-provider flag pattern, how to shard a tool across extra runners on each provider, and the trap of excluding runner/node 0 from a tool that derives a shard or profile name from its own index.

### Fixtures (`.scaffold/tests/fixtures/init/**`)

- Regenerated `init` snapshots (the baseline and every `circleci*`/tool-removal dataset) to reflect the new `env`/step wiring. No hand edits.

## Verification

Gates run locally: full `p0` group green; full `InitTest` suite green; `composer lint` (PHPCS, PHPStan, Rector) clean from `.scaffold/tests`; `actionlint` and `yamllint` clean on both CI configs; a local CodeRabbit review with zero findings.

## Before / After

```
BEFORE

.github/workflows/test.yml  (env: DRUPAL_VERSION only)
  Run JavaScript tests         -- no runner condition
  Run tests                    -- no runner condition
  Upload browser output        -- if: always()
  Upload coverage report       -- no runner condition
  Upload coverage to Codecov   -- if: env.CODECOV_TOKEN != ''

.circleci/config.yml  (no role declaration)
  Run JavaScript tests         -- runs on every node
  Run tests                    -- runs on every node
  Upload coverage to Codecov   -- runs on every node

  Pinning a tool to one runner means writing a raw node/matrix
  index check into every step that tool happens to touch.


AFTER

.github/workflows/test.yml
  env: DRUPAL_VERSION, CI_RUNNER_INDEX, CI_RUNNER_TOTAL,
       CI_IS_JEST_RUNNER: true, CI_IS_PHPUNIT_RUNNER: true
  Run JavaScript tests         -- if: env.CI_IS_JEST_RUNNER == 'true'
  Run tests                    -- if: env.CI_IS_PHPUNIT_RUNNER == 'true'
  Upload browser output        -- if: always() && CI_IS_PHPUNIT_RUNNER
  Upload coverage report       -- if: env.CI_IS_PHPUNIT_RUNNER == 'true'
  Upload coverage to Codecov   -- if: CI_IS_PHPUNIT_RUNNER && token set

.circleci/config.yml
  Set test runner roles (new)  -- derives flags from CIRCLE_NODE_INDEX
  Run JavaScript tests         -- guard: CI_IS_JEST_RUNNER=1 || exit 0
  Run tests                    -- guard: CI_IS_PHPUNIT_RUNNER=1 || exit 0
  Upload coverage to Codecov   -- guard: CI_IS_PHPUNIT_RUNNER=1 || exit 0

  Moving a tool to another runner is one edit to its flag's
  declaration; every step reading that flag follows automatically.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaces repeated CI runner conditions with centrally declared variables for GitHub Actions and CircleCI.
- Adds `CI_RUNNER_INDEX`, `CI_RUNNER_TOTAL`, `CI_IS_JEST_RUNNER`, and `CI_IS_PHPUNIT_RUNNER`.
- Updates test, coverage, and artifact steps to use tool-specific runner flags.
- Adds CircleCI role initialization through `$BASH_ENV`.
- Adds configuration tests and regenerates initialization fixtures.
- Documents CI tool distribution and shard assignment.

Possibly related to `#524`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->